### PR TITLE
Feature get_execution_result argument of execute and subscribe

### DIFF
--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -1,0 +1,36 @@
+.. _extensions:
+
+Extensions
+----------
+
+When you execute (or subscribe) GraphQL requests, the server will send
+responses which may have 3 fields:
+
+- data: the serialized response from the backend
+- errors: a list of potential errors
+- extensions: an optional field for additional data
+
+If there are errors in the response, then the
+:code:`execute` or :code:`subscribe` methods will
+raise a :code:`TransportQueryError`.
+
+If no errors are present, then only the data from the response is returned by default.
+
+.. code-block:: python
+
+    result = client.execute(query)
+    # result is here the content of the data field
+
+If you need to receive the extensions data too, then you can run the
+:code:`execute` or :code:`subscribe` methods with :code:`get_execution_result=True`.
+
+In that case, the full execution result is returned and you can have access
+to the extensions field
+
+.. code-block:: python
+
+    result = client.execute(query, get_execution_result=True)
+    # result is here an ExecutionResult instance
+
+    # result.data is the content of the data field
+    # result.extensions is the content of the extensions field

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -11,3 +11,4 @@ Usage
    headers
    file_upload
    custom_scalars_and_enums
+   extensions

--- a/gql/transport/exceptions.py
+++ b/gql/transport/exceptions.py
@@ -35,11 +35,13 @@ class TransportQueryError(Exception):
         query_id: Optional[int] = None,
         errors: Optional[List[Any]] = None,
         data: Optional[Any] = None,
+        extensions: Optional[Any] = None,
     ):
         super().__init__(msg)
         self.query_id = query_id
         self.errors = errors
         self.data = data
+        self.extensions = extensions
 
 
 class TransportClosed(TransportError):

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1070,6 +1070,6 @@ async def test_aiohttp_query_with_extensions(event_loop, aiohttp_server):
 
         query = gql(query1_str)
 
-        execution_result = await session._execute(query)
+        execution_result = await session.execute(query, get_execution_result=True)
 
         assert execution_result.extensions["key1"] == "val1"

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -328,7 +328,7 @@ async def test_requests_query_with_extensions(
 
             query = gql(query1_str)
 
-            execution_result = session._execute(query)
+            execution_result = session.execute(query, get_execution_result=True)
 
             assert execution_result.extensions["key1"] == "val1"
 

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -596,6 +596,6 @@ async def test_websocket_simple_query_with_extensions(
 
     query = gql(query_str)
 
-    execution_result = await session._execute(query)
+    execution_result = await session.execute(query, get_execution_result=True)
 
     assert execution_result.extensions["key1"] == "val1"


### PR DESCRIPTION
Add new argument `get_execution_result` to `execute` and `subscribe` methods.

If `get_execution_result` is True, then the full `ExecutionResult` (with the extension field) is returned to the user.