### PR TITLE
chore: bump pytest and pytest-asyncio dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ install_requires = [
 
 tests_require = [
     'coveralls==1.11.1',
-    'pytest==4.6.9',
+    'pytest==5.4.1',
     'pytest-cov==2.8.1',
     'mock==3.0.5',
     'vcrpy==3.0.0',
 ]
 
 if sys.version_info > (3, 6):
-    tests_require.append('pytest-asyncio>=0.9.0')
+    tests_require.append('pytest-asyncio==0.11.0')
 
 dev_requires = [
     'flake8==3.7.9',

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,20 @@ install_requires = [
 
 tests_require = [
     'coveralls==1.11.1',
-    'pytest==5.4.1',
     'pytest-cov==2.8.1',
     'mock==3.0.5',
     'vcrpy==3.0.0',
 ]
 
 if sys.version_info > (3, 6):
-    tests_require.append('pytest-asyncio==0.11.0')
+    tests_require.append([
+        'pytest==5.4.1',
+        'pytest-asyncio==0.11.0',
+    ])
+else:
+    tests_require.append([
+        'pytest==4.6.9',
+    ])
 
 dev_requires = [
     'flake8==3.7.9',


### PR DESCRIPTION
This will fix the Travis CI job as `pytest-asyncio` got a new update which relies on the `pytest` v5.4.0+ API.