### PR TITLE
Should pass kwargs into RequestsHTTPTransport requests method

### DIFF
--- a/gql/transport/http.py
+++ b/gql/transport/http.py
@@ -1,6 +1,6 @@
 class HTTPTransport(object):
 
-    def __init__(self, url, headers=None, cookies=None):
+    def __init__(self, url, headers=None, cookies=None, **kwargs):
         self.url = url
         self.headers = headers
         self.cookies = cookies

--- a/gql/transport/http.py
+++ b/gql/transport/http.py
@@ -4,3 +4,4 @@ class HTTPTransport(object):
         self.url = url
         self.headers = headers
         self.cookies = cookies
+        self.kwargs = kwargs

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -35,6 +35,7 @@ class RequestsHTTPTransport(HTTPTransport):
             'timeout': timeout or self.default_timeout,
             data_key: payload
         }
+        post_args.update(self.kwargs)
         request = requests.post(self.url, **post_args)
         request.raise_for_status()
 


### PR DESCRIPTION
We should allow the **kwargs to be passed into the RequestHTTPTransport by the init kwargs.  For example, we would like the requests to mark the SSL verify to be false.  So it could be easily to be passed. like :  

self.transport = RequestsHTTPTransport(url=self.url, auth=HTTPBasicAuth(self.account, self.pwd), use_json=True,
                                               verify=False)