### PR TITLE
Retry logic change proposal

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -25,7 +25,7 @@ class Client(object):
         type_def=None,
         transport=None,
         fetch_schema_from_transport=False,
-        retries=0,
+        retries=0,  # We should remove this parameter and let the transport level handle it
     ):
         assert not (
             type_def and introspection

--- a/gql/client.py
+++ b/gql/client.py
@@ -93,3 +93,13 @@ class Client(object):
                 retries_count += 1
 
         raise RetryError(retries_count, last_exception)
+
+    def close(self):
+        """Close the client and it's underlying transport"""
+        self.transport.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/gql/transport/__init__.py
+++ b/gql/transport/__init__.py
@@ -24,7 +24,8 @@ class Transport:
     def close(self):
         """Close the transport
 
-        This method doesn't have to be implemented unless the transport would benefit from it,
-        for example any long-lived TCP Connection like HTTP Keep-Alive or Websocket.
+        This method doesn't have to be implemented unless the transport would benefit from it.
+        This is currently used by the RequestsHTTPTransport transport to close the session's
+        connection pool.
         """
         pass

--- a/gql/transport/__init__.py
+++ b/gql/transport/__init__.py
@@ -20,3 +20,17 @@ class Transport:
         raise NotImplementedError(
             "Any Transport subclass must implement execute method"
         )
+
+    def close(self):
+        """Close the transport
+
+        This method doesn't have to be implemented unless the transport would benefit from it,
+        for example any long-lived TCP Connection like HTTP Keep-Alive or Websocket.
+        """
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/gql/transport/__init__.py
+++ b/gql/transport/__init__.py
@@ -28,9 +28,3 @@ class Transport:
         for example any long-lived TCP Connection like HTTP Keep-Alive or Websocket.
         """
         pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.close()

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -42,6 +42,7 @@ class RequestsHTTPTransport(Transport):
         :param verify: Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use. (Default: True).
+        :param retries: Pre-setup of the requests' Session for performing retries
         :param kwargs: Optional arguments that ``request`` takes. These can be seen at the :requests_: source code
             or the official :docs_:
 
@@ -114,3 +115,7 @@ class RequestsHTTPTransport(Transport):
                 "Server did not return a GraphQL result", response=response
             )
         return ExecutionResult(errors=result.get("errors"), data=result.get("data"))
+
+    def close(self):
+        """Closing the transport by closing the inner session"""
+        self.session.close()

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -66,10 +66,10 @@ class RequestsHTTPTransport(Transport):
                 max_retries=Retry(
                     total=retries,
                     backoff_factor=0.1,
-                    status_forcelist=[500, 502, 503, 504]
+                    status_forcelist=[500, 502, 503, 504],
                 )
             )
-            for prefix in 'http://', 'https://':
+            for prefix in "http://", "https://":
                 self.session.mount(prefix, adapter)
 
     def execute(self, document, variable_values=None, timeout=None):

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -60,7 +60,7 @@ class RequestsHTTPTransport(Transport):
         # Creating a session that can later be re-use to configure custom mechanisms
         self.session = requests.Session()
 
-        # If we specified a retry
+        # If we specified some retries, we provide a predefined retry-logic
         if retries > 0:
             adapter = HTTPAdapter(
                 max_retries=Retry(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,10 +70,11 @@ def test_retries_on_transport(execute_mock):
     uses requests) is pretty low-level itself.
     """
     expected_retries = 3
-    execute_mock.side_effect = NewConnectionError("Should be HTTPConnection", "Fake connection error")
+    execute_mock.side_effect = NewConnectionError(
+        "Should be HTTPConnection", "Fake connection error"
+    )
     transport = RequestsHTTPTransport(
-        url="http://localhost:9999",
-        retries=expected_retries,
+        url="http://localhost:9999", retries=expected_retries,
     )
     client = Client(transport=transport)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,7 +56,7 @@ def test_retries(execute_mock):
 
     with pytest.raises(Exception):
         client.execute(query)
-
+    client.close()
     assert execute_mock.call_count == expected_retries
 
 
@@ -95,6 +95,7 @@ def test_execute_result_error():
 
     with pytest.raises(Exception) as exc_info:
         client.execute(failing_query)
+    client.close()
     assert 'Cannot query field "id" on type "Continent".' in str(exc_info.value)
 
 
@@ -108,6 +109,7 @@ def test_http_transport_raise_for_status_error(http_transport_query):
 
     with pytest.raises(Exception) as exc_info:
         client.execute(http_transport_query)
+    client.close()
     assert "400 Client Error: Bad Request for url" in str(exc_info.value)
 
 
@@ -122,6 +124,7 @@ def test_http_transport_verify_error(http_transport_query):
     )
     with pytest.warns(Warning) as record:
         client.execute(http_transport_query)
+    client.close()  # We could have written `with client:` on top of the `with pytest...` instead
     assert len(record) == 1
     assert "Unverified HTTPS request is being made to host" in str(record[0].message)
 
@@ -150,4 +153,5 @@ def test_gql():
     """
     )
     result = client.execute(query)
+    client.close()
     assert result["user"] is None


### PR DESCRIPTION
First of all, thank you for this great library that we use in many of our tools, libraries and services at @habx.

The `Client` code should let the `Transport` handle the retry logic.

This would simply improve the library because:
- It allows clients to customize the created `requests.Session` behavior to implement their own retry logic. We currently are wrapping your code in ours simply to add some exponential backoff (which is pretty standard).
- This makes the calling code shorter 
- We currently end-up performing retries on transports like the `LocalSchemaTransport` where it doesn't make sense

I think we should also remove the `retries` parameter in the `Client.execute` code but that would mean breaking the current API. It all depends on how you feel about that.

I'm open to any suggestions to improve this PR and help us deal with this issue.