### PR TITLE
Async generators always ensure that inner generator are closed properly

### DIFF
--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -163,7 +163,8 @@ async def test_websocket_subscription_break(
 
         if count <= 5:
             # Note: the following line is only necessary for pypy3 v3.6.1
-            await session._generator.aclose()
+            if sys.version_info < (3, 7):
+                await session._generator.aclose()
             break
 
         count -= 1


### PR DESCRIPTION
Previously, when using `break` inside `async for session.susbcribe(...`, the inner generator will not close properly because of the `_generator` variable reference which is still available from the session.

This PR will try to always ensure that if an async generator closes,  the inner generators will also close.

This should ensure that a `subscribe` will close directly after a `break` if you don't keep any references of the generator