### PR TITLE
Saving http response headers reference in transports

### DIFF
--- a/docs/usage/headers.rst
+++ b/docs/usage/headers.rst
@@ -6,3 +6,5 @@ If you want to add additional http headers for your connection, you can specify 
 .. code-block:: python
 
     transport = AIOHTTPTransport(url='YOUR_URL', headers={'Authorization': 'token'})
+
+After the connection, the latest response headers can be found in :code:`transport.response_headers`

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -81,7 +81,7 @@ class RequestsHTTPTransport(Transport):
 
         self.session = None
 
-        self.response_header = None
+        self.response_headers = None
 
     def connect(self):
 
@@ -219,7 +219,7 @@ class RequestsHTTPTransport(Transport):
         response = self.session.request(
             self.method, self.url, **post_args  # type: ignore
         )
-        self.response_header = response.headers
+        self.response_headers = response.headers
 
         def raise_response_error(resp: requests.Response, reason: str):
             # We raise a TransportServerError if the status code is 400 or higher

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -81,6 +81,8 @@ class RequestsHTTPTransport(Transport):
 
         self.session = None
 
+        self.response_header = None
+
     def connect(self):
 
         if self.session is None:
@@ -217,6 +219,7 @@ class RequestsHTTPTransport(Transport):
         response = self.session.request(
             self.method, self.url, **post_args  # type: ignore
         )
+        self.response_header = response.headers
 
         def raise_response_error(resp: requests.Response, reason: str):
             # We raise a TransportServerError if the status code is 400 or higher

--- a/gql/transport/websockets_base.py
+++ b/gql/transport/websockets_base.py
@@ -9,7 +9,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union, cast
 import websockets
 from graphql import DocumentNode, ExecutionResult
 from websockets.client import WebSocketClientProtocol
-from websockets.datastructures import HeadersLike
+from websockets.datastructures import Headers, HeadersLike
 from websockets.exceptions import ConnectionClosed
 from websockets.typing import Data, Subprotocol
 
@@ -168,6 +168,8 @@ class WebsocketsTransportBase(AsyncTransport):
 
         # The list of supported subprotocols should be defined in the subclass
         self.supported_subprotocols: List[Subprotocol] = []
+
+        self.response_headers: Optional[Headers] = None
 
     async def _initialize(self):
         """Hook to send the initialization messages after the connection
@@ -494,6 +496,8 @@ class WebsocketsTransportBase(AsyncTransport):
                 self._connecting = False
 
             self.websocket = cast(WebSocketClientProtocol, self.websocket)
+
+            self.response_headers = self.websocket.response_headers
 
             # Run the after_connect hook of the subclass
             await self._after_connect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,9 @@ class WebSocketServer:
             self.testcert, ssl_context = get_localhost_ssl_context()
             extra_serve_args["ssl"] = ssl_context
 
+        # Adding dummy response headers
+        extra_serve_args["extra_headers"] = {"dummy": "test1234"}
+
         # Start a server with a random open port
         self.start_server = websockets.server.serve(
             handler, "127.0.0.1", 0, **extra_serve_args


### PR DESCRIPTION
The purpose of this Pull Request is to add a request response header attribute. Accessing response header can be useful for retrieving rate limiting information from some APIs.