### PR TITLE
Downgrade minimum graphql-core version to >=3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "aiohttp==3.6.2",
-    "graphql-core>=3.1,<3.2",
+    "graphql-core>=3,<3.2",
     "requests>=2.23,<3",
     "websockets>=8.1,<9",
     "yarl>=1.4,<2.0",


### PR DESCRIPTION
When gql was upgraded to v3.0 it was [requiring directly the version `>=3.1` for `graphql-core`](https://github.com/graphql-python/gql/commit/369cabf0a4dc58e3045ff6b9686b706354612b1a). This PR is to test if it works with `graphql-core>=3,<3.2`