### PR TITLE
Client support for retrying requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - 3.5
 cache: pip
 install:
-- pip install pytest pytest-cov coveralls flake8
+- pip install -r ./dev_requirements.txt
 - pip install -e .
 script:
 - flake8 gql

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+coveralls
+flake8
+mock

--- a/gql/client.py
+++ b/gql/client.py
@@ -65,7 +65,7 @@ class Client(object):
                 return result
             except Exception as e:
                 last_exception = e
-                logging.warn("Request failed with exception %s. Retrying for the %s time...", retries_count + 1, exc_info=True)
+                logging.warn("Request failed with exception %s. Retrying for the %s time...", e, retries_count + 1, exc_info=True)
             finally:
                 retries_count += 1
 

--- a/gql/client.py
+++ b/gql/client.py
@@ -65,10 +65,9 @@ class Client(object):
                 return result
             except Exception as e:
                 last_exception = e
-                logging.warn("Request failed with exception %s. Retrying for the %s time...", e, retries_count + 1, exc_info=True)
+                logging.warn("Request failed with exception %s. Retrying for the %s time...",
+                             e, retries_count + 1, exc_info=True)
             finally:
                 retries_count += 1
 
         raise RetryError(retries_count, last_exception)
-
-

--- a/gql/client.py
+++ b/gql/client.py
@@ -1,13 +1,22 @@
+import logging
+
 from graphql import parse, introspection_query, build_ast_schema, build_client_schema
 from graphql.validation import validate
 
 from .transport.local_schema import LocalSchemaTransport
 
 
-class Client(object):
+class RetryError(Exception):
+    """Custom exception thrown when retry logic fails"""
+    def __init__(self, retries_count, last_exception):
+        message = "Failed %s retries: %s" % (retries_count, last_exception)
+        super(RetryError, self).__init__(message)
+        self.last_exception = last_exception
 
+
+class Client(object):
     def __init__(self, schema=None, introspection=None, type_def=None, transport=None,
-                 fetch_schema_from_transport=False):
+                 fetch_schema_from_transport=False, retries=0):
         assert not(type_def and introspection), 'Cant provide introspection type definition at the same time'
         if transport and fetch_schema_from_transport:
             assert not schema, 'Cant fetch the schema from transport if is already provided'
@@ -25,6 +34,7 @@ class Client(object):
         self.schema = schema
         self.introspection = introspection
         self.transport = transport
+        self.retries = retries
 
     def validate(self, document):
         if not self.schema:
@@ -36,7 +46,29 @@ class Client(object):
     def execute(self, document, *args, **kwargs):
         if self.schema:
             self.validate(document)
-        result = self.transport.execute(document, *args, **kwargs)
+
+        result = self._get_result(document, *args, **kwargs)
         if result.errors:
             raise result.errors[0]
+
         return result.data
+
+    def _get_result(self, document, *args, **kwargs):
+        if not self.retries:
+            return self.transport.execute(document, *args, **kwargs)
+
+        last_exception = None
+        retries_count = 0
+        while retries_count < self.retries:
+            try:
+                result = self.transport.execute(document, *args, **kwargs)
+                return result
+            except Exception as e:
+                last_exception = e
+                logging.warn("Request failed with exception %s. Retrying for the %s time...", retries_count + 1, exc_info=True)
+            finally:
+                retries_count += 1
+
+        raise RetryError(retries_count, last_exception)
+
+

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -12,7 +12,7 @@ class RequestsHTTPTransport(HTTPTransport):
         """
         :param url: The GraphQL URL
         :param auth: Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth
-        :param use_json: Choose whether to send the request body as a json or as form-urlencoded (Default: form-urlencoded)
+        :param use_json: Send request body as JSON instead of form-urlencoded
         :param timeout: Specifies a default timeout for requests (Default: None)
         """
         super(RequestsHTTPTransport, self).__init__(url, **kwargs)

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -8,11 +8,12 @@ from .http import HTTPTransport
 
 
 class RequestsHTTPTransport(HTTPTransport):
-    def __init__(self, url, auth=None, **kwargs):
-        super(RequestsHTTPTransport, self).__init__(url, **kwargs)
+    def __init__(self, auth=None, timeout=None, *args, **kwargs):
+        super(RequestsHTTPTransport, self).__init__(*args, **kwargs)
         self.auth = auth
+        self.default_timeout = timeout
 
-    def execute(self, document, variable_values=None):
+    def execute(self, document, variable_values=None, timeout=None):
         query_str = print_ast(document)
         request = requests.post(
             self.url,
@@ -21,7 +22,8 @@ class RequestsHTTPTransport(HTTPTransport):
                 'variables': variable_values
             },
             headers=self.headers,
-            auth=self.auth
+            auth=self.auth,
+            timeout=timeout or self.default_timeout
         )
         request.raise_for_status()
 

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -8,8 +8,8 @@ from .http import HTTPTransport
 
 
 class RequestsHTTPTransport(HTTPTransport):
-    def __init__(self, auth=None, timeout=None, *args, **kwargs):
-        super(RequestsHTTPTransport, self).__init__(*args, **kwargs)
+    def __init__(self, url, auth=None, timeout=None, **kwargs):
+        super(RequestsHTTPTransport, self).__init__(url, **kwargs)
         self.auth = auth
         self.default_timeout = timeout
 

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
         'graphql-core>=0.5.0',
         'promise>=0.4.0'
     ],
-    tests_require=['pytest>=2.7.2'],
+    tests_require=['pytest>=2.7.2', 'mock'],
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,34 @@
+import pytest
+import mock
+
+from gql import Client, gql
+from gql.transport.requests import RequestsHTTPTransport
+
+
+@mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
+def test_retries(execute_mock):
+    expected_retries = 3
+    execute_mock.side_effect =Exception("fail")
+
+    client = Client(
+        retries=expected_retries,
+        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql')
+    )
+
+    query = gql('''
+    {
+      myFavoriteFilm: film(id:"RmlsbToz") {
+        id
+        title
+        episodeId
+      }
+    }
+    ''')
+
+    with pytest.raises(Exception):
+        client.execute(query)
+
+    assert execute_mock.call_count == expected_retries
+
+
+


### PR DESCRIPTION
Client can retry requests in case of transport errors (usefull for avoiding timeout errors and other http stuff)

Also:
* added ability to specify default timeout for `RequestsHTTPTransport` and allow overriding the default timeout when calling `execute`.

* Added ability to have `RequestsHTTPTransport` post JSON requests