### PR TITLE
Publish wheels to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ deploy:
   on:
     tags: true
     python: 3.8
+  distributions: "sdist bdist_wheel"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[wheel]
+universal=1
+
 [flake8]
 max-line-length = 120
 


### PR DESCRIPTION
Hi 👋 

This PR adds support to build & publish universal wheels (`.whl`) to pypi so that users do not need to "build from source" when installing.

See: https://pythonwheels.com/

Thanks!

cc @Cito 