### PR TITLE
Check for errors during client.fetch_schema()

### DIFF
--- a/docs/advanced/error_handling.rst
+++ b/docs/advanced/error_handling.rst
@@ -41,6 +41,11 @@ Here are the possible Transport Errors:
   The message of the exception contains the first error returned by the backend.
   All the errors messages are available in the exception :code:`errors` attribute.
 
+  If the error message begins with :code:`Error while fetching schema:`, it means
+  that gql was not able to get the schema from the backend.
+  If you don't need the schema, you can try to create the client with
+  :code:`fetch_schema_from_transport=False`
+
 - :class:`TransportClosed <gql.transport.exceptions.TransportClosed>`:
   This exception is generated when the client is trying to use the transport
   while the transport was previously closed.

--- a/gql/client.py
+++ b/gql/client.py
@@ -802,6 +802,15 @@ class SyncClientSession:
         Don't use this function and instead set the fetch_schema_from_transport
         attribute to True"""
         execution_result = self.transport.execute(parse(get_introspection_query()))
+
+        if execution_result.errors:
+            raise TransportQueryError(
+                str(execution_result.errors[0]),
+                errors=execution_result.errors,
+                data=execution_result.data,
+                extensions=execution_result.extensions,
+            )
+
         self.client.introspection = execution_result.data
         self.client.schema = build_client_schema(self.client.introspection)
 
@@ -1175,6 +1184,15 @@ class AsyncClientSession:
         execution_result = await self.transport.execute(
             parse(get_introspection_query())
         )
+
+        if execution_result.errors:
+            raise TransportQueryError(
+                str(execution_result.errors[0]),
+                errors=execution_result.errors,
+                data=execution_result.data,
+                extensions=execution_result.extensions,
+            )
+
         self.client.introspection = execution_result.data
         self.client.schema = build_client_schema(self.client.introspection)
 

--- a/gql/client.py
+++ b/gql/client.py
@@ -805,7 +805,11 @@ class SyncClientSession:
 
         if execution_result.errors:
             raise TransportQueryError(
-                f"Error while fetching schema: {execution_result.errors[0]!s}",
+                (
+                    f"Error while fetching schema: {execution_result.errors[0]!s}\n"
+                    "If you don't need the schema, you can try with: "
+                    '"fetch_schema_from_transport=False"'
+                ),
                 errors=execution_result.errors,
                 data=execution_result.data,
                 extensions=execution_result.extensions,
@@ -1187,7 +1191,11 @@ class AsyncClientSession:
 
         if execution_result.errors:
             raise TransportQueryError(
-                f"Error while fetching schema: {execution_result.errors[0]!s}",
+                (
+                    f"Error while fetching schema: {execution_result.errors[0]!s}\n"
+                    "If you don't need the schema, you can try with: "
+                    '"fetch_schema_from_transport=False"'
+                ),
                 errors=execution_result.errors,
                 data=execution_result.data,
                 extensions=execution_result.extensions,

--- a/gql/client.py
+++ b/gql/client.py
@@ -805,7 +805,7 @@ class SyncClientSession:
 
         if execution_result.errors:
             raise TransportQueryError(
-                str(execution_result.errors[0]),
+                f"Error while fetching schema: {execution_result.errors[0]!s}",
                 errors=execution_result.errors,
                 data=execution_result.data,
                 extensions=execution_result.extensions,
@@ -1187,7 +1187,7 @@ class AsyncClientSession:
 
         if execution_result.errors:
             raise TransportQueryError(
-                str(execution_result.errors[0]),
+                f"Error while fetching schema: {execution_result.errors[0]!s}",
                 errors=execution_result.errors,
                 data=execution_result.data,
                 extensions=execution_result.extensions,

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1190,3 +1190,46 @@ async def test_aiohttp_query_https(event_loop, ssl_aiohttp_server, ssl_close_tim
         africa = continents[0]
 
         assert africa["code"] == "AF"
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_error_fetching_schema(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    error_answer = """
+{
+    "errors": [
+        {
+            "errorType": "UnauthorizedException",
+            "message": "Permission denied"
+        }
+    ]
+}
+"""
+
+    async def handler(request):
+        return web.Response(
+            text=error_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    transport = AIOHTTPTransport(url=url, timeout=10)
+
+    with pytest.raises(TransportQueryError) as exc_info:
+        async with Client(transport=transport, fetch_schema_from_transport=True):
+            pass
+
+    expected_error = (
+        "Error while fetching schema: "
+        "{'errorType': 'UnauthorizedException', 'message': 'Permission denied'}"
+    )
+
+    assert expected_error in str(exc_info.value)
+    assert transport.session is None


### PR DESCRIPTION
Hi everyone!

We (@wang2bo2 and I) came across a bug when our JWT tokens expired. 

## Current behavior / steps to reproduce
- Use an expired JWT token
- The server returns an error for the expired token, but the error is not checked client side (see PR changes). 
- The result is the error being added added to the client as the data/schema. 
- This causes another error to be raised, which isn't immediately obvious that it's due to an expired JWT. See stacktrace below.

```
... [project trace omitted] ...
File "/root/.cache/pypoetry/virtualenvs/project-xS3fZVNL-py3.8/lib/python3.8/site-packages/gql/client.py", line 617, in __enter__
         self.session.fetch_schema()
File "/root/.cache/pypoetry/virtualenvs/project-xS3fZVNL-py3.8/lib/python3.8/site-packages/gql/client.py", line 806, in fetch_schema
         self.client.schema = build_client_schema(self.client.introspection)
File "/root/.cache/pypoetry/virtualenvs/project-xS3fZVNL-py3.8/lib/python3.8/site-packages/gql/utilities/build_client_schema.py", line 79, in build_client_schema
         raise TypeError(
TypeError: Invalid or incomplete introspection result. Ensure that you are passing the 'data' attribute of an introspection response and no 'errors' were returned alongside: None.
```

## Expected behavior
- The error from the server should be raised inside the client sdk.


## Fix
The error handling used elsewhere in the library was copied over to the sync and async `fetch_schema` functions.

Thank you all for maintaining this useful SDK 🙂 