### PR TITLE
JSONfy variables if not string

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import requests
+import json
 from graphql.execution import ExecutionResult
 from graphql.language.printer import print_ast
 
@@ -24,8 +25,12 @@ class RequestsHTTPTransport(HTTPTransport):
         query_str = print_ast(document)
         payload = {
             'query': query_str,
-            'variables': variable_values or {}
         }
+
+        if type(variable_values) is str:
+            payload['variables'] = variable_values or ""
+        else:
+            payload['variables'] = json.dumps(variable_values or {}, sort_keys=True)
 
         data_key = 'json' if self.use_json else 'data'
         post_args = {

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -67,3 +67,60 @@ def test_hero_name_query(client):
     }
     result = client.execute(query)
     assert result == expected
+
+
+def test_hero_name_query_variable(client):
+    query = gql('''
+    query($user: ID!) {
+      myFavoriteFilm: film(id:$user) {
+        id
+        title
+        episodeId
+        characters(first:5) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+    ''')
+    expected = {
+        "myFavoriteFilm": {
+            "id": "RmlsbToz",
+            "title": "Return of the Jedi",
+            "episodeId": 6,
+            "characters": {
+                "edges": [
+                  {
+                      "node": {
+                          "name": "Luke Skywalker"
+                      }
+                  },
+                    {
+                      "node": {
+                          "name": "C-3PO"
+                      }
+                  },
+                    {
+                      "node": {
+                          "name": "R2-D2"
+                      }
+                  },
+                    {
+                      "node": {
+                          "name": "Darth Vader"
+                      }
+                  },
+                    {
+                      "node": {
+                          "name": "Leia Organa"
+                      }
+                  }
+                ]
+            }
+        }
+    }
+    result = client.execute(query, variable_values={"user": "RmlsbToz"})
+    assert result == expected


### PR DESCRIPTION
Gives the possibility to specify variables as a python dict.

One of the reasons to have variables in GraphQL is to avoid value injections like `{"id":"%s"} % (10)` directly on the query. So, to keep this feature, I've implemented this little PR.
