### PR TITLE
⬆️ Expand aiohttp version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.7.1,<3.8.0",
+    "aiohttp>=3.7.1,<3.9.0",
 ]
 
 install_requests_requires = [


### PR DESCRIPTION
A new version of aiohttp has been released, with [an important fix preventing header injection](https://github.com/aio-libs/aiohttp/issues/4818). I looked through the aiohttp changelog and wasn't able to find any breaking changes, so I believe it should be safe to use with gql.

All of the offline tests passed locally with aiohttp 3.8.1 installed 🙂 

Thanks for your work on gql! 😄 