### PR TITLE
Resolve TypeError when raising GraphQL errors

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -49,7 +49,7 @@ class Client(object):
 
         result = self._get_result(document, *args, **kwargs)
         if result.errors:
-            raise result.errors[0]
+            raise Exception(str(result.errors[0]))
 
         return result.data
 


### PR DESCRIPTION
`results.errors[0]` is a dict and raising it throws a `TypeError`:
`TypeError: exceptions must be old-style classes or derived from BaseException, not dict`

This fixes this error.
Granted its not the best solution and we should probably subclass `Exception` to our own `GQLError` or something in the future.
But at least it makes the current code work and provide error feedback and not a `TypeError`