### PR TITLE
Fix running execute and subscribe of client in a new Thread

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -110,7 +110,13 @@ class Client:
 
         if isinstance(self.transport, AsyncTransport):
 
-            loop = asyncio.get_event_loop()
+            # Get the current asyncio event loop
+            # Or create a new event loop if there isn't one (in a new Thread)
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
 
             assert not loop.is_running(), (
                 "Cannot run client.execute(query) if an asyncio loop is running."
@@ -146,9 +152,15 @@ class Client:
         We need an async transport for this functionality.
         """
 
-        async_generator = self.subscribe_async(document, *args, **kwargs)
+        # Get the current asyncio event loop
+        # Or create a new event loop if there isn't one (in a new Thread)
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
-        loop = asyncio.get_event_loop()
+        async_generator = self.subscribe_async(document, *args, **kwargs)
 
         assert not loop.is_running(), (
             "Cannot run client.subscribe(query) if an asyncio loop is running."

--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -128,6 +128,14 @@ class WebsocketsTransport(AsyncTransport):
         self.receive_data_task: Optional[asyncio.Future] = None
         self.close_task: Optional[asyncio.Future] = None
 
+        # We need to set an event loop here if there is none
+        # Or else we will not be able to create an asyncio.Event()
+        try:
+            self._loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+
         self._wait_closed: asyncio.Event = asyncio.Event()
         self._wait_closed.set()
 


### PR DESCRIPTION
In a new Thread, there is no default asyncio event loop like the main thread
And if we do asyncio.get_event_loop() OR if we create an asyncio.Event()
Then a RuntimeError will be generated

This commit fixes this problem.
This should fix the issue #134 and allow to use gql inside Flask which is multiThreaded
