### PR TITLE
Allow headers to be specified on a per request basis

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -20,16 +20,19 @@ class RequestsHTTPTransport(HTTPTransport):
         self.default_timeout = timeout
         self.use_json = use_json
 
-    def execute(self, document, variable_values=None, timeout=None):
+    def execute(self, document, variable_values=None, timeout=None, headers={}):
         query_str = print_ast(document)
         payload = {
             'query': query_str,
             'variables': variable_values or {}
         }
 
+        merged_headers = self.headers.copy() if self.headers else {}
+        merged_headers.update(headers)
+
         data_key = 'json' if self.use_json else 'data'
         post_args = {
-            'headers': self.headers,
+            'headers': merged_headers,
             'auth': self.auth,
             'cookies': self.cookies,
             'timeout': timeout or self.default_timeout,


### PR DESCRIPTION
Previously all the headers were passed through in the transport, which is configured when the GQL client is initialized. 

In our use of the GQL client library, we have found that it is useful to be able to specify headers on a per request basis, so I would like to add support for that.