### PR TITLE
Handle keep-alive behavior to close the connection

### DIFF
--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 import json
 import logging
 from ssl import SSLContext
@@ -94,6 +95,7 @@ class WebsocketsTransport(AsyncTransport):
         connect_timeout: int = 10,
         close_timeout: int = 10,
         ack_timeout: int = 10,
+        keep_alive_timeout: int = 0,
         connect_args: Dict[str, Any] = {},
     ) -> None:
         """Initialize the transport with the given parameters.
@@ -107,6 +109,7 @@ class WebsocketsTransport(AsyncTransport):
         :param close_timeout: Timeout in seconds for the close.
         :param ack_timeout: Timeout in seconds to wait for the connection_ack message
             from the server.
+        :param keep_alive_timeout: Timeout in seconds to receive a sign of liveness from the server.
         :param connect_args: Other parameters forwarded to websockets.connect
         """
         self.url: str = url
@@ -117,6 +120,7 @@ class WebsocketsTransport(AsyncTransport):
         self.connect_timeout: int = connect_timeout
         self.close_timeout: int = close_timeout
         self.ack_timeout: int = ack_timeout
+        self.keep_alive_timeout: int = keep_alive_timeout
 
         self.connect_args = connect_args
 
@@ -125,6 +129,7 @@ class WebsocketsTransport(AsyncTransport):
         self.listeners: Dict[int, ListenerQueue] = {}
 
         self.receive_data_task: Optional[asyncio.Future] = None
+        self.check_keep_alive_task: Optional[asyncio.Future] = None
         self.close_task: Optional[asyncio.Future] = None
 
         # We need to set an event loop here if there is none
@@ -141,6 +146,10 @@ class WebsocketsTransport(AsyncTransport):
         self._no_more_listeners: asyncio.Event = asyncio.Event()
         self._no_more_listeners.set()
 
+        self._next_keep_alive_message: asyncio.Event = asyncio.Event()
+        self._next_keep_alive_message.set()
+
+        self._keep_alive_not_received: bool = False
         self._connecting: bool = False
 
         self.close_exception: Optional[Exception] = None
@@ -313,8 +322,9 @@ class WebsocketsTransport(AsyncTransport):
                         )
 
             elif answer_type == "ka":
-                # KeepAlive message
-                pass
+                # Keep-alive message
+                if self.check_keep_alive_task is not None:
+                    self._next_keep_alive_message.set()
             elif answer_type == "connection_ack":
                 pass
             elif answer_type == "connection_error":
@@ -330,8 +340,31 @@ class WebsocketsTransport(AsyncTransport):
 
         return answer_type, answer_id, execution_result
 
-    async def _receive_data_loop(self) -> None:
+    async def _check_ws_liveness(self) -> None:
+        """Coroutine which will periodically check the liveness of the connection through keep-alive messages
+        """
 
+        try:
+            while True:
+                await asyncio.wait_for(self._next_keep_alive_message.wait(), self.keep_alive_timeout)
+
+                # Reset for the next iteration
+                self._next_keep_alive_message.clear()
+        except asyncio.TimeoutError:
+            # No keep-alive message in the appriopriate interval, make the receive loop stopping properly by knowing from where it comes
+            self._keep_alive_not_received = True
+
+            if self.receive_data_task is not None:
+                # More info: https://stackoverflow.com/a/43810272/1113207
+                self.receive_data_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self.receive_data_task
+
+        except asyncio.CancelledError:
+            # The client is probably closing, handle it properly
+            pass
+
+    async def _receive_data_loop(self) -> None:
         try:
             while True:
 
@@ -372,6 +405,16 @@ class WebsocketsTransport(AsyncTransport):
 
                 await self._handle_answer(answer_type, answer_id, execution_result)
 
+        except Exception as err:
+            if self._keep_alive_not_received:
+                # No keep-alive message in the appriopriate interval, close with error
+                # while trying to notify the server of a proper close (in case the keep-alive interval of the client or server was not aligned the connection still remains)
+                e = TransportServerError(
+                    "No keep-alive message has been received within the expected interval ('keep_alive_timeout' parameter)")
+
+                await self._fail(e, clean_close=True)
+            else:
+                raise err
         finally:
             log.debug("Exiting _receive_data_loop()")
 
@@ -534,6 +577,7 @@ class WebsocketsTransport(AsyncTransport):
 
             self.next_query_id = 1
             self.close_exception = None
+            self._keep_alive_not_received = False
             self._wait_closed.clear()
 
             # Send the init message and wait for the ack from the server
@@ -546,6 +590,11 @@ class WebsocketsTransport(AsyncTransport):
             except (TransportProtocolError, asyncio.TimeoutError) as e:
                 await self._fail(e, clean_close=False)
                 raise e
+
+            # If specified, create a task to check liveness of the connection (through keep-alive messages)
+            if self.keep_alive_timeout > 0:
+                self.check_keep_alive_task = asyncio.ensure_future(
+                    self._check_ws_liveness())
 
             # Create a task to listen to the incoming websocket messages
             self.receive_data_task = asyncio.ensure_future(self._receive_data_loop())
@@ -595,6 +644,13 @@ class WebsocketsTransport(AsyncTransport):
             # We should always have an active websocket connection here
             assert self.websocket is not None
 
+            # Properly shut down liveness checker if enabled
+            if self.check_keep_alive_task is not None:
+                # More info: https://stackoverflow.com/a/43810272/1113207
+                self.check_keep_alive_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self.check_keep_alive_task
+
             # Saving exception to raise it later if trying to use the transport
             # after it has already closed.
             self.close_exception = e
@@ -627,6 +683,7 @@ class WebsocketsTransport(AsyncTransport):
 
             self.websocket = None
             self.close_task = None
+            self.check_keep_alive_task = None
 
             self._wait_closed.set()
 

--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -1,7 +1,7 @@
 import asyncio
-from contextlib import suppress
 import json
 import logging
+from contextlib import suppress
 from ssl import SSLContext
 from typing import Any, AsyncGenerator, Dict, Optional, Tuple, Union, cast
 
@@ -346,7 +346,9 @@ class WebsocketsTransport(AsyncTransport):
 
         try:
             while True:
-                await asyncio.wait_for(self._next_keep_alive_message.wait(), self.keep_alive_timeout)
+                await asyncio.wait_for(
+                    self._next_keep_alive_message.wait(), self.keep_alive_timeout
+                )
 
                 # Reset for the next iteration
                 self._next_keep_alive_message.clear()
@@ -409,10 +411,12 @@ class WebsocketsTransport(AsyncTransport):
             if self._keep_alive_not_received:
                 # No keep-alive message in the appriopriate interval, close with error
                 # while trying to notify the server of a proper close (in case the keep-alive interval of the client or server was not aligned the connection still remains)
-                e = TransportServerError(
-                    "No keep-alive message has been received within the expected interval ('keep_alive_timeout' parameter)")
-
-                await self._fail(e, clean_close=True)
+                await self._fail(
+                    TransportServerError(
+                        "No keep-alive message has been received within the expected interval ('keep_alive_timeout' parameter)"
+                    ),
+                    clean_close=True,
+                )
             else:
                 raise err
         finally:
@@ -594,7 +598,8 @@ class WebsocketsTransport(AsyncTransport):
             # If specified, create a task to check liveness of the connection (through keep-alive messages)
             if self.keep_alive_timeout > 0:
                 self.check_keep_alive_task = asyncio.ensure_future(
-                    self._check_ws_liveness())
+                    self._check_ws_liveness()
+                )
 
             # Create a task to listen to the incoming websocket messages
             self.receive_data_task = asyncio.ensure_future(self._receive_data_loop())

--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -109,7 +109,8 @@ class WebsocketsTransport(AsyncTransport):
         :param close_timeout: Timeout in seconds for the close.
         :param ack_timeout: Timeout in seconds to wait for the connection_ack message
             from the server.
-        :param keep_alive_timeout: Timeout in seconds to receive a sign of liveness from the server.
+        :param keep_alive_timeout: Timeout in seconds to receive a sign of liveness
+            from the server.
         :param connect_args: Other parameters forwarded to websockets.connect
         """
         self.url: str = url
@@ -341,7 +342,8 @@ class WebsocketsTransport(AsyncTransport):
         return answer_type, answer_id, execution_result
 
     async def _check_ws_liveness(self) -> None:
-        """Coroutine which will periodically check the liveness of the connection through keep-alive messages
+        """Coroutine which will periodically check the liveness of the connection
+        through keep-alive messages
         """
 
         try:
@@ -353,7 +355,8 @@ class WebsocketsTransport(AsyncTransport):
                 # Reset for the next iteration
                 self._next_keep_alive_message.clear()
         except asyncio.TimeoutError:
-            # No keep-alive message in the appriopriate interval, make the receive loop stopping properly by knowing from where it comes
+            # No keep-alive message in the appriopriate interval,
+            # make the receive loop stopping properly by knowing from where it comes
             self._keep_alive_not_received = True
 
             if self.receive_data_task is not None:
@@ -410,10 +413,13 @@ class WebsocketsTransport(AsyncTransport):
         except Exception as err:
             if self._keep_alive_not_received:
                 # No keep-alive message in the appriopriate interval, close with error
-                # while trying to notify the server of a proper close (in case the keep-alive interval of the client or server was not aligned the connection still remains)
+                # while trying to notify the server of a proper close (in case
+                # the keep-alive interval of the client or server was not aligned
+                # the connection still remains)
                 await self._fail(
                     TransportServerError(
-                        "No keep-alive message has been received within the expected interval ('keep_alive_timeout' parameter)"
+                        "No keep-alive message has been received within "
+                        "the expected interval ('keep_alive_timeout' parameter)"
                     ),
                     clean_close=True,
                 )
@@ -595,7 +601,8 @@ class WebsocketsTransport(AsyncTransport):
                 await self._fail(e, clean_close=False)
                 raise e
 
-            # If specified, create a task to check liveness of the connection (through keep-alive messages)
+            # If specified, create a task to check liveness of the connection
+            # through keep-alive messages
             if self.keep_alive_timeout > 0:
                 self.check_keep_alive_task = asyncio.ensure_future(
                     self._check_ws_liveness()

--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -439,8 +439,6 @@ async def test_websocket_subscription_with_keepalive_with_timeout_nok(
 
         assert "No keep-alive message has been received" in str(exc_info.value)
 
-        assert count == 9
-
 
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])


### PR DESCRIPTION
Hi @leszekhanusz ,

Here the PR for the keep-alive behavior https://github.com/graphql-python/gql/issues/200, tested with real servers sending `ka` messages.

I read the CONTRIBUTING.md but struggled with the `make check`, I installed them but it changes all my files (including yours) like if parameters were not taken in account. Moreover `isort` tells me some lines are >88chars but **no** other tools automatically adjust them (I thought it would?). I guess I missed something... I did the venv creation + `make dev-setup`.

_Tip for others: in my app code I forgot to `await ws_transport.wait_close()` making the reconnection after a keep-alive failure failing because some stuff were not clean in the meantime (`asyncio` giving the priority to other tasks including mines trying a reconnect)._

Tell me if I need to adjust something :)