### PR TITLE
Fix race condition when trying to connect twice at the same time with the websockets transport

### DIFF
--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -7,6 +7,7 @@ import websockets
 
 from gql import Client, gql
 from gql.transport.exceptions import (
+    TransportAlreadyConnected,
     TransportClosed,
     TransportProtocolError,
     TransportQueryError,
@@ -294,3 +295,31 @@ async def test_websocket_server_sending_invalid_query_errors(event_loop, server)
     # Invalid server message is ignored
     async with Client(transport=sample_transport):
         await asyncio.sleep(2 * MS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
+async def test_websocket_non_regression_bug_105(event_loop, server):
+
+    # This test will check a fix to a race condition which happens if the user is trying
+    # to connect using the same client twice at the same time
+    # See bug #105
+
+    url = f"ws://{server.hostname}:{server.port}/graphql"
+    print(f"url = {url}")
+
+    sample_transport = WebsocketsTransport(url=url)
+
+    client = Client(transport=sample_transport)
+
+    # Create a coroutine which start the connection with the transport but does nothing
+    async def client_connect(client):
+        async with client:
+            await asyncio.sleep(2 * MS)
+
+    # Create two tasks which will try to connect using the same client (not allowed)
+    connect_task1 = asyncio.ensure_future(client_connect(client))
+    connect_task2 = asyncio.ensure_future(client_connect(client))
+
+    with pytest.raises(TransportAlreadyConnected):
+        await asyncio.gather(connect_task1, connect_task2)


### PR DESCRIPTION
Connecting twice with the same client is not allowed and should raise `TransportAlreadyConnected` the second time.

Because of a bug in the websockets transport, if the user tries to connect twice at the same time (in different tasks), it will raise a RuntimeError (`RuntimeError: cannot call recv while another coroutine is already waiting for the next message`)

This PR will fix this bug which was reported in issue #105 