### PR TITLE
aiohttp transport - optional variables and operation name

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -103,11 +103,14 @@ class AIOHTTPTransport(AsyncTransport):
         """
 
         query_str = print_ast(document)
-        payload = {
+        payload: Dict[str, Any] = {
             "query": query_str,
-            "variables": variable_values or {},
-            "operationName": operation_name or "",
         }
+
+        if variable_values:
+            payload["variables"] = variable_values
+        if operation_name:
+            payload["operationName"] = operation_name
 
         post_args = {
             "json": payload,

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -227,7 +227,6 @@ async def test_aiohttp_extra_args(event_loop, aiohttp_server):
 query2_str = """
     query getEurope ($code: ID!) {
       continent (code: $code) {
-        code
         name
       }
     }

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -222,3 +222,44 @@ async def test_aiohttp_extra_args(event_loop, aiohttp_server):
         africa = continents[0]
 
         assert africa["code"] == "AF"
+
+
+query2_str = """
+    query getEurope ($code: ID!) {
+      continent (code: $code) {
+        code
+        name
+      }
+    }
+"""
+
+query2_server_answer = '{"data": {"continent": {"name": "Europe"}}}'
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_query_variable_values(event_loop, aiohttp_server):
+    async def handler(request):
+        return web.Response(text=query2_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    sample_transport = AIOHTTPTransport(url=url, timeout=10)
+
+    async with Client(transport=sample_transport,) as session:
+
+        params = {"code": "EU"}
+
+        query = gql(query2_str)
+
+        # Execute query asynchronously
+        result = await session.execute(
+            query, variable_values=params, operation_name="getEurope"
+        )
+
+        continent = result["continent"]
+
+        assert continent["name"] == "Europe"


### PR DESCRIPTION
- works the same as the requests transport
- fix connecting to servers which do not support setting operationName to "" (#92)