### PR TITLE
Allows for custom/any HTTP method (other than POST)

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -29,6 +29,7 @@ class RequestsHTTPTransport(Transport):
         timeout=None,  # type: int
         verify=True,  # type: bool
         retries=0,  # type: int
+        method="POST",  # type: str
         **kwargs  # type: Any
     ):
         """Initialize the transport with the given request parameters.
@@ -43,6 +44,7 @@ class RequestsHTTPTransport(Transport):
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use. (Default: True).
         :param retries: Pre-setup of the requests' Session for performing retries
+        :param method: HTTP method used for requests. (Default: POST).
         :param kwargs: Optional arguments that ``request`` takes. These can be seen at the :requests_: source code
             or the official :docs_:
 
@@ -56,6 +58,7 @@ class RequestsHTTPTransport(Transport):
         self.use_json = use_json
         self.default_timeout = timeout
         self.verify = verify
+        self.method = method
         self.kwargs = kwargs
 
         # Creating a session that can later be re-use to configure custom mechanisms
@@ -101,7 +104,7 @@ class RequestsHTTPTransport(Transport):
         post_args.update(self.kwargs)
 
         # Using the created session to perform requests
-        response = self.session.post(self.url, **post_args)  # type: ignore
+        response = self.session.request(self.method, self.url, **post_args)  # type: ignore
         try:
             result = response.json()
             if not isinstance(result, dict):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -167,6 +167,37 @@ def test_http_transport_verify_error(http_transport_query):
     assert "Unverified HTTPS request is being made to host" in str(record[0].message)
 
 
+def test_http_transport_specify_method_valid(http_transport_query):
+    client = Client(
+        transport=RequestsHTTPTransport(
+            url="https://countries.trevorblades.com/",
+            use_json=True,
+            headers={"Content-type": "application/json"},
+            method="POST",
+        )
+    )
+
+    result = client.execute(http_transport_query)
+    client.close()
+    assert result is not None
+
+
+def test_http_transport_specify_method_invalid(http_transport_query):
+    client = Client(
+        transport=RequestsHTTPTransport(
+            url="https://countries.trevorblades.com/",
+            use_json=True,
+            headers={"Content-type": "application/json"},
+            method="GET",
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        client.execute(http_transport_query)
+    client.close()
+    assert "400 Client Error: Bad Request for url" in str(exc_info.value)
+
+
 def test_gql():
     sample_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
Hi,

I wanted to use this library for a project, but I can't run the queries against the GraphQL API that I use (Prismic GraphQL).

The reason: it only support `GET` HTTP method (and return 404 for `POST`) ([see Prismic doc](https://prismic.io/docs/graphql/getting-started/intro-to-the-graphql-api#14_2-a-graphql-api-that-uses-get)).

As the method was hardcoded as `POST` in the library, I was unable to make it work passing a `method` kwargs to`RequestsHTTPTransport` :

```python
client = gql.Client(
        transport=gql.transport.requests.RequestsHTTPTransport(
            url="https://<repo>.prismic.io/graphql",
            headers={
                "Content-type": "application/json",
                "Authorization": "Token <token>",
                "Prismic-ref": "<ref>",
            },
            method="GET",
        ),
        fetch_schema_from_transport=True,
    )
```

Here a PR for making that possible. By default, the HTTP method remains `POST`; but for those that need/want, they can pass another method to `RequestsHTTPTransport`.