### PR TITLE
Update type hint to align with docs and usage.

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -40,7 +40,7 @@ class RequestsHTTPTransport(Transport):
         auth: Optional[AuthBase] = None,
         use_json: bool = True,
         timeout: Optional[int] = None,
-        verify: bool = True,
+        verify: Union[bool, str] = True,
         retries: int = 0,
         method: str = "POST",
         **kwargs: Any,


### PR DESCRIPTION
### Description

Updated the type hint for the `verify` kwarg of `RequestsHTTPTransport` to align with both the class documentation and intended usage of `verify`.

### Testing

All tests pass. I'm happy to write a test that verifies both a `bool` and a `str` can be provided as an arg to `verify` but that seemed a bit overkill to me as MyPy should cover such usages in application code.