### PR TITLE
Docs subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ target/
 # Databases
 *.sqlite3
 .DS_Store
+
+### VisualStudioCode ###
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ coverage.xml
 # Django stuff:
 *.log
 
+# Type checking
+/.mypy_cache
+.pyre
+/type_info.json
+
 # Sphinx documentation
 docs/_build/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,9 @@ python:
   - pypy
   - pypy3
 cache: pip
-install:
-  - pip install -e .[dev]
-script:
-  - flake8 gql tests
-  - pytest --cov-report=term-missing --cov=gql tests
-after_success:
-  - coveralls
+install: pip install coveralls tox
+script: tox
+after_success: coveralls
 deploy:
   provider: pypi
   user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,18 @@ python:
   - 3.9-dev
   - pypy
   - pypy3
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=black
+    - python: 3.6
+      env: TOXENV=import-order
+    - python: 3.6
+      env: TOXENV=mypy
+    - python: 3.6
+      env: TOXENV=manifest
 cache: pip
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ python:
 cache: pip
 install: pip install tox-travis
 script: tox
-after_success: coveralls
+after_success:
+  - pip install coveralls
+  - coveralls
 deploy:
   provider: pypi
   user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - pypy
   - pypy3
 cache: pip
-install: pip install coveralls tox
+install: pip install tox-travis
 script: tox
 after_success: coveralls
 deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ virtualenv gql-dev
 Activate the virtualenv and install dependencies by running:
 
 ```console
-python pip install -e ".[test]"
+python pip install -e[dev]
 ```
 
 If you are using Linux or MacOS, you can make use of Makefile command 
@@ -50,7 +50,7 @@ Then activate the environment with `conda activate gql-dev`.
 Proceed to install all dependencies by running:
 
 ```console
-python pip install -e ".[test]"
+pip install -e.[dev]
 ```
 
 And you ready to start development!

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,8 @@ include Makefile
 
 include tox.ini
 
-recursive-include tests *.py *.yaml
+recursive-include tests *.py *.yaml *.graphql
+recursive-include tests_py36 *.py
 
 prune gql-checker
 

--- a/gql/__init__.py
+++ b/gql/__init__.py
@@ -1,4 +1,4 @@
 from .gql import gql
 from .client import Client
 
-__all__ = ['gql', 'Client']
+__all__ = ["gql", "Client"]

--- a/gql/client.py
+++ b/gql/client.py
@@ -1,6 +1,6 @@
 import logging
 
-from graphql import parse, introspection_query, build_ast_schema, build_client_schema
+from graphql import build_ast_schema, build_client_schema, introspection_query, parse
 from graphql.validation import validate
 
 from .transport.local_schema import LocalSchemaTransport
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 class RetryError(Exception):
     """Custom exception thrown when retry logic fails"""
+
     def __init__(self, retries_count, last_exception):
         message = "Failed %s retries: %s" % (retries_count, last_exception)
         super(RetryError, self).__init__(message)
@@ -17,17 +18,30 @@ class RetryError(Exception):
 
 
 class Client(object):
-    def __init__(self, schema=None, introspection=None, type_def=None, transport=None,
-                 fetch_schema_from_transport=False, retries=0):
-        assert not(type_def and introspection), 'Cant provide introspection type definition at the same time'
+    def __init__(
+        self,
+        schema=None,
+        introspection=None,
+        type_def=None,
+        transport=None,
+        fetch_schema_from_transport=False,
+        retries=0,
+    ):
+        assert not (
+            type_def and introspection
+        ), "Cant provide introspection type definition at the same time"
         if transport and fetch_schema_from_transport:
-            assert not schema, 'Cant fetch the schema from transport if is already provided'
+            assert (
+                not schema
+            ), "Cant fetch the schema from transport if is already provided"
             introspection = transport.execute(parse(introspection_query)).data
         if introspection:
-            assert not schema, 'Cant provide introspection and schema at the same time'
+            assert not schema, "Cant provide introspection and schema at the same time"
             schema = build_client_schema(introspection)
         elif type_def:
-            assert not schema, 'Cant provide Type definition and schema at the same time'
+            assert (
+                not schema
+            ), "Cant provide Type definition and schema at the same time"
             type_def_ast = parse(type_def)
             schema = build_ast_schema(type_def_ast)
         elif schema and not transport:
@@ -40,7 +54,9 @@ class Client(object):
 
     def validate(self, document):
         if not self.schema:
-            raise Exception("Cannot validate locally the document, you need to pass a schema.")
+            raise Exception(
+                "Cannot validate locally the document, you need to pass a schema."
+            )
         validation_errors = validate(self.schema, document)
         if validation_errors:
             raise validation_errors[0]
@@ -67,8 +83,12 @@ class Client(object):
                 return result
             except Exception as e:
                 last_exception = e
-                log.warning("Request failed with exception %s. Retrying for the %s time...",
-                            e, retries_count + 1, exc_info=True)
+                log.warning(
+                    "Request failed with exception %s. Retrying for the %s time...",
+                    e,
+                    retries_count + 1,
+                    exc_info=True,
+                )
             finally:
                 retries_count += 1
 

--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -1,10 +1,15 @@
 from functools import partial
 
 import six
-from graphql import GraphQLInputObjectType, GraphQLInputObjectField
 from graphql.language import ast
 from graphql.language.printer import print_ast
-from graphql.type import (GraphQLEnumType, GraphQLList, GraphQLNonNull)
+from graphql.type import (
+    GraphQLEnumType,
+    GraphQLInputObjectField,
+    GraphQLInputObjectType,
+    GraphQLList,
+    GraphQLNonNull,
+)
 from graphql.utils.ast_from_value import ast_from_value
 
 from .utils import to_camel_case
@@ -31,7 +36,7 @@ class DSLSchema(object):
         return self.execute(query(*args, **kwargs))
 
     def mutate(self, *args, **kwargs):
-        return self.query(*args, operation='mutation', **kwargs)
+        return self.query(*args, operation="mutation", **kwargs)
 
     def execute(self, document):
         return self.client.execute(document)
@@ -54,7 +59,9 @@ class DSLType(object):
         if camel_cased_name in self.type.fields:
             return camel_cased_name, self.type.fields[camel_cased_name]
 
-        raise KeyError('Field {} does not exist in type {}.'.format(name, self.type.name))
+        raise KeyError(
+            "Field {} does not exist in type {}.".format(name, self.type.name)
+        )
 
 
 def selections(*fields):
@@ -63,7 +70,6 @@ def selections(*fields):
 
 
 class DSLField(object):
-
     def __init__(self, name, field):
         self.field = field
         self.ast_field = ast.Field(name=ast.Name(value=name), arguments=[])
@@ -88,10 +94,7 @@ class DSLField(object):
             arg_type_serializer = get_arg_serializer(arg.type)
             serialized_value = arg_type_serializer(value)
             self.ast_field.arguments.append(
-                ast.Argument(
-                    name=ast.Name(value=name),
-                    value=serialized_value
-                )
+                ast.Argument(name=ast.Name(value=name), value=serialized_value)
             )
         return self
 
@@ -111,20 +114,22 @@ def selection_field(field):
 
 
 def query(*fields, **kwargs):
-    if 'operation' not in kwargs:
-        kwargs['operation'] = 'query'
+    if "operation" not in kwargs:
+        kwargs["operation"] = "query"
     return ast.Document(
-        definitions=[ast.OperationDefinition(
-            operation=kwargs['operation'],
-            selection_set=ast.SelectionSet(
-                selections=list(selections(*fields))
+        definitions=[
+            ast.OperationDefinition(
+                operation=kwargs["operation"],
+                selection_set=ast.SelectionSet(selections=list(selections(*fields))),
             )
-        )]
+        ]
     )
 
 
 def serialize_list(serializer, list_values):
-    assert isinstance(list_values, Iterable), 'Expected iterable, received "{}"'.format(repr(list_values))
+    assert isinstance(list_values, Iterable), 'Expected iterable, received "{}"'.format(
+        repr(list_values)
+    )
     return ast.ListValue(values=[serializer(v) for v in list_values])
 
 
@@ -136,7 +141,11 @@ def get_arg_serializer(arg_type):
     if isinstance(arg_type, GraphQLInputObjectType):
         serializers = {k: get_arg_serializer(v) for k, v in arg_type.fields.items()}
         return lambda value: ast.ObjectValue(
-            fields=[ast.ObjectField(ast.Name(k), serializers[k](v)) for k, v in value.items()])
+            fields=[
+                ast.ObjectField(ast.Name(k), serializers[k](v))
+                for k, v in value.items()
+            ]
+        )
     if isinstance(arg_type, GraphQLList):
         inner_serializer = get_arg_serializer(arg_type.of_type)
         return partial(serialize_list, inner_serializer)

--- a/gql/gql.py
+++ b/gql/gql.py
@@ -5,7 +5,7 @@ from graphql.language.source import Source
 
 def gql(request_string):
     if isinstance(request_string, six.string_types):
-        source = Source(request_string, 'GraphQL request')
+        source = Source(request_string, "GraphQL request")
         return parse(source)
     else:
         raise Exception('Received incompatible request "{}".'.format(request_string))

--- a/gql/transport/__init__.py
+++ b/gql/transport/__init__.py
@@ -17,4 +17,6 @@ class Transport:
         :param document: GraphQL query as AST Node or Document object.
         :return: Either ExecutionResult or a Promise that resolves to ExecutionResult object.
         """
-        raise NotImplementedError("Any Transport subclass must implement execute method")
+        raise NotImplementedError(
+            "Any Transport subclass must implement execute method"
+        )

--- a/gql/transport/local_schema.py
+++ b/gql/transport/local_schema.py
@@ -1,18 +1,18 @@
-from typing import Union, Any
-
 from graphql import GraphQLSchema
-from graphql.execution import execute, ExecutionResult
+from graphql.execution import ExecutionResult, execute
 from graphql.language.ast import Document
 from promise import Promise
 
 from gql.transport import Transport
+from typing import Any, Union
 
 
 class LocalSchemaTransport(Transport):
     """A transport for executing GraphQL queries against a local schema."""
+
     def __init__(
         self,  # type: LocalSchemaTransport
-        schema  # type: GraphQLSchema
+        schema,  # type: GraphQLSchema
     ):
         """Initialize the transport with the given local schema.
 
@@ -29,9 +29,4 @@ class LocalSchemaTransport(Transport):
         :param kwargs: Keyword options passed to execute method from graphql-core library.
         :return: Either ExecutionResult or a Promise that resolves to ExecutionResult object.
         """
-        return execute(
-            self.schema,
-            document,
-            *args,
-            **kwargs
-        )
+        return execute(self.schema, document, *args, **kwargs)

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from typing import Any, Dict, Union
-
 import requests
 from graphql.execution import ExecutionResult
 from graphql.language.ast import Node
@@ -10,6 +8,7 @@ from requests.auth import AuthBase
 from requests.cookies import RequestsCookieJar
 
 from gql.transport import Transport
+from typing import Any, Dict, Union
 
 
 class RequestsHTTPTransport(Transport):
@@ -17,6 +16,7 @@ class RequestsHTTPTransport(Transport):
 
     The transport uses the requests library to send HTTP POST requests.
     """
+
     def __init__(
         self,  # type: RequestsHTTPTransport
         url,  # type: str
@@ -66,19 +66,16 @@ class RequestsHTTPTransport(Transport):
             occurred, and is a non-empty array if an error occurred.
         """
         query_str = print_ast(document)
-        payload = {
-            'query': query_str,
-            'variables': variable_values or {}
-        }
+        payload = {"query": query_str, "variables": variable_values or {}}
 
-        data_key = 'json' if self.use_json else 'data'
+        data_key = "json" if self.use_json else "data"
         post_args = {
-            'headers': self.headers,
-            'auth': self.auth,
-            'cookies': self.cookies,
-            'timeout': timeout or self.default_timeout,
-            'verify': self.verify,
-            data_key: payload
+            "headers": self.headers,
+            "auth": self.auth,
+            "cookies": self.cookies,
+            "timeout": timeout or self.default_timeout,
+            "verify": self.verify,
+            data_key: payload,
         }
 
         # Pass kwargs to requests post method
@@ -92,7 +89,9 @@ class RequestsHTTPTransport(Transport):
         except ValueError:
             result = {}
 
-        if 'errors' not in result and 'data' not in result:
+        if "errors" not in result and "data" not in result:
             response.raise_for_status()
-            raise requests.HTTPError("Server did not return a GraphQL result", response=response)
-        return ExecutionResult(errors=result.get('errors'), data=result.get('data'))
+            raise requests.HTTPError(
+                "Server did not return a GraphQL result", response=response
+            )
+        return ExecutionResult(errors=result.get("errors"), data=result.get("data"))

--- a/gql/utils.py
+++ b/gql/utils.py
@@ -4,7 +4,7 @@
 # From this response in Stackoverflow
 # http://stackoverflow.com/a/19053800/1072990
 def to_camel_case(snake_str):
-    components = snake_str.split('_')
+    components = snake_str.split("_")
     # We capitalize the first letter of each component except the first one
     # with the 'title' method and join them together.
-    return components[0] + "".join(x.title() if x else '_' for x in components[1:])
+    return components[0] + "".join(x.title() if x else "_" for x in components[1:])

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ max-line-length = 120
 
 [isort]
 known_first_party=gql
+
+[tool:pytest]
+norecursedirs = venv .venv .tox .git .cache .mypy_cache .pytest_cache

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'coveralls==1.11.1',
     'pytest==4.6.9',
     'pytest-cov==2.8.1',
+    'pytest-asyncio>=0.9.0',
     'mock==3.0.5',
     'vcrpy==3.0.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import setup, find_packages
 
 install_requires = [
@@ -11,10 +13,12 @@ tests_require = [
     'coveralls==1.11.1',
     'pytest==4.6.9',
     'pytest-cov==2.8.1',
-    'pytest-asyncio>=0.9.0',
     'mock==3.0.5',
     'vcrpy==3.0.0',
 ]
+
+if sys.version_info > (3, 6):
+    tests_require.append('pytest-asyncio>=0.9.0')
 
 dev_requires = [
     'flake8==3.7.9',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ if sys.version_info > (3, 6):
 
 dev_requires = [
     'flake8==3.7.9',
+    'isort<4.0.0',
+    'black==19.10b0',
+    'mypy==0.761',
     'check-manifest>=0.40,<1',
 ] + tests_require
 

--- a/tests/starwars/fixtures.py
+++ b/tests/starwars/fixtures.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections import namedtuple
 
-Human = namedtuple('Human', 'id name friends appearsIn homePlanet isAlive')
+Human = namedtuple('Human', 'id name friends appearsIn homePlanet')
 
 luke = Human(
     id='1000',
@@ -9,7 +9,6 @@ luke = Human(
     friends=['1002', '1003', '2000', '2001'],
     appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Tatooine',
-    isAlive=True,
 )
 
 vader = Human(
@@ -18,7 +17,6 @@ vader = Human(
     friends=['1004'],
     appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Tatooine',
-    isAlive=False,
 )
 
 han = Human(
@@ -27,7 +25,6 @@ han = Human(
     friends=['1000', '1003', '2001'],
     appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet=None,
-    isAlive=True,
 )
 
 leia = Human(
@@ -36,7 +33,6 @@ leia = Human(
     friends=['1000', '1002', '2000', '2001'],
     appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Alderaan',
-    isAlive=True,
 )
 
 tarkin = Human(
@@ -45,7 +41,6 @@ tarkin = Human(
     friends=['1001'],
     appearsIn=['NEWHOPE'],
     homePlanet=None,
-    isAlive=False,
 )
 
 humanData = {
@@ -142,4 +137,3 @@ async def reviewAdded(episode):
         yield reviews[episode][count]
         await asyncio.sleep(1)
         count += 1
-

--- a/tests/starwars/fixtures.py
+++ b/tests/starwars/fixtures.py
@@ -7,7 +7,7 @@ luke = Human(
     id='1000',
     name='Luke Skywalker',
     friends=['1002', '1003', '2000', '2001'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     homePlanet='Tatooine',
 )
 
@@ -15,7 +15,7 @@ vader = Human(
     id='1001',
     name='Darth Vader',
     friends=['1004'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     homePlanet='Tatooine',
 )
 
@@ -23,7 +23,7 @@ han = Human(
     id='1002',
     name='Han Solo',
     friends=['1000', '1003', '2001'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     homePlanet=None,
 )
 
@@ -31,7 +31,7 @@ leia = Human(
     id='1003',
     name='Leia Organa',
     friends=['1000', '1002', '2000', '2001'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     homePlanet='Alderaan',
 )
 
@@ -39,7 +39,7 @@ tarkin = Human(
     id='1004',
     name='Wilhuff Tarkin',
     friends=['1001'],
-    appearsIn=['NEWHOPE'],
+    appearsIn=[4],
     homePlanet=None,
 )
 
@@ -57,7 +57,7 @@ threepio = Droid(
     id='2000',
     name='C-3PO',
     friends=['1000', '1002', '1003', '2001'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     primaryFunction='Protocol',
 )
 
@@ -65,7 +65,7 @@ artoo = Droid(
     id='2001',
     name='R2-D2',
     friends=['1000', '1002', '1003'],
-    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
+    appearsIn=[4, 5, 6],
     primaryFunction='Astromech',
 )
 
@@ -75,25 +75,25 @@ droidData = {
 }
 
 reviews = {
-    'NEWHOPE': [
+    4: [
         {
             'stars': 4,
             'commentary': 'Was good.',
-            'episode': 'NEWHOPE'
+            'episode': 4
         },
     ],
-    'EMPIRE': [
+    5: [
         {
             'stars': 5,
             'commentary': 'This is a great movie!',
-            'episode': 'EMPIRE'
+            'episode': 5
         },
     ],
-    'JEDI': [
+    6: [
         {
             'stars': 3,
             'commentary': 'Was expecting more stuff',
-            'episode': 'JEDI'
+            'episode': 6
         },
     ]
 }
@@ -112,7 +112,7 @@ def getFriends(character):
 
 
 def getHero(episode):
-    if episode == 'EMPIRE':
+    if episode == 5:
         return humanData.get('1000')
     return droidData.get('2001')
 

--- a/tests/starwars/fixtures.py
+++ b/tests/starwars/fixtures.py
@@ -1,100 +1,78 @@
 from collections import namedtuple
 
-Human = namedtuple('Human', 'id name friends appearsIn homePlanet')
+Human = namedtuple("Human", "id name friends appearsIn homePlanet")
 
 luke = Human(
-    id='1000',
-    name='Luke Skywalker',
-    friends=['1002', '1003', '2000', '2001'],
+    id="1000",
+    name="Luke Skywalker",
+    friends=["1002", "1003", "2000", "2001"],
     appearsIn=[4, 5, 6],
-    homePlanet='Tatooine',
+    homePlanet="Tatooine",
 )
 
 vader = Human(
-    id='1001',
-    name='Darth Vader',
-    friends=['1004'],
+    id="1001",
+    name="Darth Vader",
+    friends=["1004"],
     appearsIn=[4, 5, 6],
-    homePlanet='Tatooine',
+    homePlanet="Tatooine",
 )
 
 han = Human(
-    id='1002',
-    name='Han Solo',
-    friends=['1000', '1003', '2001'],
+    id="1002",
+    name="Han Solo",
+    friends=["1000", "1003", "2001"],
     appearsIn=[4, 5, 6],
     homePlanet=None,
 )
 
 leia = Human(
-    id='1003',
-    name='Leia Organa',
-    friends=['1000', '1002', '2000', '2001'],
+    id="1003",
+    name="Leia Organa",
+    friends=["1000", "1002", "2000", "2001"],
     appearsIn=[4, 5, 6],
-    homePlanet='Alderaan',
+    homePlanet="Alderaan",
 )
 
 tarkin = Human(
-    id='1004',
-    name='Wilhuff Tarkin',
-    friends=['1001'],
-    appearsIn=[4],
-    homePlanet=None,
+    id="1004", name="Wilhuff Tarkin", friends=["1001"], appearsIn=[4], homePlanet=None,
 )
 
 humanData = {
-    '1000': luke,
-    '1001': vader,
-    '1002': han,
-    '1003': leia,
-    '1004': tarkin,
+    "1000": luke,
+    "1001": vader,
+    "1002": han,
+    "1003": leia,
+    "1004": tarkin,
 }
 
-Droid = namedtuple('Droid', 'id name friends appearsIn primaryFunction')
+Droid = namedtuple("Droid", "id name friends appearsIn primaryFunction")
 
 threepio = Droid(
-    id='2000',
-    name='C-3PO',
-    friends=['1000', '1002', '1003', '2001'],
+    id="2000",
+    name="C-3PO",
+    friends=["1000", "1002", "1003", "2001"],
     appearsIn=[4, 5, 6],
-    primaryFunction='Protocol',
+    primaryFunction="Protocol",
 )
 
 artoo = Droid(
-    id='2001',
-    name='R2-D2',
-    friends=['1000', '1002', '1003'],
+    id="2001",
+    name="R2-D2",
+    friends=["1000", "1002", "1003"],
     appearsIn=[4, 5, 6],
-    primaryFunction='Astromech',
+    primaryFunction="Astromech",
 )
 
 droidData = {
-    '2000': threepio,
-    '2001': artoo,
+    "2000": threepio,
+    "2001": artoo,
 }
 
 reviews = {
-    4: [
-        {
-            'stars': 4,
-            'commentary': 'Was good.',
-            'episode': 4
-        },
-    ],
-    5: [
-        {
-            'stars': 5,
-            'commentary': 'This is a great movie!',
-            'episode': 5
-        },
-    ],
-    6: [
-        {
-            'stars': 3,
-            'commentary': 'Was expecting more stuff',
-            'episode': 6
-        },
-    ]
+    4: [{"stars": 4, "commentary": "Was good.", "episode": 4}],
+    5: [{"stars": 5, "commentary": "This is a great movie!", "episode": 5}],
+    6: [{"stars": 3, "commentary": "Was expecting more stuff", "episode": 6}],
 }
 
 
@@ -112,8 +90,8 @@ def getFriends(character):
 
 def getHero(episode):
     if episode == 5:
-        return humanData.get('1000')
-    return droidData.get('2001')
+        return luke
+    return artoo
 
 
 def getHuman(id):
@@ -126,5 +104,5 @@ def getDroid(id):
 
 def createReview(episode, review):
     reviews[episode].append(review)
-    review['episode'] = episode
+    review["episode"] = episode
     return review

--- a/tests/starwars/fixtures.py
+++ b/tests/starwars/fixtures.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import namedtuple
 
 Human = namedtuple('Human', 'id name friends appearsIn homePlanet')
@@ -129,11 +128,3 @@ def createReview(episode, review):
     reviews[episode].append(review)
     review['episode'] = episode
     return review
-
-
-async def reviewAdded(episode):
-    count = 0
-    while count < len(reviews[episode]):
-        yield reviews[episode][count]
-        await asyncio.sleep(1)
-        count += 1

--- a/tests/starwars/fixtures.py
+++ b/tests/starwars/fixtures.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import namedtuple
 
 Human = namedtuple('Human', 'id name friends appearsIn homePlanet isAlive')
@@ -6,7 +7,7 @@ luke = Human(
     id='1000',
     name='Luke Skywalker',
     friends=['1002', '1003', '2000', '2001'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Tatooine',
     isAlive=True,
 )
@@ -15,7 +16,7 @@ vader = Human(
     id='1001',
     name='Darth Vader',
     friends=['1004'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Tatooine',
     isAlive=False,
 )
@@ -24,7 +25,7 @@ han = Human(
     id='1002',
     name='Han Solo',
     friends=['1000', '1003', '2001'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet=None,
     isAlive=True,
 )
@@ -33,7 +34,7 @@ leia = Human(
     id='1003',
     name='Leia Organa',
     friends=['1000', '1002', '2000', '2001'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     homePlanet='Alderaan',
     isAlive=True,
 )
@@ -42,7 +43,7 @@ tarkin = Human(
     id='1004',
     name='Wilhuff Tarkin',
     friends=['1001'],
-    appearsIn=[4],
+    appearsIn=['NEWHOPE'],
     homePlanet=None,
     isAlive=False,
 )
@@ -61,7 +62,7 @@ threepio = Droid(
     id='2000',
     name='C-3PO',
     friends=['1000', '1002', '1003', '2001'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     primaryFunction='Protocol',
 )
 
@@ -69,13 +70,37 @@ artoo = Droid(
     id='2001',
     name='R2-D2',
     friends=['1000', '1002', '1003'],
-    appearsIn=[4, 5, 6],
+    appearsIn=['NEWHOPE', 'EMPIRE', 'JEDI'],
     primaryFunction='Astromech',
 )
 
 droidData = {
     '2000': threepio,
     '2001': artoo,
+}
+
+reviews = {
+    'NEWHOPE': [
+        {
+            'stars': 4,
+            'commentary': 'Was good.',
+            'episode': 'NEWHOPE'
+        },
+    ],
+    'EMPIRE': [
+        {
+            'stars': 5,
+            'commentary': 'This is a great movie!',
+            'episode': 'EMPIRE'
+        },
+    ],
+    'JEDI': [
+        {
+            'stars': 3,
+            'commentary': 'Was expecting more stuff',
+            'episode': 'JEDI'
+        },
+    ]
 }
 
 
@@ -92,9 +117,9 @@ def getFriends(character):
 
 
 def getHero(episode):
-    if episode == 5:
-        return luke
-    return artoo
+    if episode == 'EMPIRE':
+        return humanData.get('1000')
+    return droidData.get('2001')
 
 
 def getHuman(id):
@@ -105,7 +130,16 @@ def getDroid(id):
     return droidData.get(id)
 
 
-def updateHumanAlive(id, status):
-    human = humanData.get(id)
-    human = human._replace(isAlive=status)
-    return human
+def createReview(episode, review):
+    reviews[episode].append(review)
+    review['episode'] = episode
+    return review
+
+
+async def reviewAdded(episode):
+    count = 0
+    while count < len(reviews[episode]):
+        yield reviews[episode][count]
+        await asyncio.sleep(1)
+        count += 1
+

--- a/tests/starwars/schema.py
+++ b/tests/starwars/schema.py
@@ -1,8 +1,8 @@
 from graphql.type import (GraphQLArgument, GraphQLEnumType, GraphQLEnumValue,
                           GraphQLField, GraphQLInterfaceType, GraphQLList,
                           GraphQLNonNull, GraphQLObjectType, GraphQLSchema,
-                          GraphQLString, GraphQLBoolean, GraphQLInt,
-                          GraphQLInputObjectType, GraphQLInputObjectField)
+                          GraphQLString, GraphQLInt, GraphQLInputObjectType,
+                          GraphQLInputObjectField)
 
 from .fixtures import createReview, getCharacters, getDroid, getFriends, getHero, getHuman, reviewAdded
 
@@ -73,10 +73,6 @@ humanType = GraphQLObjectType(
         'homePlanet': GraphQLField(
             GraphQLString,
             description='The home planet of the human, or null if unknown.',
-        ),
-        'isAlive': GraphQLField(
-            GraphQLBoolean,
-            description='The human is still alive.'
         ),
     },
     interfaces=[characterInterface]

--- a/tests/starwars/schema.py
+++ b/tests/starwars/schema.py
@@ -1,216 +1,200 @@
-from graphql.type import (GraphQLArgument, GraphQLEnumType, GraphQLEnumValue,
-                          GraphQLField, GraphQLInterfaceType, GraphQLList,
-                          GraphQLNonNull, GraphQLObjectType, GraphQLSchema,
-                          GraphQLString, GraphQLInt, GraphQLInputObjectType,
-                          GraphQLInputObjectField)
+from graphql.type import (
+    GraphQLArgument,
+    GraphQLEnumType,
+    GraphQLEnumValue,
+    GraphQLField,
+    GraphQLInputObjectField,
+    GraphQLInputObjectType,
+    GraphQLInt,
+    GraphQLInterfaceType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLSchema,
+    GraphQLString,
+)
 
-from .fixtures import createReview, getCharacters, getDroid, getFriends, getHero, getHuman
+from .fixtures import (
+    createReview,
+    getCharacters,
+    getDroid,
+    getFriends,
+    getHero,
+    getHuman,
+)
 
 episodeEnum = GraphQLEnumType(
-    'Episode',
-    description='One of the films in the Star Wars Trilogy',
+    "Episode",
+    description="One of the films in the Star Wars Trilogy",
     values={
-        'NEWHOPE': GraphQLEnumValue(
-            4,
-            description='Released in 1977.',
-        ),
-        'EMPIRE': GraphQLEnumValue(
-            5,
-            description='Released in 1980.',
-        ),
-        'JEDI': GraphQLEnumValue(
-            6,
-            description='Released in 1983.',
-        )
-    }
+        "NEWHOPE": GraphQLEnumValue(4, description="Released in 1977.",),
+        "EMPIRE": GraphQLEnumValue(5, description="Released in 1980.",),
+        "JEDI": GraphQLEnumValue(6, description="Released in 1983.",),
+    },
 )
 
 characterInterface = GraphQLInterfaceType(
-    'Character',
-    description='A character in the Star Wars Trilogy',
+    "Character",
+    description="A character in the Star Wars Trilogy",
     fields=lambda: {
-        'id': GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            description='The id of the character.'
+        "id": GraphQLField(
+            GraphQLNonNull(GraphQLString), description="The id of the character."
         ),
-        'name': GraphQLField(
-            GraphQLString,
-            description='The name of the character.'
-        ),
-        'friends': GraphQLField(
+        "name": GraphQLField(GraphQLString, description="The name of the character."),
+        "friends": GraphQLField(
             GraphQLList(characterInterface),
-            description='The friends of the character, or an empty list if they have none.'
+            description="The friends of the character, or an empty list if they have none.",
         ),
-        'appearsIn': GraphQLField(
-            GraphQLList(episodeEnum),
-            description='Which movies they appear in.'
+        "appearsIn": GraphQLField(
+            GraphQLList(episodeEnum), description="Which movies they appear in."
         ),
     },
-    resolve_type=lambda character, *_: humanType if getHuman(character.id) else droidType,
+    resolve_type=lambda character, *_: humanType
+    if getHuman(character.id)
+    else droidType,
 )
 
 humanType = GraphQLObjectType(
-    'Human',
-    description='A humanoid creature in the Star Wars universe.',
+    "Human",
+    description="A humanoid creature in the Star Wars universe.",
     fields=lambda: {
-        'id': GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            description='The id of the human.',
+        "id": GraphQLField(
+            GraphQLNonNull(GraphQLString), description="The id of the human.",
         ),
-        'name': GraphQLField(
-            GraphQLString,
-            description='The name of the human.',
-        ),
-        'friends': GraphQLField(
+        "name": GraphQLField(GraphQLString, description="The name of the human.",),
+        "friends": GraphQLField(
             GraphQLList(characterInterface),
-            description='The friends of the human, or an empty list if they have none.',
+            description="The friends of the human, or an empty list if they have none.",
             resolver=lambda human, info, **args: getFriends(human),
         ),
-        'appearsIn': GraphQLField(
-            GraphQLList(episodeEnum),
-            description='Which movies they appear in.',
+        "appearsIn": GraphQLField(
+            GraphQLList(episodeEnum), description="Which movies they appear in.",
         ),
-        'homePlanet': GraphQLField(
+        "homePlanet": GraphQLField(
             GraphQLString,
-            description='The home planet of the human, or null if unknown.',
+            description="The home planet of the human, or null if unknown.",
         ),
     },
-    interfaces=[characterInterface]
+    interfaces=[characterInterface],
 )
 
 droidType = GraphQLObjectType(
-    'Droid',
-    description='A mechanical creature in the Star Wars universe.',
+    "Droid",
+    description="A mechanical creature in the Star Wars universe.",
     fields=lambda: {
-        'id': GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            description='The id of the droid.',
+        "id": GraphQLField(
+            GraphQLNonNull(GraphQLString), description="The id of the droid.",
         ),
-        'name': GraphQLField(
-            GraphQLString,
-            description='The name of the droid.',
-        ),
-        'friends': GraphQLField(
+        "name": GraphQLField(GraphQLString, description="The name of the droid.",),
+        "friends": GraphQLField(
             GraphQLList(characterInterface),
-            description='The friends of the droid, or an empty list if they have none.',
+            description="The friends of the droid, or an empty list if they have none.",
             resolver=lambda droid, info, **args: getFriends(droid),
         ),
-        'appearsIn': GraphQLField(
-            GraphQLList(episodeEnum),
-            description='Which movies they appear in.',
+        "appearsIn": GraphQLField(
+            GraphQLList(episodeEnum), description="Which movies they appear in.",
         ),
-        'primaryFunction': GraphQLField(
-            GraphQLString,
-            description='The primary function of the droid.',
-        )
+        "primaryFunction": GraphQLField(
+            GraphQLString, description="The primary function of the droid.",
+        ),
     },
-    interfaces=[characterInterface]
+    interfaces=[characterInterface],
 )
 
 reviewType = GraphQLObjectType(
-    'Review',
-    description='Represents a review for a movie',
+    "Review",
+    description="Represents a review for a movie",
     fields=lambda: {
-        'episode': GraphQLField(
-            episodeEnum,
-            description='The movie'
-        ),
-        'stars': GraphQLField(
+        "episode": GraphQLField(episodeEnum, description="The movie"),
+        "stars": GraphQLField(
             GraphQLNonNull(GraphQLInt),
-            description='The number of stars this review gave, 1-5'
+            description="The number of stars this review gave, 1-5",
         ),
-        'commentary': GraphQLField(
-            GraphQLString,
-            description='Comment about the movie'
-        )
-    }
+        "commentary": GraphQLField(
+            GraphQLString, description="Comment about the movie"
+        ),
+    },
 )
 
 reviewInputType = GraphQLInputObjectType(
-    'ReviewInput',
-    description='The input object sent when someone is creating a new review',
+    "ReviewInput",
+    description="The input object sent when someone is creating a new review",
     fields={
-        'stars': GraphQLInputObjectField(
-            GraphQLInt,
-            description='0-5 stars'
+        "stars": GraphQLInputObjectField(GraphQLInt, description="0-5 stars"),
+        "commentary": GraphQLInputObjectField(
+            GraphQLString, description="Comment about the movie, optional"
         ),
-        'commentary': GraphQLInputObjectField(
-            GraphQLString,
-            description='Comment about the movie, optional'
-        )
-    }
+    },
 )
 
 queryType = GraphQLObjectType(
-    'Query',
+    "Query",
     fields=lambda: {
-        'hero': GraphQLField(
+        "hero": GraphQLField(
             characterInterface,
             args={
-                'episode': GraphQLArgument(
-                    description='If omitted, returns the hero of the whole saga. If '
-                                'provided, returns the hero of that particular episode.',
+                "episode": GraphQLArgument(
+                    description="If omitted, returns the hero of the whole saga. If "
+                    "provided, returns the hero of that particular episode.",
                     type=episodeEnum,
                 )
             },
-            resolver=lambda root, info, **args: getHero(args.get('episode')),
+            resolver=lambda root, info, **args: getHero(args.get("episode")),
         ),
-        'human': GraphQLField(
+        "human": GraphQLField(
             humanType,
             args={
-                'id': GraphQLArgument(
-                    description='id of the human',
-                    type=GraphQLNonNull(GraphQLString),
+                "id": GraphQLArgument(
+                    description="id of the human", type=GraphQLNonNull(GraphQLString),
                 )
             },
-            resolver=lambda root, info, **args: getHuman(args['id']),
+            resolver=lambda root, info, **args: getHuman(args["id"]),
         ),
-        'droid': GraphQLField(
+        "droid": GraphQLField(
             droidType,
             args={
-                'id': GraphQLArgument(
-                    description='id of the droid',
-                    type=GraphQLNonNull(GraphQLString),
+                "id": GraphQLArgument(
+                    description="id of the droid", type=GraphQLNonNull(GraphQLString),
                 )
             },
-            resolver=lambda root, info, **args: getDroid(args['id']),
+            resolver=lambda root, info, **args: getDroid(args["id"]),
         ),
-        'characters': GraphQLField(
+        "characters": GraphQLField(
             GraphQLList(characterInterface),
             args={
-                'ids': GraphQLArgument(
-                    description='list of character ids',
+                "ids": GraphQLArgument(
+                    description="list of character ids",
                     type=GraphQLList(GraphQLString),
                 )
             },
-            resolver=lambda root, info, **args: getCharacters(args['ids']),
+            resolver=lambda root, info, **args: getCharacters(args["ids"]),
         ),
-    }
+    },
 )
 
 mutationType = GraphQLObjectType(
-    'Mutation',
-    description='The mutation type, represents all updates we can make to our data',
+    "Mutation",
+    description="The mutation type, represents all updates we can make to our data",
     fields=lambda: {
-        'createReview': GraphQLField(
+        "createReview": GraphQLField(
             reviewType,
             args={
-                'episode': GraphQLArgument(
-                    description='Episode to create review',
-                    type=episodeEnum,
+                "episode": GraphQLArgument(
+                    description="Episode to create review", type=episodeEnum,
                 ),
-                'review': GraphQLArgument(
-                    description='set alive status',
-                    type=reviewInputType,
+                "review": GraphQLArgument(
+                    description="set alive status", type=reviewInputType,
                 ),
             },
-            resolver=lambda root, info, **args: createReview(args.get('episode'), args.get('review')),
+            resolver=lambda root, info, **args: createReview(
+                args.get("episode"), args.get("review")
+            ),
         ),
-    }
+    },
 )
 
 StarWarsSchema = GraphQLSchema(
     query=queryType,
     mutation=mutationType,
-    types=[humanType, droidType, reviewType, reviewInputType]
+    types=[humanType, droidType, reviewType, reviewInputType],
 )

--- a/tests/starwars/schema.py
+++ b/tests/starwars/schema.py
@@ -11,15 +11,15 @@ episodeEnum = GraphQLEnumType(
     description='One of the films in the Star Wars Trilogy',
     values={
         'NEWHOPE': GraphQLEnumValue(
-            value='NEWHOPE',
+            4,
             description='Released in 1977.',
         ),
         'EMPIRE': GraphQLEnumValue(
-            value='EMPIRE',
+            5,
             description='Released in 1980.',
         ),
         'JEDI': GraphQLEnumValue(
-            value='JEDI',
+            6,
             description='Released in 1983.',
         )
     }

--- a/tests/starwars/schema.py
+++ b/tests/starwars/schema.py
@@ -4,7 +4,7 @@ from graphql.type import (GraphQLArgument, GraphQLEnumType, GraphQLEnumValue,
                           GraphQLString, GraphQLInt, GraphQLInputObjectType,
                           GraphQLInputObjectField)
 
-from .fixtures import createReview, getCharacters, getDroid, getFriends, getHero, getHuman, reviewAdded
+from .fixtures import createReview, getCharacters, getDroid, getFriends, getHero, getHuman
 
 episodeEnum = GraphQLEnumType(
     'Episode',
@@ -209,25 +209,8 @@ mutationType = GraphQLObjectType(
     }
 )
 
-subscriptionType = GraphQLObjectType(
-    'Subscription',
-    fields=lambda: {
-        'reviewAdded': GraphQLField(
-            reviewType,
-            args={
-                'episode': GraphQLArgument(
-                    description='Episode to review',
-                    type=episodeEnum,
-                )
-            },
-            resolver=lambda root, info, **args: reviewAdded(args.get('episode')),
-        )
-    }
-)
-
 StarWarsSchema = GraphQLSchema(
     query=queryType,
     mutation=mutationType,
-    subscription=subscriptionType,
     types=[humanType, droidType, reviewType, reviewInputType]
 )

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -148,7 +148,7 @@ def test_arg_serializer_list(ds):
 
 def test_arg_serializer_enum(ds):
     result = ds.query(
-        ds.Query.hero.args(episode='EMPIRE').select(
+        ds.Query.hero.args(episode=5).select(
             ds.Character.name
         )
     )
@@ -163,7 +163,7 @@ def test_arg_serializer_enum(ds):
 def test_create_review_mutation_result(ds):
     result = ds.mutate(
         ds.Mutation.createReview.args(
-            episode='JEDI',
+            episode=6,
             review={
                 'stars': 5,
                 'commentary': 'This is a great movie!'

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -148,7 +148,7 @@ def test_arg_serializer_list(ds):
 
 def test_arg_serializer_enum(ds):
     result = ds.query(
-        ds.Query.hero.args(episode=5).select(
+        ds.Query.hero.args(episode='EMPIRE').select(
             ds.Character.name
         )
     )
@@ -160,17 +160,23 @@ def test_arg_serializer_enum(ds):
     assert result == expected
 
 
-def test_human_alive_mutation_result(ds):
+def test_create_review_mutation_result(ds):
     result = ds.mutate(
-        ds.Mutation.updateHumanAliveStatus.args(id=1004, status=True).select(
-            ds.Human.name,
-            ds.Human.isAlive
+        ds.Mutation.createReview.args(
+            episode='JEDI',
+            review={
+                'stars': 5,
+                'commentary': 'This is a great movie!'
+            }
+        ).select(
+            ds.Review.stars,
+            ds.Review.commentary
         )
     )
     expected = {
-        'updateHumanAliveStatus': {
-            'name': 'Wilhuff Tarkin',
-            'isAlive': True
+        'createReview': {
+            'stars': 5,
+            'commentary': 'This is a great movie!'
         }
     }
     assert result == expected

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -15,32 +15,28 @@ def ds():
 
 def test_invalid_field_on_type_query(ds):
     with pytest.raises(KeyError) as exc_info:
-        ds.Query.extras.select(
-            ds.Character.name
-        )
+        ds.Query.extras.select(ds.Character.name)
     assert "Field extras does not exist in type Query." in str(exc_info.value)
 
 
 def test_incompatible_query_field(ds):
     with pytest.raises(Exception) as exc_info:
-        ds.query('hero')
+        ds.query("hero")
     assert "Received incompatible query field" in str(exc_info.value)
 
 
 def test_hero_name_query(ds):
-    query = '''
+    query = """
 hero {
   name
 }
-    '''.strip()
-    query_dsl = ds.Query.hero.select(
-        ds.Character.name
-    )
+    """.strip()
+    query_dsl = ds.Query.hero.select(ds.Character.name)
     assert query == str(query_dsl)
 
 
 def test_hero_name_and_friends_query(ds):
-    query = '''
+    query = """
 hero {
   id
   name
@@ -48,19 +44,17 @@ hero {
     name
   }
 }
-    '''.strip()
+    """.strip()
     query_dsl = ds.Query.hero.select(
         ds.Character.id,
         ds.Character.name,
-        ds.Character.friends.select(
-            ds.Character.name,
-        )
+        ds.Character.friends.select(ds.Character.name,),
     )
     assert query == str(query_dsl)
 
 
 def test_nested_query(ds):
-    query = '''
+    query = """
 hero {
   name
   friends {
@@ -71,112 +65,70 @@ hero {
     }
   }
 }
-    '''.strip()
+    """.strip()
     query_dsl = ds.Query.hero.select(
         ds.Character.name,
         ds.Character.friends.select(
             ds.Character.name,
             ds.Character.appears_in,
-            ds.Character.friends.select(
-                ds.Character.name
-            )
-        )
+            ds.Character.friends.select(ds.Character.name),
+        ),
     )
     assert query == str(query_dsl)
 
 
 def test_fetch_luke_query(ds):
-    query = '''
+    query = """
 human(id: "1000") {
   name
 }
-    '''.strip()
-    query_dsl = ds.Query.human(id="1000").select(
-        ds.Human.name,
-    )
+    """.strip()
+    query_dsl = ds.Query.human(id="1000").select(ds.Human.name,)
 
     assert query == str(query_dsl)
 
 
 def test_fetch_luke_aliased(ds):
-    query = '''
+    query = """
 luke: human(id: "1000") {
   name
 }
-    '''.strip()
-    query_dsl = ds.Query.human.args(id=1000).alias('luke').select(
-        ds.Character.name,
-    )
+    """.strip()
+    query_dsl = ds.Query.human.args(id=1000).alias("luke").select(ds.Character.name,)
     assert query == str(query_dsl)
 
 
 def test_hero_name_query_result(ds):
-    result = ds.query(
-        ds.Query.hero.select(
-            ds.Character.name
-        )
-    )
-    expected = {
-        'hero': {
-            'name': 'R2-D2'
-        }
-    }
+    result = ds.query(ds.Query.hero.select(ds.Character.name))
+    expected = {"hero": {"name": "R2-D2"}}
     assert result == expected
 
 
 def test_arg_serializer_list(ds):
     result = ds.query(
-        ds.Query.characters.args(ids=[1000, 1001, 1003]).select(
-            ds.Character.name,
-        )
+        ds.Query.characters.args(ids=[1000, 1001, 1003]).select(ds.Character.name,)
     )
     expected = {
-        'characters': [
-            {
-                'name': 'Luke Skywalker'
-            },
-            {
-                'name': 'Darth Vader'
-            },
-            {
-                'name': 'Leia Organa'
-            }
+        "characters": [
+            {"name": "Luke Skywalker"},
+            {"name": "Darth Vader"},
+            {"name": "Leia Organa"},
         ]
     }
     assert result == expected
 
 
 def test_arg_serializer_enum(ds):
-    result = ds.query(
-        ds.Query.hero.args(episode=5).select(
-            ds.Character.name
-        )
-    )
-    expected = {
-        'hero': {
-            'name': 'Luke Skywalker'
-        }
-    }
+    result = ds.query(ds.Query.hero.args(episode=5).select(ds.Character.name))
+    expected = {"hero": {"name": "Luke Skywalker"}}
     assert result == expected
 
 
 def test_create_review_mutation_result(ds):
     result = ds.mutate(
         ds.Mutation.createReview.args(
-            episode=6,
-            review={
-                'stars': 5,
-                'commentary': 'This is a great movie!'
-            }
-        ).select(
-            ds.Review.stars,
-            ds.Review.commentary
-        )
+            episode=6, review={"stars": 5, "commentary": "This is a great movie!"}
+        ).select(ds.Review.stars, ds.Review.commentary)
     )
-    expected = {
-        'createReview': {
-            'stars': 5,
-            'commentary': 'This is a great movie!'
-        }
-    }
+    expected = {"createReview": {"stars": 5, "commentary": "This is a great movie!"}}
     assert result == expected

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -11,24 +11,23 @@ def client():
 
 
 def test_hero_name_query(client):
-    query = gql('''
+    query = gql(
+        """
         query HeroNameQuery {
           hero {
             name
           }
         }
-    ''')
-    expected = {
-        'hero': {
-            'name': 'R2-D2'
-        }
-    }
+    """
+    )
+    expected = {"hero": {"name": "R2-D2"}}
     result = client.execute(query)
     assert result == expected
 
 
 def test_hero_name_and_friends_query(client):
-    query = gql('''
+    query = gql(
+        """
         query HeroNameAndFriendsQuery {
           hero {
             id
@@ -38,16 +37,17 @@ def test_hero_name_and_friends_query(client):
             }
           }
         }
-    ''')
+    """
+    )
     expected = {
-        'hero': {
-            'id': '2001',
-            'name': 'R2-D2',
-            'friends': [
-                {'name': 'Luke Skywalker'},
-                {'name': 'Han Solo'},
-                {'name': 'Leia Organa'},
-            ]
+        "hero": {
+            "id": "2001",
+            "name": "R2-D2",
+            "friends": [
+                {"name": "Luke Skywalker"},
+                {"name": "Han Solo"},
+                {"name": "Leia Organa"},
+            ],
         }
     }
     result = client.execute(query)
@@ -55,7 +55,8 @@ def test_hero_name_and_friends_query(client):
 
 
 def test_nested_query(client):
-    query = gql('''
+    query = gql(
+        """
         query NestedQuery {
           hero {
             name
@@ -68,63 +69,42 @@ def test_nested_query(client):
             }
           }
         }
-    ''')
+    """
+    )
     expected = {
-        'hero': {
-            'name': 'R2-D2',
-            'friends': [
+        "hero": {
+            "name": "R2-D2",
+            "friends": [
                 {
-                    'name': 'Luke Skywalker',
-                    'appearsIn': ['NEWHOPE', 'EMPIRE', 'JEDI'],
-                    'friends': [
-                        {
-                            'name': 'Han Solo',
-                        },
-                        {
-                            'name': 'Leia Organa',
-                        },
-                        {
-                            'name': 'C-3PO',
-                        },
-                        {
-                            'name': 'R2-D2',
-                        },
-                    ]
+                    "name": "Luke Skywalker",
+                    "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                    "friends": [
+                        {"name": "Han Solo"},
+                        {"name": "Leia Organa"},
+                        {"name": "C-3PO"},
+                        {"name": "R2-D2"},
+                    ],
                 },
                 {
-                    'name': 'Han Solo',
-                    'appearsIn': ['NEWHOPE', 'EMPIRE', 'JEDI'],
-                    'friends': [
-                        {
-                            'name': 'Luke Skywalker',
-                        },
-                        {
-                            'name': 'Leia Organa',
-                        },
-                        {
-                            'name': 'R2-D2',
-                        },
-                    ]
+                    "name": "Han Solo",
+                    "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                    "friends": [
+                        {"name": "Luke Skywalker"},
+                        {"name": "Leia Organa"},
+                        {"name": "R2-D2"},
+                    ],
                 },
                 {
-                    'name': 'Leia Organa',
-                    'appearsIn': ['NEWHOPE', 'EMPIRE', 'JEDI'],
-                    'friends': [
-                        {
-                            'name': 'Luke Skywalker',
-                        },
-                        {
-                            'name': 'Han Solo',
-                        },
-                        {
-                            'name': 'C-3PO',
-                        },
-                        {
-                            'name': 'R2-D2',
-                        },
-                    ]
+                    "name": "Leia Organa",
+                    "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                    "friends": [
+                        {"name": "Luke Skywalker"},
+                        {"name": "Han Solo"},
+                        {"name": "C-3PO"},
+                        {"name": "R2-D2"},
+                    ],
                 },
-            ]
+            ],
         }
     }
     result = client.execute(query)
@@ -132,99 +112,92 @@ def test_nested_query(client):
 
 
 def test_fetch_luke_query(client):
-    query = gql('''
+    query = gql(
+        """
         query FetchLukeQuery {
           human(id: "1000") {
             name
           }
         }
-    ''')
-    expected = {
-        'human': {
-            'name': 'Luke Skywalker',
-        }
-    }
+    """
+    )
+    expected = {"human": {"name": "Luke Skywalker"}}
     result = client.execute(query)
     assert result == expected
 
 
 def test_fetch_some_id_query(client):
-    query = gql('''
+    query = gql(
+        """
         query FetchSomeIDQuery($someId: String!) {
           human(id: $someId) {
             name
           }
         }
-    ''')
+    """
+    )
     params = {
-        'someId': '1000',
+        "someId": "1000",
     }
-    expected = {
-        'human': {
-            'name': 'Luke Skywalker',
-        }
-    }
+    expected = {"human": {"name": "Luke Skywalker"}}
     result = client.execute(query, variable_values=params)
     assert result == expected
 
 
 def test_fetch_some_id_query2(client):
-    query = gql('''
+    query = gql(
+        """
         query FetchSomeIDQuery($someId: String!) {
           human(id: $someId) {
             name
           }
         }
-    ''')
+    """
+    )
     params = {
-        'someId': '1002',
+        "someId": "1002",
     }
-    expected = {
-        'human': {
-            'name': 'Han Solo',
-        }
-    }
+    expected = {"human": {"name": "Han Solo"}}
     result = client.execute(query, variable_values=params)
     assert result == expected
 
 
 def test_invalid_id_query(client):
-    query = gql('''
+    query = gql(
+        """
         query humanQuery($id: String!) {
           human(id: $id) {
             name
           }
         }
-    ''')
+    """
+    )
     params = {
-        'id': 'not a valid id',
+        "id": "not a valid id",
     }
-    expected = {
-        'human': None
-    }
+    expected = {"human": None}
     result = client.execute(query, variable_values=params)
     assert result == expected
 
 
 def test_fetch_luke_aliased(client):
-    query = gql('''
+    query = gql(
+        """
         query FetchLukeAliased {
           luke: human(id: "1000") {
             name
           }
         }
-    ''')
-    expected = {
-        'luke': {
-            'name': 'Luke Skywalker',
-        }
-    }
+    """
+    )
+    expected = {"luke": {"name": "Luke Skywalker"}}
     result = client.execute(query)
     assert result == expected
 
 
 def test_fetch_luke_and_leia_aliased(client):
-    query = gql('''
+    query = gql(
+        """
         query FetchLukeAndLeiaAliased {
           luke: human(id: "1000") {
             name
@@ -233,21 +206,16 @@ def test_fetch_luke_and_leia_aliased(client):
             name
           }
         }
-    ''')
-    expected = {
-        'luke': {
-            'name': 'Luke Skywalker',
-        },
-        'leia': {
-            'name': 'Leia Organa',
-        }
-    }
+    """
+    )
+    expected = {"luke": {"name": "Luke Skywalker"}, "leia": {"name": "Leia Organa"}}
     result = client.execute(query)
     assert result == expected
 
 
 def test_duplicate_fields(client):
-    query = gql('''
+    query = gql(
+        """
         query DuplicateFields {
           luke: human(id: "1000") {
             name
@@ -258,23 +226,19 @@ def test_duplicate_fields(client):
             homePlanet
           }
         }
-    ''')
+    """
+    )
     expected = {
-        'luke': {
-            'name': 'Luke Skywalker',
-            'homePlanet': 'Tatooine',
-        },
-        'leia': {
-            'name': 'Leia Organa',
-            'homePlanet': 'Alderaan',
-        }
+        "luke": {"name": "Luke Skywalker", "homePlanet": "Tatooine"},
+        "leia": {"name": "Leia Organa", "homePlanet": "Alderaan"},
     }
     result = client.execute(query)
     assert result == expected
 
 
 def test_use_fragment(client):
-    query = gql('''
+    query = gql(
+        """
         query UseFragment {
           luke: human(id: "1000") {
             ...HumanFragment
@@ -287,55 +251,44 @@ def test_use_fragment(client):
           name
           homePlanet
         }
-    ''')
+    """
+    )
     expected = {
-        'luke': {
-            'name': 'Luke Skywalker',
-            'homePlanet': 'Tatooine',
-        },
-        'leia': {
-            'name': 'Leia Organa',
-            'homePlanet': 'Alderaan',
-        }
+        "luke": {"name": "Luke Skywalker", "homePlanet": "Tatooine"},
+        "leia": {"name": "Leia Organa", "homePlanet": "Alderaan"},
     }
     result = client.execute(query)
     assert result == expected
 
 
 def test_check_type_of_r2(client):
-    query = gql('''
+    query = gql(
+        """
         query CheckTypeOfR2 {
           hero {
             __typename
             name
           }
         }
-    ''')
-    expected = {
-        'hero': {
-            '__typename': 'Droid',
-            'name': 'R2-D2',
-        }
-    }
+    """
+    )
+    expected = {"hero": {"__typename": "Droid", "name": "R2-D2"}}
     result = client.execute(query)
     assert result == expected
 
 
 def test_check_type_of_luke(client):
-    query = gql('''
+    query = gql(
+        """
         query CheckTypeOfLuke {
           hero(episode: EMPIRE) {
             __typename
             name
           }
         }
-    ''')
-    expected = {
-        'hero': {
-            '__typename': 'Human',
-            'name': 'Luke Skywalker',
-        }
-    }
+    """
+    )
+    expected = {"hero": {"__typename": "Human", "name": "Luke Skywalker"}}
     result = client.execute(query)
     assert result == expected
 
@@ -343,38 +296,37 @@ def test_check_type_of_luke(client):
 def test_parse_error(client):
     result = None
     with pytest.raises(Exception) as exc_info:
-        query = gql('''
+        query = gql(
+            """
             qeury
-        ''')
+        """
+        )
         result = client.execute(query)
     error = exc_info.value
     formatted_error = format_error(error)
-    assert formatted_error['locations'] == [{'column': 13, 'line': 2}]
-    assert 'Syntax Error GraphQL request (2:13) Unexpected Name "qeury"' in formatted_error['message']
+    assert formatted_error["locations"] == [{"column": 13, "line": 2}]
+    assert (
+        'Syntax Error GraphQL request (2:13) Unexpected Name "qeury"'
+        in formatted_error["message"]
+    )
     assert not result
 
 
 def test_mutation_result(client):
-    query = gql('''
+    query = gql(
+        """
         mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
           createReview(episode: $ep, review: $review) {
             stars
             commentary
           }
         }
-    ''')
+    """
+    )
     params = {
-        'ep': 'JEDI',
-        'review': {
-            'stars': 5,
-            'commentary': 'This is a great movie!'
-        }
+        "ep": "JEDI",
+        "review": {"stars": 5, "commentary": "This is a great movie!"},
     }
-    expected = {
-        'createReview': {
-            'stars': 5,
-            'commentary': 'This is a great movie!'
-        }
-    }
+    expected = {"createReview": {"stars": 5, "commentary": "This is a great movie!"}}
     result = client.execute(query, variable_values=params)
     assert result == expected

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -1,5 +1,10 @@
+import asyncio
+from asyncio import get_event_loop
+
 import pytest
+from graphql import subscribe
 from graphql.error import format_error
+from graphql.execution.executors.asyncio import AsyncioExecutor
 
 from gql import Client, gql
 
@@ -353,3 +358,99 @@ def test_parse_error(client):
     assert formatted_error['locations'] == [{'column': 13, 'line': 2}]
     assert 'Syntax Error GraphQL request (2:13) Unexpected Name "qeury"' in formatted_error['message']
     assert not result
+
+
+def test_mutation_result(client):
+    query = gql('''
+        mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
+          createReview(episode: $ep, review: $review) {
+            stars
+            commentary
+          }
+        }
+    ''')
+    params = {
+        'ep': 'JEDI',
+        'review': {
+            'stars': 5,
+            'commentary': 'This is a great movie!'
+        }
+    }
+    expected = {
+        'createReview': {
+            'stars': 5,
+            'commentary': 'This is a great movie!'
+        }
+    }
+    result = client.execute(query, variable_values=params)
+    assert result == expected
+
+
+class ObservableAsyncIterable:
+    def __init__(self, observable):
+        self.disposable = None
+        self.queue = asyncio.Queue()
+        self.observable = observable
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        type_, val = await self.queue.get()
+        if type_ in ('E', 'C'):
+            raise StopAsyncIteration()
+        return val
+
+    async def __aenter__(self):
+        self.disposable = self.observable.subscribe(
+            on_next=lambda val: self.queue.put_nowait(('N', val)),
+            on_error=lambda exc: self.queue.put_nowait(('E', exc)),
+            on_completed=lambda: self.queue.put_nowait(('C', None)),
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.disposable.dispose()
+
+
+@pytest.mark.asyncio
+async def test_subscription_support():
+    subs = gql('''
+        subscription ListenEpisodeReviews($ep: Episode!) {
+          reviewAdded(episode: $ep) {
+            stars,
+            commentary,
+            episode
+          }
+        }
+    ''')
+    params = {
+        'ep': 'JEDI'
+    }
+    expected_one = {
+        'stars': 3,
+        'commentary': 'Was expecting more stuff',
+        'episode': 'JEDI'
+    }
+    expected_two = {
+        'stars': 5,
+        'commentary': 'This is a great movie!',
+        'episode': 'JEDI'
+    }
+    # For asyncio, requires set return_promise=True as stated on the following comment
+    # https://github.com/graphql-python/graphql-core/issues/63#issuecomment-568270864
+    loop = get_event_loop()
+    execution_result = await subscribe(
+        schema=StarWarsSchema,
+        document_ast=subs,
+        return_promise=True,
+        variable_values=params,
+        executor=AsyncioExecutor(loop=loop)
+    )
+    expected = []
+    async with ObservableAsyncIterable(execution_result) as oai:
+        async for i in oai:
+            review = i.to_dict()
+            expected.append(review['data']['reviewAdded'])
+    assert expected[0] == expected_one
+    assert expected[1] == expected_two

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -1,14 +1,8 @@
-import asyncio
-from asyncio import get_event_loop
-
 import pytest
-from graphql import subscribe
 from graphql.error import format_error
-from graphql.execution.executors.asyncio import AsyncioExecutor
 
 from gql import Client, gql
-
-from .schema import StarWarsSchema
+from tests.starwars.schema import StarWarsSchema
 
 
 @pytest.fixture
@@ -384,73 +378,3 @@ def test_mutation_result(client):
     }
     result = client.execute(query, variable_values=params)
     assert result == expected
-
-
-class ObservableAsyncIterable:
-    def __init__(self, observable):
-        self.disposable = None
-        self.queue = asyncio.Queue()
-        self.observable = observable
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        type_, val = await self.queue.get()
-        if type_ in ('E', 'C'):
-            raise StopAsyncIteration()
-        return val
-
-    async def __aenter__(self):
-        self.disposable = self.observable.subscribe(
-            on_next=lambda val: self.queue.put_nowait(('N', val)),
-            on_error=lambda exc: self.queue.put_nowait(('E', exc)),
-            on_completed=lambda: self.queue.put_nowait(('C', None)),
-        )
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        self.disposable.dispose()
-
-
-@pytest.mark.asyncio
-async def test_subscription_support():
-    subs = gql('''
-        subscription ListenEpisodeReviews($ep: Episode!) {
-          reviewAdded(episode: $ep) {
-            stars,
-            commentary,
-            episode
-          }
-        }
-    ''')
-    params = {
-        'ep': 'JEDI'
-    }
-    expected_one = {
-        'stars': 3,
-        'commentary': 'Was expecting more stuff',
-        'episode': 'JEDI'
-    }
-    expected_two = {
-        'stars': 5,
-        'commentary': 'This is a great movie!',
-        'episode': 'JEDI'
-    }
-    # For asyncio, requires set return_promise=True as stated on the following comment
-    # https://github.com/graphql-python/graphql-core/issues/63#issuecomment-568270864
-    loop = get_event_loop()
-    execution_result = await subscribe(
-        schema=StarWarsSchema,
-        document_ast=subs,
-        return_promise=True,
-        variable_values=params,
-        executor=AsyncioExecutor(loop=loop)
-    )
-    expected = []
-    async with ObservableAsyncIterable(execution_result) as oai:
-        async for i in oai:
-            review = i.to_dict()
-            expected.append(review['data']['reviewAdded'])
-    assert expected[0] == expected_one
-    assert expected[1] == expected_two

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -16,7 +16,8 @@ def local_schema():
 
 @pytest.fixture
 def typedef_schema():
-    return Client(type_def='''
+    return Client(
+        type_def="""
 schema {
   query: Query
 }
@@ -54,7 +55,8 @@ type Query {
   droid(id: String!): Droid
   hero(episode: Episode): Character
   human(id: String!): Human
-}''')
+}"""
+    )
 
 
 @pytest.fixture
@@ -62,7 +64,7 @@ def introspection_schema():
     return Client(introspection=introspection)
 
 
-@pytest.fixture(params=['local_schema', 'typedef_schema', 'introspection_schema'])
+@pytest.fixture(params=["local_schema", "typedef_schema", "introspection_schema"])
 def client(request):
     return request.getfixturevalue(request.param)
 
@@ -83,7 +85,7 @@ def test_incompatible_request_gql(client):
 
 
 def test_nested_query_with_fragment(client):
-    query = '''
+    query = """
         query NestedQueryWithFragment {
           hero {
             ...NameAndAppearances
@@ -99,32 +101,32 @@ def test_nested_query_with_fragment(client):
           name
           appearsIn
         }
-    '''
+    """
     assert not validation_errors(client, query)
 
 
 def test_non_existent_fields(client):
-    query = '''
+    query = """
         query HeroSpaceshipQuery {
           hero {
             favoriteSpaceship
           }
         }
-    '''
+    """
     assert validation_errors(client, query)
 
 
 def test_require_fields_on_object(client):
-    query = '''
+    query = """
         query HeroNoFieldsQuery {
           hero
         }
-    '''
+    """
     assert validation_errors(client, query)
 
 
 def test_disallows_fields_on_scalars(client):
-    query = '''
+    query = """
         query HeroFieldsOnScalarQuery {
           hero {
             name {
@@ -132,24 +134,24 @@ def test_disallows_fields_on_scalars(client):
             }
           }
         }
-    '''
+    """
     assert validation_errors(client, query)
 
 
 def test_disallows_object_fields_on_interfaces(client):
-    query = '''
+    query = """
         query DroidFieldOnCharacter {
           hero {
             name
             primaryFunction
           }
         }
-    '''
+    """
     assert validation_errors(client, query)
 
 
 def test_allows_object_fields_in_fragments(client):
-    query = '''
+    query = """
         query DroidFieldInFragment {
           hero {
             name
@@ -159,12 +161,12 @@ def test_allows_object_fields_in_fragments(client):
         fragment DroidFields on Droid {
           primaryFunction
         }
-    '''
+    """
     assert not validation_errors(client, query)
 
 
 def test_allows_object_fields_in_inline_fragments(client):
-    query = '''
+    query = """
         query DroidFieldInFragment {
           hero {
             name
@@ -173,5 +175,5 @@ def test_allows_object_fields_in_inline_fragments(client):
             }
           }
         }
-    '''
+    """
     assert not validation_errors(client, query)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,23 +1,25 @@
 import os
 
-import pytest
 import mock
-
+import pytest
 from graphql import build_ast_schema, parse
+
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport, Transport
 
 
 @pytest.fixture
 def http_transport_query():
-    return gql('''
+    return gql(
+        """
     query getContinents {
       continents {
         code
         name
       }
     }
-    ''')
+    """
+    )
 
 
 def test_request_transport_not_implemented(http_transport_query):
@@ -30,17 +32,18 @@ def test_request_transport_not_implemented(http_transport_query):
     assert "Any Transport subclass must implement execute method" == str(exc_info.value)
 
 
-@mock.patch('gql.transport.requests.RequestsHTTPTransport.execute')
+@mock.patch("gql.transport.requests.RequestsHTTPTransport.execute")
 def test_retries(execute_mock):
     expected_retries = 3
     execute_mock.side_effect = Exception("fail")
 
     client = Client(
         retries=expected_retries,
-        transport=RequestsHTTPTransport(url='http://swapi.graphene-python.org/graphql')
+        transport=RequestsHTTPTransport(url="http://swapi.graphene-python.org/graphql"),
     )
 
-    query = gql('''
+    query = gql(
+        """
     {
       myFavoriteFilm: film(id:"RmlsbToz") {
         id
@@ -48,7 +51,8 @@ def test_retries(execute_mock):
         episodeId
       }
     }
-    ''')
+    """
+    )
 
     with pytest.raises(Exception):
         client.execute(query)
@@ -59,8 +63,10 @@ def test_retries(execute_mock):
 def test_no_schema_exception():
     with pytest.raises(Exception) as exc_info:
         client = Client()
-        client.validate('')
-    assert "Cannot validate locally the document, you need to pass a schema." in str(exc_info.value)
+        client.validate("")
+    assert "Cannot validate locally the document, you need to pass a schema." in str(
+        exc_info.value
+    )
 
 
 def test_execute_result_error():
@@ -69,15 +75,14 @@ def test_execute_result_error():
     client = Client(
         retries=expected_retries,
         transport=RequestsHTTPTransport(
-            url='https://countries.trevorblades.com/',
+            url="https://countries.trevorblades.com/",
             use_json=True,
-            headers={
-                "Content-type": "application/json",
-            }
-        )
+            headers={"Content-type": "application/json"},
+        ),
     )
 
-    failing_query = gql('''
+    failing_query = gql(
+        """
     query getContinents {
       continents {
         code
@@ -85,20 +90,19 @@ def test_execute_result_error():
         id
       }
     }
-    ''')
+    """
+    )
 
     with pytest.raises(Exception) as exc_info:
         client.execute(failing_query)
-    assert "Cannot query field \"id\" on type \"Continent\"." in str(exc_info.value)
+    assert 'Cannot query field "id" on type "Continent".' in str(exc_info.value)
 
 
 def test_http_transport_raise_for_status_error(http_transport_query):
     client = Client(
         transport=RequestsHTTPTransport(
-            url='https://countries.trevorblades.com/',
-            headers={
-                "Content-type": "application/json",
-            }
+            url="https://countries.trevorblades.com/",
+            headers={"Content-type": "application/json"},
         )
     )
 
@@ -110,12 +114,10 @@ def test_http_transport_raise_for_status_error(http_transport_query):
 def test_http_transport_verify_error(http_transport_query):
     client = Client(
         transport=RequestsHTTPTransport(
-            url='https://countries.trevorblades.com/',
+            url="https://countries.trevorblades.com/",
             use_json=True,
-            headers={
-                "Content-type": "application/json",
-            },
-            verify=False
+            headers={"Content-type": "application/json"},
+            verify=False,
         )
     )
     with pytest.warns(Warning) as record:
@@ -125,20 +127,27 @@ def test_http_transport_verify_error(http_transport_query):
 
 
 def test_gql():
-    sample_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures', 'graphql', 'sample.graphql')
+    sample_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "fixtures",
+        "graphql",
+        "sample.graphql",
+    )
     with open(sample_path) as source:
         document = parse(source.read())
 
     schema = build_ast_schema(document)
 
     client = Client(schema=schema)
-    query = gql('''
+    query = gql(
+        """
         query getUser {
           user(id: "1000") {
             id
             username
           }
         }
-    ''')
+    """
+    )
     result = client.execute(query)
-    assert result['user'] is None
+    assert result["user"] is None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -6,33 +6,29 @@ from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
 # https://github.com/graphql-python/swapi-graphene
-URL = 'http://127.0.0.1:8000/graphql'
+URL = "http://127.0.0.1:8000/graphql"
 
 
 @pytest.fixture
 def client():
-    with vcr.use_cassette('tests/fixtures/vcr_cassettes/client.yaml'):
+    with vcr.use_cassette("tests/fixtures/vcr_cassettes/client.yaml"):
         request = requests.get(
-            URL,
-            headers={
-                'Host': 'swapi.graphene-python.org',
-                'Accept': 'text/html',
-            }
+            URL, headers={"Host": "swapi.graphene-python.org", "Accept": "text/html"}
         )
         request.raise_for_status()
-        csrf = request.cookies['csrftoken']
+        csrf = request.cookies["csrftoken"]
 
         return Client(
             transport=RequestsHTTPTransport(
-                url=URL,
-                cookies={"csrftoken": csrf},
-                headers={'x-csrftoken':  csrf}),
-            fetch_schema_from_transport=True
+                url=URL, cookies={"csrftoken": csrf}, headers={"x-csrftoken": csrf}
+            ),
+            fetch_schema_from_transport=True,
         )
 
 
 def test_hero_name_query(client):
-    query = gql('''
+    query = gql(
+        """
     {
       myFavoriteFilm: film(id:"RmlsbToz") {
         id
@@ -47,7 +43,8 @@ def test_hero_name_query(client):
         }
       }
     }
-    ''')
+    """
+    )
     expected = {
         "myFavoriteFilm": {
             "id": "RmlsbToz",
@@ -55,35 +52,15 @@ def test_hero_name_query(client):
             "episodeId": 6,
             "characters": {
                 "edges": [
-                  {
-                      "node": {
-                          "name": "Luke Skywalker"
-                      }
-                  },
-                    {
-                      "node": {
-                          "name": "C-3PO"
-                      }
-                  },
-                    {
-                      "node": {
-                          "name": "R2-D2"
-                      }
-                  },
-                    {
-                      "node": {
-                          "name": "Darth Vader"
-                      }
-                  },
-                    {
-                      "node": {
-                          "name": "Leia Organa"
-                      }
-                  }
+                    {"node": {"name": "Luke Skywalker"}},
+                    {"node": {"name": "C-3PO"}},
+                    {"node": {"name": "R2-D2"}},
+                    {"node": {"name": "Darth Vader"}},
+                    {"node": {"name": "Leia Organa"}},
                 ]
-            }
+            },
         }
     }
-    with vcr.use_cassette('tests/fixtures/vcr_cassettes/execute.yaml'):
+    with vcr.use_cassette("tests/fixtures/vcr_cassettes/execute.yaml"):
         result = client.execute(query)
         assert result == expected

--- a/tests_py36/fixtures.py
+++ b/tests_py36/fixtures.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from tests.starwars.fixtures import reviews
+
+
+async def reviewAdded(episode):
+    count = 0
+    while count < len(reviews[episode]):
+        yield reviews[episode][count]
+        await asyncio.sleep(1)
+        count += 1

--- a/tests_py36/schema.py
+++ b/tests_py36/schema.py
@@ -1,0 +1,28 @@
+from graphql import GraphQLField, GraphQLArgument, GraphQLObjectType, GraphQLSchema
+
+from tests.starwars.schema import reviewType, episodeEnum, queryType, mutationType, humanType, droidType, \
+    reviewInputType
+from tests_py36.fixtures import reviewAdded
+
+subscriptionType = GraphQLObjectType(
+    'Subscription',
+    fields=lambda: {
+        'reviewAdded': GraphQLField(
+            reviewType,
+            args={
+                'episode': GraphQLArgument(
+                    description='Episode to review',
+                    type=episodeEnum,
+                )
+            },
+            resolver=lambda root, info, **args: reviewAdded(args.get('episode')),
+        )
+    }
+)
+
+StarWarsSchema = GraphQLSchema(
+    query=queryType,
+    mutation=mutationType,
+    subscription=subscriptionType,
+    types=[humanType, droidType, reviewType, reviewInputType]
+)

--- a/tests_py36/test_query.py
+++ b/tests_py36/test_query.py
@@ -1,0 +1,79 @@
+import asyncio
+from asyncio import get_event_loop
+
+import pytest
+from graphql import subscribe
+from graphql.execution.executors.asyncio import AsyncioExecutor
+
+from gql import gql
+from tests_py36.schema import StarWarsSchema
+
+
+class ObservableAsyncIterable:
+    def __init__(self, observable):
+        self.disposable = None
+        self.queue = asyncio.Queue()
+        self.observable = observable
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        type_, val = await self.queue.get()
+        if type_ in ('E', 'C'):
+            raise StopAsyncIteration()
+        return val
+
+    async def __aenter__(self):
+        self.disposable = self.observable.subscribe(
+            on_next=lambda val: self.queue.put_nowait(('N', val)),
+            on_error=lambda exc: self.queue.put_nowait(('E', exc)),
+            on_completed=lambda: self.queue.put_nowait(('C', None)),
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.disposable.dispose()
+
+
+@pytest.mark.asyncio
+async def test_subscription_support():
+    subs = gql('''
+        subscription ListenEpisodeReviews($ep: Episode!) {
+          reviewAdded(episode: $ep) {
+            stars,
+            commentary,
+            episode
+          }
+        }
+    ''')
+    params = {
+        'ep': 'JEDI'
+    }
+    expected_one = {
+        'stars': 3,
+        'commentary': 'Was expecting more stuff',
+        'episode': 'JEDI'
+    }
+    expected_two = {
+        'stars': 5,
+        'commentary': 'This is a great movie!',
+        'episode': 'JEDI'
+    }
+    # For asyncio, requires set return_promise=True as stated on the following comment
+    # https://github.com/graphql-python/graphql-core/issues/63#issuecomment-568270864
+    loop = get_event_loop()
+    execution_result = await subscribe(
+        schema=StarWarsSchema,
+        document_ast=subs,
+        return_promise=True,
+        variable_values=params,
+        executor=AsyncioExecutor(loop=loop)
+    )
+    expected = []
+    async with ObservableAsyncIterable(execution_result) as oai:
+        async for i in oai:
+            review = i.to_dict()
+            expected.append(review['data']['reviewAdded'])
+    assert expected[0] == expected_one
+    assert expected[1] == expected_two

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,py,py3}, flake8, manifest
+envlist = py{27,35,36,37,38,39-dev,py,py3}, flake8, manifest
 ; requires = tox-conda
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ deps = -e.[test]
 ; Prevent installing issues: https://github.com/ContinuumIO/anaconda-issues/issues/542
 commands =
     pip install -U setuptools
-    pytest --cov-report=term-missing --cov=gql tests {posargs}
+    py{27,35}: pytest --cov-report=term-missing --cov=gql tests {posargs}
+    py{36,37,38}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
 
 [testenv:flake8]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,9 @@ deps = -e.[test]
 ; Prevent installing issues: https://github.com/ContinuumIO/anaconda-issues/issues/542
 commands =
     pip install -U setuptools
-    py{27,35,py}: pytest --cov-report=term-missing --cov=gql tests {posargs}
-    py{36,37,38,39-dev,py3}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
+    py{27,35,py}: pytest tests {posargs}
+    py{36,38,39-dev,py3}: pytest tests tests_py36 {posargs}
+    py{37}: pytest tests tests_py36 {posargs: --cov-report=term-missing --cov=gql}
 
 [testenv:black]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{27,35,36,37,38,39-dev,py,py3}, flake8, manifest
+envlist = 
+    black,flake8,import-order,mypy,manifest,
+    py{27,35,36,37,38,39-dev,py,py3}
 ; requires = tox-conda
 
 [pytest]
@@ -21,14 +23,32 @@ commands =
     py{27,35,py}: pytest --cov-report=term-missing --cov=gql tests {posargs}
     py{36,37,38,39-dev,py3}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
 
+[testenv:black]
+basepython=python3.6
+deps = -e.[dev]
+commands =
+    black --check gql tests
+
 [testenv:flake8]
-basepython = python3.8
+basepython = python3.6
 deps = -e.[dev]
 commands =
     flake8 gql tests
 
+[testenv:import-order]
+basepython=python3.6
+deps = -e.[dev]
+commands =
+    isort -rc gql/ tests/
+
+[testenv:mypy]
+basepython=python3.6
+deps = -e.[dev]
+commands =
+    mypy gql tests --ignore-missing-imports
+
 [testenv:manifest]
-basepython = python3.8
+basepython = python3.6
 deps = -e.[dev]
 commands =
     check-manifest -v

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps = -e.[test]
 commands =
     pip install -U setuptools
     py{27,35,py}: pytest --cov-report=term-missing --cov=gql tests {posargs}
-    py{36,37,38,py3}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
+    py{36,37,38,39-dev,py3}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
 
 [testenv:flake8]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py{27,35,36,37,38}, flake8, manifest
 ; requires = tox-conda
 
+[pytest]
+markers = asyncio
+
 [testenv]
 passenv = *
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}, flake8, manifest
+envlist = py{27,35,36,37,38,py,py3}, flake8, manifest
 ; requires = tox-conda
 
 [pytest]
@@ -18,8 +18,8 @@ deps = -e.[test]
 ; Prevent installing issues: https://github.com/ContinuumIO/anaconda-issues/issues/542
 commands =
     pip install -U setuptools
-    py{27,35}: pytest --cov-report=term-missing --cov=gql tests {posargs}
-    py{36,37,38}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
+    py{27,35,py}: pytest --cov-report=term-missing --cov=gql tests {posargs}
+    py{36,37,38,py3}: pytest --cov-report=term-missing --cov=gql tests tests_py36 {posargs}
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
Based on [this graphene PR](https://github.com/graphql-python/graphene/pull/1107/files) and reading about [GraphQL sample schema](https://github.com/apollographql/starwars-server/blob/master/data/swapiSchema.js), I tried to replicate the subscription feature using gql library.

There were big issues as this isn't well documented but this PR should provide insight for end users to use GraphQL subscriptions along with gql.

The only issue is that **asyncio, async/await features are not supported on Python 2.7.** 
Also, the **yield** keyword will throw a `SyntaxError` on Python 3.5.

Also, the `Episode` enumerable was using integers instead of strings values, so I replaced them to follow the sample GraphQL schema.

For last, this PR also provides support for passing `GraphQLInputObjectType` and `GraphQLInputObjectField` if using DSL based on #24.

Cheers!