### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
   - pypy
   - pypy3
 cache: pip

--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -1,4 +1,3 @@
-import collections
 import decimal
 from functools import partial
 
@@ -9,6 +8,11 @@ from graphql.type import (GraphQLField, GraphQLList,
                           GraphQLNonNull, GraphQLEnumType)
 
 from .utils import to_camel_case
+
+if six.PY3:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 class DSLSchema(object):
@@ -134,7 +138,7 @@ def query(*fields):
 
 
 def serialize_list(serializer, values):
-    assert isinstance(values, collections.Iterable), 'Expected iterable, received "{}"'.format(repr(values))
+    assert isinstance(values, Iterable), 'Expected iterable, received "{}"'.format(repr(values))
     return [serializer(v) for v in values]
 
 


### PR DESCRIPTION
Fixes #57 