### PR TITLE
Fetch CSRF cookie to validate w/ Graphene API

### DIFF
--- a/gql/transport/http.py
+++ b/gql/transport/http.py
@@ -1,5 +1,6 @@
 class HTTPTransport(object):
 
-    def __init__(self, url, headers=None):
+    def __init__(self, url, headers=None, cookies=None):
         self.url = url
         self.headers = headers
+        self.cookies = cookies

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -31,6 +31,7 @@ class RequestsHTTPTransport(HTTPTransport):
         post_args = {
             'headers': self.headers,
             'auth': self.auth,
+            'cookies': self.cookies,
             'timeout': timeout or self.default_timeout,
             data_key: payload
         }

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
@@ -6,9 +7,19 @@ from gql.transport.requests import RequestsHTTPTransport
 
 @pytest.fixture
 def client():
+    request = requests.get('http://swapi.graphene-python.org/graphql',
+                           headers={
+                               'Host': 'swapi.graphene-python.org',
+                               'Accept': 'text/html',
+                           })
+    request.raise_for_status()
+    csrf = request.cookies['csrftoken']
+
     return Client(
-      transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql'),
-      fetch_schema_from_transport=True
+        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql',
+                                        cookies={"csrftoken": csrf},
+                                        headers={'x-csrftoken':  csrf}),
+        fetch_schema_from_transport=True
     )
 
 


### PR DESCRIPTION
SWAPI now requires CSRF cookie in order to problemo.

I changed the test case to retrieve this cookie, and use it to query. To use it, I added a new parameter for HTTPTransport.

It refers to behavior observed on issue #8 .