### PR TITLE
Feat: Add Streaming functionalities to file uploads

### DIFF
--- a/docs/usage/file_upload.rst
+++ b/docs/usage/file_upload.rst
@@ -67,3 +67,34 @@ It is also possible to upload multiple files using a list.
 
     f1.close()
     f2.close()
+
+
+Aiohttp StreamReader
+--------------------
+
+In order to upload a aiohttp StreamReader, you need to:
+
+* get response from aiohttp request and then get StreamReader from `resp.content`
+* provide the StreamReader to the `variable_values` argument of `execute`
+* set the `upload_files` argument to True
+
+
+.. code-block:: python
+
+   async with ClientSession() as client:
+       async with client.get('YOUR_URL') as resp:
+           transport = AIOHTTPTransport(url='YOUR_URL')
+           client = Client(transport=transport)
+           query = gql('''
+             mutation($file: Upload!) {
+               singleUpload(file: $file) {
+                 id
+               }
+             }
+           ''')
+
+           params = {"file": resp.content}
+
+           result = client.execute(
+               query, variable_values=params, upload_files=True
+           )

--- a/docs/usage/file_upload.rst
+++ b/docs/usage/file_upload.rst
@@ -98,3 +98,40 @@ In order to upload a aiohttp StreamReader, you need to:
            result = client.execute(
                query, variable_values=params, upload_files=True
            )
+
+Asynchronous Generator
+----------------------
+
+In order to upload a single file use asynchronous generator(https://docs.aiohttp.org/en/stable/client_quickstart.html#streaming-uploads), you need to:
+
+* сreate a asynchronous generator
+* set the generator as a variable value in the mutation
+* provide the opened file to the `variable_values` argument of `execute`
+* set the `upload_files` argument to True
+
+.. code-block:: python
+
+    transport = AIOHTTPTransport(url='YOUR_URL')
+
+    client = Client(transport=sample_transport)
+
+    query = gql('''
+      mutation($file: Upload!) {
+        singleUpload(file: $file) {
+          id
+        }
+      }
+    ''')
+
+    async def file_sender(file_name=None):
+        async with aiofiles.open(file_name, 'rb') as f:
+            chunk = await f.read(64*1024)
+                while chunk:
+                    yield chunk
+                    chunk = await f.read(64*1024)
+
+    params = {"file": file_sender(file_name='YOUR_FILE_PATH')}
+
+    result = client.execute(
+		query, variable_values=params, upload_files=True
+	)

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -144,7 +144,9 @@ class AIOHTTPTransport(AsyncTransport):
 
             # If we upload files, we will extract the files present in the
             # variable_values dict and replace them by null values
-            nulled_variable_values, files = extract_files(variable_values)
+            nulled_variable_values, files = extract_files(
+                variable_values, (aiohttp.StreamReader,)
+            )
 
             # Save the nulled variable values in the payload
             payload["variables"] = nulled_variable_values

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 from ssl import SSLContext
@@ -145,7 +146,8 @@ class AIOHTTPTransport(AsyncTransport):
             # If we upload files, we will extract the files present in the
             # variable_values dict and replace them by null values
             nulled_variable_values, files = extract_files(
-                variable_values, (aiohttp.StreamReader,)
+                variables=variable_values,
+                file_classes=(io.IOBase, aiohttp.StreamReader),
             )
 
             # Save the nulled variable values in the payload

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -29,6 +29,7 @@ class AIOHTTPTransport(AsyncTransport):
 
     This transport use the aiohttp library with asyncio.
     """
+    file_classes = (io.IOBase, aiohttp.StreamReader)
 
     def __init__(
         self,
@@ -147,7 +148,7 @@ class AIOHTTPTransport(AsyncTransport):
             # variable_values dict and replace them by null values
             nulled_variable_values, files = extract_files(
                 variables=variable_values,
-                file_classes=(io.IOBase, aiohttp.StreamReader),
+                file_classes=self.file_classes,
             )
 
             # Save the nulled variable values in the payload

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -175,7 +175,8 @@ class AIOHTTPTransport(AsyncTransport):
             data.add_field("map", file_map_str, content_type="application/json")
 
             # Add the extracted files as remaining fields
-            data.add_fields(*file_streams.items())
+            for k, v in file_streams.items():
+                data.add_field(k, v, filename=k)
 
             post_args: Dict[str, Any] = {"data": data}
 

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -2,7 +2,7 @@ import io
 import json
 import logging
 from ssl import SSLContext
-from typing import Any, AsyncGenerator, Dict, Optional, Union
+from typing import Any, AsyncGenerator, Dict, Optional, Tuple, Type, Union
 
 import aiohttp
 from aiohttp.client_exceptions import ClientResponseError
@@ -30,7 +30,11 @@ class AIOHTTPTransport(AsyncTransport):
     This transport use the aiohttp library with asyncio.
     """
 
-    file_classes = (io.IOBase, aiohttp.StreamReader)
+    file_classes: Tuple[Type[Any], ...] = (
+        io.IOBase,
+        aiohttp.StreamReader,
+        AsyncGenerator,
+    )
 
     def __init__(
         self,

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -29,6 +29,7 @@ class AIOHTTPTransport(AsyncTransport):
 
     This transport use the aiohttp library with asyncio.
     """
+
     file_classes = (io.IOBase, aiohttp.StreamReader)
 
     def __init__(
@@ -147,8 +148,7 @@ class AIOHTTPTransport(AsyncTransport):
             # If we upload files, we will extract the files present in the
             # variable_values dict and replace them by null values
             nulled_variable_values, files = extract_files(
-                variables=variable_values,
-                file_classes=self.file_classes,
+                variables=variable_values, file_classes=self.file_classes,
             )
 
             # Save the nulled variable values in the payload

--- a/gql/utils.py
+++ b/gql/utils.py
@@ -3,6 +3,8 @@
 import io
 from typing import Any, Dict, Tuple
 
+from aiohttp import StreamReader
+
 
 # From this response in Stackoverflow
 # http://stackoverflow.com/a/19053800/1072990
@@ -14,8 +16,8 @@ def to_camel_case(snake_str):
 
 
 def is_file_like(value: Any) -> bool:
-    """Check if a value represents a file like object"""
-    return isinstance(value, io.IOBase)
+    """Check if a value represents a file like object or StreamReader"""
+    return isinstance(value, io.IOBase) or isinstance(value, StreamReader)
 
 
 def extract_files(variables: Dict) -> Tuple[Dict, Dict]:

--- a/gql/utils.py
+++ b/gql/utils.py
@@ -1,9 +1,7 @@
 """Utilities to manipulate several python objects."""
 
 import io
-from typing import Any, Dict, Tuple
-
-from aiohttp import StreamReader
+from typing import Any, Dict, Optional, Tuple
 
 
 # From this response in Stackoverflow
@@ -15,12 +13,18 @@ def to_camel_case(snake_str):
     return components[0] + "".join(x.title() if x else "_" for x in components[1:])
 
 
-def is_file_like(value: Any) -> bool:
-    """Check if a value represents a file like object or StreamReader"""
-    return isinstance(value, io.IOBase) or isinstance(value, StreamReader)
+def is_file_like(value: Any, additional_file_like_instances: Tuple[Any]) -> bool:
+    """Check if a value represents a file like object"""
+    if additional_file_like_instances:
+        return isinstance(value, io.IOBase) or isinstance(
+            value, additional_file_like_instances
+        )
+    return isinstance(value, io.IOBase)
 
 
-def extract_files(variables: Dict) -> Tuple[Dict, Dict]:
+def extract_files(
+    variables: Dict, additional_file_like_instances: Optional[Tuple[Any]]
+) -> Tuple[Dict, Dict]:
     files = {}
 
     def recurse_extract(path, obj):
@@ -42,7 +46,7 @@ def extract_files(variables: Dict) -> Tuple[Dict, Dict]:
                 value = recurse_extract(f"{path}.{key}", value)
                 nulled_obj[key] = value
             return nulled_obj
-        elif is_file_like(obj):
+        elif is_file_like(obj, additional_file_like_instances):
             # extract obj from its parent and put it into files instead.
             files[path] = obj
             return None

--- a/gql/utils.py
+++ b/gql/utils.py
@@ -13,7 +13,9 @@ def to_camel_case(snake_str):
     return components[0] + "".join(x.title() if x else "_" for x in components[1:])
 
 
-def is_file_like(value: Any, additional_file_like_instances: Tuple[Any]) -> bool:
+def is_file_like(
+    value: Any, additional_file_like_instances: Optional[Tuple[Any]] = None
+) -> bool:
     """Check if a value represents a file like object"""
     if additional_file_like_instances:
         return isinstance(value, io.IOBase) or isinstance(
@@ -23,7 +25,7 @@ def is_file_like(value: Any, additional_file_like_instances: Tuple[Any]) -> bool
 
 
 def extract_files(
-    variables: Dict, additional_file_like_instances: Optional[Tuple[Any]]
+    variables: Dict, additional_file_like_instances: Optional[Tuple[Any]] = None
 ) -> Tuple[Dict, Dict]:
     files = {}
 

--- a/gql/utils.py
+++ b/gql/utils.py
@@ -1,7 +1,6 @@
 """Utilities to manipulate several python objects."""
 
-import io
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple, Type
 
 
 # From this response in Stackoverflow
@@ -13,19 +12,8 @@ def to_camel_case(snake_str):
     return components[0] + "".join(x.title() if x else "_" for x in components[1:])
 
 
-def is_file_like(
-    value: Any, additional_file_like_instances: Optional[Tuple[Any]] = None
-) -> bool:
-    """Check if a value represents a file like object"""
-    if additional_file_like_instances:
-        return isinstance(value, io.IOBase) or isinstance(
-            value, additional_file_like_instances
-        )
-    return isinstance(value, io.IOBase)
-
-
 def extract_files(
-    variables: Dict, additional_file_like_instances: Optional[Tuple[Any]] = None
+    variables: Dict, file_classes: Tuple[Type[Any], ...]
 ) -> Tuple[Dict, Dict]:
     files = {}
 
@@ -48,7 +36,7 @@ def extract_files(
                 value = recurse_extract(f"{path}.{key}", value)
                 nulled_obj[key] = value
             return nulled_obj
-        elif is_file_like(obj, additional_file_like_instances):
+        elif isinstance(obj, file_classes):
             # extract obj from its parent and put it into files instead.
             files[path] = obj
             return None

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ tests_requires = [
     "pytest-cov==2.8.1",
     "mock==4.0.2",
     "vcrpy==4.0.2",
+    "aiofiles",
 ]
 
 dev_requires = [

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -583,7 +583,7 @@ async def test_aiohttp_binary_file_upload(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_stream_response_upload(event_loop, aiohttp_server):
+async def test_aiohttp_stream_reader_upload(event_loop, aiohttp_server):
     from aiohttp import web, ClientSession
     from gql.transport.aiohttp import AIOHTTPTransport
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -582,6 +582,84 @@ async def test_aiohttp_binary_file_upload(event_loop, aiohttp_server):
             assert success
 
 
+@pytest.mark.asyncio
+async def test_aiohttp_stream_response_upload(event_loop, aiohttp_server):
+    from aiohttp import web, ClientSession
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    async def binary_data_handler(request):
+        return web.Response(
+            body=binary_file_content, content_type="binary/octet-stream"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", binary_upload_handler)
+    app.router.add_route("GET", "/binary_data", binary_data_handler)
+
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+    binary_data_url = server.make_url("/binary_data")
+
+    sample_transport = AIOHTTPTransport(url=url, timeout=10)
+
+    async with Client(transport=sample_transport) as session:
+        query = gql(file_upload_mutation_1)
+        async with ClientSession() as client:
+            async with client.get(binary_data_url) as resp:
+                params = {"file": resp.content, "other_var": 42}
+
+                # Execute query asynchronously
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+    success = result["success"]
+
+    assert success
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_async_generator_upload(event_loop, aiohttp_server):
+    import aiofiles
+    from aiohttp import web
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    app = web.Application()
+    app.router.add_route("POST", "/", binary_upload_handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    sample_transport = AIOHTTPTransport(url=url, timeout=10)
+
+    with TemporaryFile(binary_file_content) as test_file:
+
+        async with Client(transport=sample_transport,) as session:
+
+            query = gql(file_upload_mutation_1)
+
+            file_path = test_file.filename
+
+            async def file_sender(file_name=None):
+                async with aiofiles.open(file_name, "rb") as f:
+                    chunk = await f.read(64 * 1024)
+                    while chunk:
+                        yield chunk
+                        chunk = await f.read(64 * 1024)
+
+            params = {"file": file_sender(file_path), "other_var": 42}
+
+            # Execute query asynchronously
+            result = await session.execute(
+                query, variable_values=params, upload_files=True
+            )
+
+            success = result["success"]
+
+            assert success
+
+
 file_upload_mutation_2 = """
     mutation($file1: Upload!, $file2: Upload!) {
       uploadFile(input:{file1:$file, file2:$file}) {

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -641,7 +641,7 @@ async def test_aiohttp_async_generator_upload(event_loop, aiohttp_server):
 
             file_path = test_file.filename
 
-            async def file_sender(file_name=None):
+            async def file_sender(file_name):
                 async with aiofiles.open(file_name, "rb") as f:
                     chunk = await f.read(64 * 1024)
                     while chunk:


### PR DESCRIPTION
When receiving a large file from a request(use aiohttp) and then transferring it through Graphql, it was necessary to read the data from the request and we can load it into RAM or save it to disk (to avoid memory leaks), and only after that it was possible to transfer it through graphql(use io.BytesIO or open()). In this branch, I tried to solved this problem.