### PR TITLE
chore: stable Python 3.9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -16,7 +16,7 @@ jobs:
           - os: windows-latest
             python-version: "3.7"
           - os: windows-latest
-            python-version: "3.9-dev"
+            python-version: "3.9"
           - os: windows-latest
             python-version: "pypy3"
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     keywords="api graphql protocol rest relay gql client",

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ python =
     pypy3: pypy3
 
 [testenv]
+conda_channels = conda-forge
 passenv = *
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     black,flake8,import-order,mypy,manifest,
-    py{36,37,38,39-dev,py3}
+    py{36,37,38,39,py3}
 
 [pytest]
 markers = asyncio
@@ -11,7 +11,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39-dev
+    3.9: py39
     pypy3: pypy3
 
 [testenv]
@@ -28,7 +28,7 @@ deps = -e.[test]
 commands =
     pip install -U setuptools
     ; run "tox -- tests -s" to show output for debugging
-    py{36,37,39-dev,py3}: pytest {posargs:tests}
+    py{36,37,39,py3}: pytest {posargs:tests}
     py{38}: pytest {posargs:tests --cov-report=term-missing --cov=gql}
 
 [testenv:black]


### PR DESCRIPTION
GH Actions supports Python 3.9 as stable release. More info: https://github.com/actions/virtual-environments/issues/1740