### PR TITLE
Feature/allow errors to be raised or returned

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from gql import gql
+
+
+@pytest.fixture()
+def gql_query():
+    return gql('''
+    {
+      myFavoriteFilm: film(id:"RmlsbToz") {
+        id
+        title
+        episodeId
+      }
+    }
+    ''')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,33 +2,67 @@ import pytest
 import mock
 
 from gql import Client, gql
+from gql.client import ResultError
 from gql.transport.requests import RequestsHTTPTransport
 
 
 @mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
-def test_retries(execute_mock):
+def test_retries(execute_mock, gql_query):
     expected_retries = 3
-    execute_mock.side_effect =Exception("fail")
+    execute_mock.side_effect = Exception("fail")
 
     client = Client(
         retries=expected_retries,
         transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql')
     )
 
-    query = gql('''
-    {
-      myFavoriteFilm: film(id:"RmlsbToz") {
-        id
-        title
-        episodeId
-      }
-    }
-    ''')
-
     with pytest.raises(Exception):
-        client.execute(query)
+        client.execute(gql_query)
 
     assert execute_mock.call_count == expected_retries
 
 
+@mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
+def test_client_does_not_raise_exception(execute_mock, gql_query):
+    mock_response = mock.Mock()
+    mock_response.errors = None
+    execute_mock.return_value = mock_response
 
+    client = Client(
+        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql'),
+        raise_error=False
+    )
+
+    assert client.execute(gql_query)
+
+
+@mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
+def test_client_raises_error_exception(execute_mock, gql_query):
+
+    mock_response = mock.Mock()
+    mock_response.errors = [{'message': 'a real error'}]
+    execute_mock.return_value = mock_response
+
+    client = Client(
+        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql'),
+        raise_error=False
+    )
+
+    with pytest.raises(ResultError):
+        client.execute(gql_query)
+
+
+@mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
+def test_client_returns_errors(execute_mock, gql_query):
+
+    mock_response = mock.Mock()
+    mock_response.errors = [{'message': 'a real error'}]
+    execute_mock.return_value = mock_response
+
+    client = Client(
+        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql'),
+        raise_error=True
+    )
+
+    response = client.execute(gql_query)
+    assert response.errors == mock_response.errors


### PR DESCRIPTION
PR to allow:

- errors to be raised with a custom exception (`ResultError`) which will allow better handling by consumers of the `Client` class.
- errors to be returned along with data which will allow consumers of the `Client` class to act on all errors rather than the first in a list.

I'd like to get some feedback on the approach before merging.