### PR TITLE
Close transport when fetching the schema failed

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -275,6 +275,9 @@ class Client:
             if self.fetch_schema_from_transport and not self.schema:
                 await self.session.fetch_schema()
         except Exception:
+            # we don't know what type of exception is thrown here because it
+            # depends on the underlying transport; we just make sure that the
+            # transport is closed and re-raise the exception
             await self.transport.close()
             raise
 
@@ -301,6 +304,9 @@ class Client:
             if self.fetch_schema_from_transport and not self.schema:
                 self.session.fetch_schema()
         except Exception:
+            # we don't know what type of exception is thrown here because it
+            # depends on the underlying transport; we just make sure that the
+            # transport is closed and re-raise the exception
             self.transport.close()
             raise
 

--- a/gql/client.py
+++ b/gql/client.py
@@ -271,8 +271,12 @@ class Client:
             self.session = AsyncClientSession(client=self)
 
         # Get schema from transport if needed
-        if self.fetch_schema_from_transport and not self.schema:
-            await self.session.fetch_schema()
+        try:
+            if self.fetch_schema_from_transport and not self.schema:
+                await self.session.fetch_schema()
+        except Exception:
+            await self.transport.close()
+            raise
 
         return self.session
 
@@ -293,8 +297,12 @@ class Client:
             self.session = SyncClientSession(client=self)
 
         # Get schema from transport if needed
-        if self.fetch_schema_from_transport and not self.schema:
-            self.session.fetch_schema()
+        try:
+            if self.fetch_schema_from_transport and not self.schema:
+                self.session.fetch_schema()
+        except Exception:
+            await self.transport.close()
+            raise
 
         return self.session
 

--- a/gql/client.py
+++ b/gql/client.py
@@ -301,7 +301,7 @@ class Client:
             if self.fetch_schema_from_transport and not self.schema:
                 self.session.fetch_schema()
         except Exception:
-            await self.transport.close()
+            self.transport.close()
             raise
 
         return self.session

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -200,3 +200,47 @@ def test_gql():
     client = Client(schema=schema)
     result = client.execute(query)
     assert result["user"] is None
+
+
+def test_sync_transport_close_on_schema_retrieval_failure():
+    """
+    Ensure that the transport session is closed if an error occurs when
+    entering the context manager (e.g., because schema retrieval fails)
+    """
+
+    from gql.transport.requests import RequestsHTTPTransport
+    transport = RequestsHTTPTransport(url="http://localhost/")
+    client = Client(transport=transport, fetch_schema_from_transport=True)
+
+    try:
+        with client as session:
+            pass
+    except Exception:
+        # we don't care what exception is thrown, we just want to check if the
+        # transport is closed afterwards
+        pass
+
+    assert client.transport.session is None
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_async_transport_close_on_schema_retrieval_failure():
+    """
+    Ensure that the transport session is closed if an error occurs when
+    entering the context manager (e.g., because schema retrieval fails)
+    """
+
+    from gql.transport.aiohttp import AIOHTTPTransport
+    transport = AIOHTTPTransport(url="http://localhost/")
+    client = Client(transport=transport, fetch_schema_from_transport=True)
+
+    try:
+        async with client as session:
+            pass
+    except Exception:
+        # we don't care what exception is thrown, we just want to check if the
+        # transport is closed afterwards
+        pass
+
+    assert client.transport.session is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -202,6 +202,7 @@ def test_gql():
     assert result["user"] is None
 
 
+@pytest.mark.requests
 def test_sync_transport_close_on_schema_retrieval_failure():
     """
     Ensure that the transport session is closed if an error occurs when
@@ -209,11 +210,12 @@ def test_sync_transport_close_on_schema_retrieval_failure():
     """
 
     from gql.transport.requests import RequestsHTTPTransport
+
     transport = RequestsHTTPTransport(url="http://localhost/")
     client = Client(transport=transport, fetch_schema_from_transport=True)
 
     try:
-        with client as session:
+        with client:
             pass
     except Exception:
         # we don't care what exception is thrown, we just want to check if the
@@ -232,11 +234,12 @@ async def test_async_transport_close_on_schema_retrieval_failure():
     """
 
     from gql.transport.aiohttp import AIOHTTPTransport
+
     transport = AIOHTTPTransport(url="http://localhost/")
     client = Client(transport=transport, fetch_schema_from_transport=True)
 
     try:
-        async with client as session:
+        async with client:
             pass
     except Exception:
         # we don't care what exception is thrown, we just want to check if the


### PR DESCRIPTION
Fetching the schema from the transport might fail with an exception. This Commit
ensures that the transport is closed in such a case and the client object can be
used to open a new session.