### PR TITLE
Add the data property in TransportQueryError

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -240,7 +240,9 @@ class SyncClientSession:
 
         # Raise an error if an error is returned in the ExecutionResult object
         if result.errors:
-            raise TransportQueryError(str(result.errors[0]), errors=result.errors)
+            raise TransportQueryError(
+                str(result.errors[0]), errors=result.errors, data=result.data
+            )
 
         assert (
             result.data is not None
@@ -315,7 +317,9 @@ class AsyncClientSession:
 
             # Raise an error if an error is returned in the ExecutionResult object
             if result.errors:
-                raise TransportQueryError(str(result.errors[0]), errors=result.errors)
+                raise TransportQueryError(
+                    str(result.errors[0]), errors=result.errors, data=result.data
+                )
 
             elif result.data is not None:
                 yield result.data
@@ -340,7 +344,9 @@ class AsyncClientSession:
 
         # Raise an error if an error is returned in the ExecutionResult object
         if result.errors:
-            raise TransportQueryError(str(result.errors[0]), errors=result.errors)
+            raise TransportQueryError(
+                str(result.errors[0]), errors=result.errors, data=result.data
+            )
 
         assert (
             result.data is not None

--- a/gql/transport/exceptions.py
+++ b/gql/transport/exceptions.py
@@ -30,10 +30,12 @@ class TransportQueryError(Exception):
         msg: str,
         query_id: Optional[int] = None,
         errors: Optional[List[Any]] = None,
+        data: Optional[Any] = None,
     ):
         super().__init__(msg)
         self.query_id = query_id
         self.errors = errors
+        self.data = data
 
 
 class TransportClosed(TransportError):


### PR DESCRIPTION
It can be useful for some users if multiple queries are done at once and some of them are succeeding and others are failing.
See issue #119 