### PR TITLE
Return all errors in TransportQueryError exception

### DIFF
--- a/gql/transport/exceptions.py
+++ b/gql/transport/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Any, List, Optional
+
+
 class TransportError(Exception):
     pass
 
@@ -22,9 +25,15 @@ class TransportQueryError(Exception):
     This exception should not close the transport connection.
     """
 
-    def __init__(self, msg, query_id=None):
+    def __init__(
+        self,
+        msg: str,
+        query_id: Optional[int] = None,
+        errors: Optional[List[Any]] = None,
+    ):
         super().__init__(msg)
         self.query_id = query_id
+        self.errors = errors
 
 
 class TransportClosed(TransportError):

--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -291,7 +291,9 @@ class WebsocketsTransport(AsyncTransport):
 
                     elif answer_type == "error":
 
-                        raise TransportQueryError(str(payload), query_id=answer_id)
+                        raise TransportQueryError(
+                            str(payload), query_id=answer_id, errors=[payload]
+                        )
 
             elif answer_type == "ka":
                 # KeepAlive message
@@ -333,6 +335,9 @@ class WebsocketsTransport(AsyncTransport):
                     # ==> Add an exception to this query queue
                     # The exception is raised for this specific query,
                     # but the transport is not closed.
+                    assert isinstance(
+                        e.query_id, int
+                    ), "TransportQueryError should have a query_id defined here"
                     try:
                         await self.listeners[e.query_id].set_exception(e)
                     except KeyError:

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import types
+from typing import List
 
 import pytest
 import websockets
@@ -44,8 +45,16 @@ async def test_websocket_invalid_query(event_loop, client_and_server, query_str)
 
     query = gql(query_str)
 
-    with pytest.raises(TransportQueryError):
+    with pytest.raises(TransportQueryError) as exc_info:
         await session.execute(query)
+
+    exception = exc_info.value
+
+    assert isinstance(exception.errors, List)
+
+    error = exception.errors[0]
+
+    assert error["extensions"]["code"] == "INTERNAL_SERVER_ERROR"
 
 
 invalid_subscription_str = """
@@ -75,9 +84,17 @@ async def test_websocket_invalid_subscription(event_loop, client_and_server, que
 
     query = gql(query_str)
 
-    with pytest.raises(TransportQueryError):
+    with pytest.raises(TransportQueryError) as exc_info:
         async for result in session.subscribe(query):
             pass
+
+    exception = exc_info.value
+
+    assert isinstance(exception.errors, List)
+
+    error = exception.errors[0]
+
+    assert error["extensions"]["code"] == "INTERNAL_SERVER_ERROR"
 
 
 connection_error_server_answer = (
@@ -170,8 +187,16 @@ async def test_websocket_sending_invalid_payload(
 
     query = gql(query_str)
 
-    with pytest.raises(TransportQueryError):
+    with pytest.raises(TransportQueryError) as exc_info:
         await session.execute(query)
+
+    exception = exc_info.value
+
+    assert isinstance(exception.errors, List)
+
+    error = exception.errors[0]
+
+    assert error["message"] == "Must provide document"
 
 
 not_json_answer = ["BLAHBLAH"]


### PR DESCRIPTION
* Add an errors attribute in the TransportQueryError to get all the errors in the exception
* expose private _execute and _subscribe functions to get ExecutionResult data directly if needed