### PR TITLE
type_def argument of Client is now deprecated.

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from typing import Any, AsyncGenerator, Dict, Generator, Optional, Union, cast
+from typing import Any, AsyncGenerator, Dict, Generator, Optional, Union
 
 from graphql import (
     DocumentNode,
@@ -31,7 +31,7 @@ class Client:
     ):
         assert not (
             type_def and introspection
-        ), "Cannot provide introspection type definition at the same time."
+        ), "Cannot provide introspection and type definition at the same time."
 
         if type_def:
             assert (
@@ -51,7 +51,7 @@ class Client:
 
         if isinstance(schema, str):
             type_def_ast = parse(schema)
-            schema = cast(GraphQLSchema, build_ast_schema(type_def_ast))
+            schema = build_ast_schema(type_def_ast)
 
         if transport and fetch_schema_from_transport:
             assert (

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -13,7 +13,7 @@ def local_schema():
 @pytest.fixture
 def typedef_schema():
     return Client(
-        type_def="""
+        schema="""
 schema {
   query: Query
 }

--- a/tests/test_async_client_validation.py
+++ b/tests/test_async_client_validation.py
@@ -82,6 +82,7 @@ starwars_invalid_subscription_str = """
         {"schema": StarWarsSchema},
         {"introspection": StarWarsIntrospection},
         {"type_def": StarWarsTypeDef},
+        {"schema": StarWarsTypeDef},
     ],
 )
 async def test_async_client_validation(
@@ -124,6 +125,7 @@ async def test_async_client_validation(
         {"schema": StarWarsSchema},
         {"introspection": StarWarsIntrospection},
         {"type_def": StarWarsTypeDef},
+        {"schema": StarWarsTypeDef},
     ],
 )
 async def test_async_client_validation_invalid_query(


### PR DESCRIPTION
The Client of gql allows us now to pass a local schema either:

- with the `schema` argument if the schema is a GraphQLSchema type
- with the `type_def` argument if the schema is passed as a string

But this is basically the same thing expressed with different types.

I propose to simplify the documentation that the `type_def` argument becomes deprecated and that the local schema is passed using the `schema` argument for both types.

To summarize, you should use `schema=` now instead of previously `type_def=` in the Client.

The schema argument will accept either:
- a string (previously passed to the type_def argument)
- a GraphQLSchema (like before)