### PR TITLE
Add skip and include directive in introspection schema

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -7,7 +7,6 @@ from graphql import (
     ExecutionResult,
     GraphQLSchema,
     build_ast_schema,
-    build_client_schema,
     get_introspection_query,
     parse,
     validate,
@@ -17,6 +16,7 @@ from .transport.async_transport import AsyncTransport
 from .transport.exceptions import TransportQueryError
 from .transport.local_schema import LocalSchemaTransport
 from .transport.transport import Transport
+from .utilities import build_client_schema
 from .utilities import parse_result as parse_result_fn
 from .utilities import serialize_variable_values
 

--- a/gql/utilities/__init__.py
+++ b/gql/utilities/__init__.py
@@ -1,3 +1,4 @@
+from .build_client_schema import build_client_schema
 from .get_introspection_query_ast import get_introspection_query_ast
 from .parse_result import parse_result
 from .serialize_variable_values import serialize_value, serialize_variable_values
@@ -5,6 +6,7 @@ from .update_schema_enum import update_schema_enum
 from .update_schema_scalars import update_schema_scalar, update_schema_scalars
 
 __all__ = [
+    "build_client_schema",
     "parse_result",
     "get_introspection_query_ast",
     "serialize_variable_values",

--- a/gql/utilities/build_client_schema.py
+++ b/gql/utilities/build_client_schema.py
@@ -1,0 +1,73 @@
+from typing import Dict
+
+from graphql import GraphQLSchema
+from graphql import build_client_schema as build_client_schema_orig
+
+__all__ = ["build_client_schema"]
+
+
+INCLUDE_DIRECTIVE_JSON = {
+    "name": "include",
+    "description": (
+        "Directs the executor to include this field or fragment "
+        "only when the `if` argument is true."
+    ),
+    "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+    "args": [
+        {
+            "name": "if",
+            "description": "Included when true.",
+            "type": {
+                "kind": "NON_NULL",
+                "name": "None",
+                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": "None"},
+            },
+            "defaultValue": "None",
+        }
+    ],
+}
+
+SKIP_DIRECTIVE_JSON = {
+    "name": "skip",
+    "description": (
+        "Directs the executor to skip this field or fragment "
+        "when the `if` argument is true."
+    ),
+    "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+    "args": [
+        {
+            "name": "if",
+            "description": "Skipped when true.",
+            "type": {
+                "kind": "NON_NULL",
+                "name": "None",
+                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": "None"},
+            },
+            "defaultValue": "None",
+        }
+    ],
+}
+
+
+def build_client_schema(introspection: Dict) -> GraphQLSchema:
+    """This is an alternative to the graphql-core function
+    :code:`build_client_schema` but with default include and skip directives
+    added to the schema to fix
+    `issue #278 <https://github.com/graphql-python/gql/issues/278>`_
+
+    .. warning::
+        This function will be removed once the issue
+        `graphql-js#3419 <https://github.com/graphql/graphql-js/issues/3419>`_
+        has been fixed and ported to graphql-core so don't use it
+        outside gql.
+    """
+
+    directives = introspection["__schema"]["directives"]
+
+    if not any(directive["name"] == "skip" for directive in directives):
+        directives.append(SKIP_DIRECTIVE_JSON)
+
+    if not any(directive["name"] == "include" for directive in directives):
+        directives.append(INCLUDE_DIRECTIVE_JSON)
+
+    return build_client_schema_orig(introspection, assume_valid=False)

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -242,7 +242,6 @@ def test_skip_directive(client):
           }
         }
     """
-    print(StarWarsIntrospection)
     assert not validation_errors(client, query)
 
 

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -61,11 +61,21 @@ def introspection_schema():
 
 
 @pytest.fixture
-def introspection_schema_no_directives():
+def introspection_schema_empty_directives():
     introspection = StarWarsIntrospection
 
     # Simulate an empty dictionary for directives
     introspection["__schema"]["directives"] = []
+
+    return Client(introspection=introspection)
+
+
+@pytest.fixture
+def introspection_schema_no_directives():
+    introspection = StarWarsIntrospection
+
+    # Simulate no directives key
+    del introspection["__schema"]["directives"]
 
     return Client(introspection=introspection)
 
@@ -75,6 +85,7 @@ def introspection_schema_no_directives():
         "local_schema",
         "typedef_schema",
         "introspection_schema",
+        "introspection_schema_empty_directives",
         "introspection_schema_no_directives",
     ]
 )
@@ -233,3 +244,16 @@ def test_skip_directive(client):
     """
     print(StarWarsIntrospection)
     assert not validation_errors(client, query)
+
+
+def test_build_client_schema_invalid_introspection():
+    from gql.utilities import build_client_schema
+
+    with pytest.raises(TypeError) as exc_info:
+        build_client_schema("blah")
+
+    assert (
+        "Invalid or incomplete introspection result. Ensure that you are passing the "
+        "'data' attribute of an introspection response and no 'errors' were returned "
+        "alongside: 'blah'."
+    ) in str(exc_info.value)


### PR DESCRIPTION
Workaround for issue #278 until [graphql-js#3419](https://github.com/graphql/graphql-js/issues/3419) has been fixed.

Always adding `skip` and `include` default directives in schema built from introspection.