### PR TITLE
Represent serialized floats to approximately python float precision

### DIFF
--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -106,10 +106,13 @@ def ast_from_serialized_value_untyped(serialized: Any) -> Optional[ValueNode]:
         return BooleanValueNode(value=serialized)
 
     if isinstance(serialized, int):
-        return IntValueNode(value=f"{serialized:d}")
+        return IntValueNode(value=str(serialized))
 
     if isinstance(serialized, float) and isfinite(serialized):
-        return FloatValueNode(value=f"{serialized:g}")
+        value = str(serialized)
+        if value.endswith(".0"):
+            value = value[:-2]
+        return FloatValueNode(value=value)
 
     if isinstance(serialized, str):
         return StringValueNode(value=serialized)

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -1,6 +1,8 @@
 import pytest
 from graphql import (
+    FloatValueNode,
     GraphQLError,
+    GraphQLFloat,
     GraphQLID,
     GraphQLInt,
     GraphQLList,
@@ -85,6 +87,20 @@ def test_ast_from_value_with_non_null_type_and_none():
         ast_from_value(None, typ)
 
     assert "Received Null value for a Non-Null type Int." in str(exc_info.value)
+
+
+def test_ast_from_value_float_precision():
+
+    # Checking precision of float serialization
+    # See https://github.com/graphql-python/graphql-core/pull/164
+
+    assert ast_from_value(123456789.01234567, GraphQLFloat) == FloatValueNode(
+        value="123456789.01234567"
+    )
+
+    assert ast_from_value(1.1, GraphQLFloat) == FloatValueNode(value="1.1")
+
+    assert ast_from_value(123.0, GraphQLFloat) == FloatValueNode(value="123")
 
 
 def test_ast_from_serialized_value_untyped_typeerror():


### PR DESCRIPTION
Reproduce the changes made in [graphql-core PR #164](https://github.com/graphql-python/graphql-core/pull/164) so that the copy-pasted `ast_from_value` function in the dsl module stays in sync with the one in graphql-core.