### PR TITLE
feat(transport/requests): RequestsHTTPTransport execute func add extra_args param

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -103,6 +103,7 @@ class RequestsHTTPTransport(Transport):
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         timeout: Optional[int] = None,
+        extra_args: Dict[str, Any] = None,
     ) -> ExecutionResult:
         """Execute GraphQL query.
 
@@ -114,6 +115,7 @@ class RequestsHTTPTransport(Transport):
         :param operation_name: Name of the operation that shall be executed.
             Only required in multi-operation documents (Default: None).
         :param timeout: Specifies a default timeout for requests (Default: None).
+        :param extra_args: additional arguments to send to the http post method
         :return: The result of execution.
             `data` is the result of executing the query, `errors` is null
             if no errors occurred, and is a non-empty array if an error occurred.
@@ -145,7 +147,8 @@ class RequestsHTTPTransport(Transport):
 
         # Pass kwargs to requests post method
         post_args.update(self.kwargs)
-
+        if extra_args:
+            post_args.update(extra_args)
         # Using the created session to perform requests
         response = self.session.request(
             self.method, self.url, **post_args  # type: ignore

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -115,7 +115,7 @@ class RequestsHTTPTransport(Transport):
         :param operation_name: Name of the operation that shall be executed.
             Only required in multi-operation documents (Default: None).
         :param timeout: Specifies a default timeout for requests (Default: None).
-        :param extra_args: additional arguments to send to the http post method
+        :param extra_args: additional arguments to send to the requests post method
         :return: The result of execution.
             `data` is the result of executing the query, `errors` is null
             if no errors occurred, and is a non-empty array if an error occurred.
@@ -147,8 +147,11 @@ class RequestsHTTPTransport(Transport):
 
         # Pass kwargs to requests post method
         post_args.update(self.kwargs)
+
+        # Pass post_args to requests post method
         if extra_args:
             post_args.update(extra_args)
+
         # Using the created session to perform requests
         response = self.session.request(
             self.method, self.url, **post_args  # type: ignore

--- a/tests/fixtures/vcr_cassettes/queries.yaml
+++ b/tests/fixtures/vcr_cassettes/queries.yaml
@@ -338,4 +338,48 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: '{"query": "query Planet($id: ID!) {\n  planet(id: $id) {\n    id\n    name\n  }\n}\n"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - csrftoken=kAyQyUjNOGXZfkKUtWtvUROaFfDe2GBiV7yIRsqs3r2j9aYchRDXTNo3lHp72h5k;
+        csrftoken=kAyQyUjNOGXZfkKUtWtvUROaFfDe2GBiV7yIRsqs3r2j9aYchRDXTNo3lHp72h5k
+      User-Agent:
+      - python-requests/2.26.0
+      authorization:
+      - xxx-123
+    method: POST
+    uri: http://127.0.0.1:8000/graphql
+  response:
+    body:
+      string: '{"data":{"planet":{"id":"UGxhbmV0OjEx","name":"Geonosis"}}}'
+    headers:
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 06 Nov 2020 11:30:21 GMT
+      Server:
+      - WSGIServer/0.1 Python/2.7.18
+      Set-Cookie:
+      - csrftoken=kAyQyUjNOGXZfkKUtWtvUROaFfDe2GBiV7yIRsqs3r2j9aYchRDXTNo3lHp72h5k;
+        expires=Fri, 05-Nov-2021 11:30:21 GMT; Max-Age=31449600; Path=/
+      Vary:
+      - Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -123,3 +123,22 @@ def test_named_query(client):
     with use_cassette("queries"):
         result = client.execute(query, operation_name="Planet2")
     assert result == expected
+
+
+def test_header_query(client):
+    query = gql(
+        """
+        query Planet($id: ID!) {
+          planet(id: $id) {
+            id
+            name
+          }
+        }
+        """
+    )
+    expected = {"planet": {"id": "UGxhbmV0OjEx", "name": "Geonosis"}}
+    with use_cassette("queries"):
+        result = client.execute(
+            query, extra_args={"headers": {"authorization": "xxx-123"}}
+        )
+    assert result == expected


### PR DESCRIPTION
RequestsHTTPTransport execute function support input headers.
like this
```
result = client.execute(
    query, extra_args={"headers": {"authorization": "xxx-123"}}
)
```