### PR TITLE
Better transport exception messages

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -204,12 +204,20 @@ class AIOHTTPTransport(AsyncTransport):
                     resp.raise_for_status()
 
                 except ClientResponseError as e:
-                    raise TransportServerError from e
+                    raise TransportServerError(str(e)) from e
 
-                raise TransportProtocolError("Server did not return a GraphQL result")
+                result_text = await resp.text()
+                raise TransportProtocolError(
+                    f"Server did not return a GraphQL result: {result_text}"
+                )
 
             if "errors" not in result and "data" not in result:
-                raise TransportProtocolError("Server did not return a GraphQL result")
+                result_text = await resp.text()
+                raise TransportProtocolError(
+                    "Server did not return a GraphQL result: "
+                    'No "data" or "error" keys in answer: '
+                    f"{result_text}"
+                )
 
             return ExecutionResult(errors=result.get("errors"), data=result.get("data"))
 

--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -325,7 +325,7 @@ class WebsocketsTransport(AsyncTransport):
 
         except ValueError as e:
             raise TransportProtocolError(
-                "Server did not return a GraphQL result"
+                f"Server did not return a GraphQL result: {answer}"
             ) from e
 
         return answer_type, answer_id, execution_result


### PR DESCRIPTION
Add the answer received in some exceptions (TransportProtocolError and TransportServerError)

Should help for cases like [#149](https://github.com/graphql-python/gql/issues/149)