### PR TITLE
Invert the order of proposed subprotocols apollo and graphql-ws

### DIFF
--- a/gql/transport/websockets.py
+++ b/gql/transport/websockets.py
@@ -203,8 +203,8 @@ class WebsocketsTransport(AsyncTransport):
         self.close_exception: Optional[Exception] = None
 
         self.supported_subprotocols = [
-            self.GRAPHQLWS_SUBPROTOCOL,
             self.APOLLO_SUBPROTOCOL,
+            self.GRAPHQLWS_SUBPROTOCOL,
         ]
 
     async def _send(self, message: str) -> None:


### PR DESCRIPTION
Some websockets backend are incorrectly returning the first proposed protocol from the http_headers.

In that case, an error like this might be received:

```
websockets.exceptions.ConnectionClosedError: code = 1002 (protocol error), no reason
```

This PR should fix `make all_tests` with countries.trevorblades.com