### PR TITLE
RequestsHTTPTransport allow retries for our POST requests

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -95,6 +95,7 @@ class RequestsHTTPTransport(Transport):
                         total=self.retries,
                         backoff_factor=0.1,
                         status_forcelist=[500, 502, 503, 504],
+                        allowed_methods=None,
                     )
                 )
                 for prefix in "http://", "https://":

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,9 @@ install_aiohttp_requires = [
 ]
 
 install_requests_requires = [
-    "requests>=2.23,<3",
+    "requests>=2.26,<3",
     "requests_toolbelt>=0.9.1,<1",
+    "urllib3>=1.26",
 ]
 
 install_websockets_requires = [


### PR DESCRIPTION
Fixes issue #222

Needs an update of the `requests` and `urllib3` dependency.