### PR TITLE
Enable mypy to discover type hints as specified in PEP 561

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,8 @@ include tox.ini
 
 include scripts/gql-cli
 
+include gql/py.typed
+
 recursive-include tests *.py *.graphql *.cnf *.yaml *.pem
 recursive-include docs *.txt *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 recursive-include docs/code_examples *.py

--- a/gql/py.typed
+++ b/gql/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The gql package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,8 @@ setup(
     ],
     keywords="api graphql protocol rest relay gql client",
     packages=find_packages(include=["gql*"]),
+    # PEP-561: https://www.python.org/dev/peps/pep-0561/
+    package_data={"gql": ["py.typed"]},
     install_requires=install_requires,
     tests_require=install_all_requires + tests_requires,
     extras_require={


### PR DESCRIPTION
This should enable mypy to discover type hints for the users of this library.


