### PR TITLE
[DRAFT] httpx async transport

### DIFF
--- a/gql/transport/httpx_async.py
+++ b/gql/transport/httpx_async.py
@@ -1,10 +1,9 @@
+import httpx
 import json
 import logging
-from time import time
-from typing import Any, AsyncGenerator, Callable, Dict, Optional, Union
 from graphql import DocumentNode, ExecutionResult, print_ast
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, Union
 
-import httpx
 from .async_transport import AsyncTransport
 from .exceptions import (
     TransportAlreadyConnected,
@@ -27,7 +26,10 @@ class HTTPXAsyncTransport(AsyncTransport):
     response_headers: Optional[httpx.Headers] = None
 
     def __init__(
-        self, url: Union[str, httpx.URL],timeout: Optional[int] = None, json_serialize: Callable = json.dumps
+        self,
+        url: Union[str, httpx.URL],
+        timeout: Optional[int] = None,
+        json_serialize: Callable = json.dumps,
     ) -> None:
         """Initialize the transport with the given httpx parameters.
 
@@ -38,7 +40,7 @@ class HTTPXAsyncTransport(AsyncTransport):
         .. _httpx.AsyncClient: https://www.python-httpx.org/async/
         """
         self.url: str = url
-        
+
         self.timeout: Optional[int] = timeout
         self.json_serialize: Callable = json_serialize
 

--- a/gql/transport/httpx_async.py
+++ b/gql/transport/httpx_async.py
@@ -1,8 +1,9 @@
-import httpx
 import json
 import logging
-from graphql import DocumentNode, ExecutionResult, print_ast
 from typing import Any, AsyncGenerator, Callable, Dict, Optional, Union
+
+import httpx
+from graphql import DocumentNode, ExecutionResult, print_ast
 
 from .async_transport import AsyncTransport
 from .exceptions import (
@@ -36,11 +37,8 @@ class HTTPXAsyncTransport(AsyncTransport):
         :param url: The GraphQL server URL. Example: 'https://server.com:PORT/path'.
         :param json_serialize: Json serializer callable.
                 By default json.dumps() function
-
-        .. _httpx.AsyncClient: https://www.python-httpx.org/async/
         """
-        self.url: str = url
-
+        self.url: Union[str, httpx.URL] = url
         self.timeout: Optional[int] = timeout
         self.json_serialize: Callable = json_serialize
 
@@ -62,7 +60,7 @@ class HTTPXAsyncTransport(AsyncTransport):
 
             log.debug("Connecting transport")
 
-            self.client = httpx.AsyncClient()
+            self.client = httpx.AsyncClient(**client_args)
 
         else:
             raise TransportAlreadyConnected("Transport is already connected")
@@ -121,7 +119,7 @@ class HTTPXAsyncTransport(AsyncTransport):
             if log.isEnabledFor(logging.INFO):
                 log.info(">>> %s", self.json_serialize(payload))
 
-            post_args = {"json": payload}
+            post_args: Any = {"json": payload}
 
         # Pass post_args to httpx post method
         if extra_args:

--- a/gql/transport/httpx_async.py
+++ b/gql/transport/httpx_async.py
@@ -1,0 +1,180 @@
+import json
+import logging
+from time import time
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, Union
+from graphql import DocumentNode, ExecutionResult, print_ast
+
+import httpx
+from .async_transport import AsyncTransport
+from .exceptions import (
+    TransportAlreadyConnected,
+    TransportClosed,
+    TransportProtocolError,
+    TransportServerError,
+)
+
+log = logging.getLogger(__name__)
+
+
+class HTTPXAsyncTransport(AsyncTransport):
+    """:ref:`Async Transport <async_transports>` to execute GraphQL queries
+    on remote servers with an HTTP connection.
+
+    This transport use the httpx library with its AsyncClient.
+    """
+
+    client: Optional[httpx.AsyncClient] = None
+    response_headers: Optional[httpx.Headers] = None
+
+    def __init__(
+        self, url: Union[str, httpx.URL],timeout: Optional[int] = None, json_serialize: Callable = json.dumps
+    ) -> None:
+        """Initialize the transport with the given httpx parameters.
+
+        :param url: The GraphQL server URL. Example: 'https://server.com:PORT/path'.
+        :param json_serialize: Json serializer callable.
+                By default json.dumps() function
+
+        .. _httpx.AsyncClient: https://www.python-httpx.org/async/
+        """
+        self.url: str = url
+        
+        self.timeout: Optional[int] = timeout
+        self.json_serialize: Callable = json_serialize
+
+    async def connect(self) -> None:
+        """Coroutine which will create an httpx AsyncClient() as self.client.
+
+        Don't call this coroutine directly on the transport, instead use
+        :code:`async with` on the client and this coroutine will be executed
+        to create the session.
+
+        Should be cleaned with a call to the close coroutine.
+        """
+
+        if self.client is None:
+            client_args: Dict[str, Any] = {}
+
+            if self.timeout is not None:
+                client_args["timeout"] = self.timeout
+
+            log.debug("Connecting transport")
+
+            self.client = httpx.AsyncClient()
+
+        else:
+            raise TransportAlreadyConnected("Transport is already connected")
+
+    async def close(self) -> None:
+        """Coroutine which will close the aiohttp session.
+
+        Don't call this coroutine directly on the transport, instead use
+        :code:`async with` on the client and this coroutine will be executed
+        when you exit the async context manager.
+        """
+        if self.client is not None:
+            await self.client.aclose()
+        self.client = None
+
+    async def execute(
+        self,
+        document: DocumentNode,
+        variable_values: Optional[Dict[str, Any]] = None,
+        operation_name: Optional[str] = None,
+        extra_args: Dict[str, Any] = None,
+        upload_files: bool = False,
+    ) -> ExecutionResult:
+        """Execute the provided document AST against the configured remote server
+        using the current session.
+        This uses the httpx library to perform a HTTP POST request asynchronously
+        to the remote server.
+
+        Don't call this coroutine directly on the transport, instead use
+        :code:`execute` on a client or a session.
+
+        :param document: the parsed GraphQL request
+        :param variable_values: An optional Dict of variable values
+        :param operation_name: An optional Operation name for the request
+        :param extra_args: additional arguments to send to the aiohttp post method
+        :param upload_files: Set to True if you want to put files in the variable values
+        :returns: an ExecutionResult object.
+        """
+
+        query_str = print_ast(document)
+
+        payload: Dict[str, Any] = {
+            "query": query_str,
+        }
+
+        if operation_name:
+            payload["operationName"] = operation_name
+
+        if upload_files:
+            raise NotImplementedError("File upload not implemented for this transport")
+
+        else:
+            if variable_values:
+                payload["variables"] = variable_values
+
+            if log.isEnabledFor(logging.INFO):
+                log.info(">>> %s", self.json_serialize(payload))
+
+            post_args = {"json": payload}
+
+        # Pass post_args to httpx post method
+        if extra_args:
+            post_args.update(extra_args)
+
+        if self.client is None:
+            raise TransportClosed("Transport is not connected")
+
+        def raise_response_error(resp: httpx.Response, reason: str):
+            # We raise a TransportServerError if the status code is 400 or higher
+            # We raise a TransportProtocolError in the other cases
+
+            try:
+                # Raise a ClientResponseError if response status is 400 or higher
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                code = resp.status_code
+                reason = httpx.codes.get_reason_phrase(code)
+                raise TransportServerError(f"{code}, message='{reason}'", code) from e
+
+            result_text = resp.text
+            raise TransportProtocolError(
+                f"Server did not return a GraphQL result: "
+                f"{reason}: "
+                f"{result_text}"
+            )
+
+        resp = await self.client.post(url=self.url, **post_args)
+
+        try:
+            result = resp.json()
+            if log.isEnabledFor(logging.INFO):
+                log.info("<<< %s", resp.text)
+        except Exception:
+            raise_response_error(resp, "Not a JSON answer")
+
+        if "errors" not in result and "data" not in result:
+            raise_response_error(resp, 'No "data" or "errors" keys in answer')
+
+        self.response_headers = resp.headers
+
+        return ExecutionResult(
+            errors=result.get("errors"),
+            data=result.get("data"),
+            extensions=result.get("extensions"),
+        )
+
+    def subscribe(
+        self,
+        document: DocumentNode,
+        variable_values: Optional[Dict[str, Any]] = None,
+        operation_name: Optional[str] = None,
+    ) -> AsyncGenerator[ExecutionResult, None]:
+        """Subscribe is not supported on HTTP.
+
+        :meta private:
+        """
+        raise NotImplementedError("The HTTP transport does not support subscriptions")

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ install_botocore_requires = [
     "botocore>=1.21,<2",
 ]
 
+install_httpx_requires = ["httpx>=0.23.0,<1"]
+
 install_all_requires = (
     install_aiohttp_requires + install_requests_requires + install_websockets_requires + install_botocore_requires
 )
@@ -104,6 +106,7 @@ setup(
         "requests": install_requests_requires,
         "websockets": install_websockets_requires,
         "botocore": install_botocore_requires,
+        "httpx": install_httpx_requires,
     },
     include_package_data=True,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import pytest
 
 from gql import Client
 
-all_transport_dependencies = ["aiohttp", "requests", "websockets", "botocore"]
+all_transport_dependencies = ["aiohttp", "requests", "websockets", "botocore", "httpx"]
 
 
 def pytest_addoption(parser):
@@ -56,6 +56,7 @@ def pytest_collection_modifyitems(config, items):
     # --aiohttp-only
     # --requests-only
     # --websockets-only
+    # --httpx-only
     for transport in all_transport_dependencies:
 
         other_transport_dependencies = [
@@ -120,6 +121,7 @@ for name in [
     "gql.transport.phoenix_channel_websockets",
     "gql.transport.requests",
     "gql.transport.websockets",
+    "gql.transport.httpx_async",
     "gql.dsl",
     "gql.utilities.parse_result",
 ]:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,7 +1,8 @@
 import io
 import json
-import pytest
 from typing import Mapping
+
+import pytest
 
 from gql import Client, gql
 from gql.cli import get_parser, main
@@ -370,40 +371,43 @@ async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server)
         await transport.execute(query)
 
 
-# @pytest.mark.asyncio
-# async def test_httpx_extra_args(event_loop, aiohttp_server):
-#     from aiohttp import web
-#     from gql.transport.httpx_async import HTTPXAsyncTransport
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="cookies not yet implemented")
+async def test_httpx_extra_args(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
 
-#     async def handler(request):
-#         return web.Response(text=query1_server_answer, content_type="application/json")
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
 
-#     app = web.Application()
-#     app.router.add_route("POST", "/", handler)
-#     server = await aiohttp_server(app)
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
 
-#     url = server.make_url("/")
+    url = server.make_url("/")
 
-#     # passing extra arguments to aiohttp.ClientSession
-#     from aiohttp import DummyCookieJar
+    # passing extra arguments to aiohttp.ClientSession
+    from aiohttp import DummyCookieJar
 
-#     jar = DummyCookieJar()
-#     transport = AIOHTTPTransport(
-#         url=url, timeout=10, client_session_args={"version": "1.1", "cookie_jar": jar}
-#     )
+    jar = DummyCookieJar()
+    transport = HTTPXAsyncTransport(
+        url=str(url),
+        timeout=10,
+        client_session_args={"version": "1.1", "cookie_jar": jar},
+    )
 
-#     async with Client(transport=transport) as session:
+    async with Client(transport=transport) as session:
 
-#         query = gql(query1_str)
+        query = gql(query1_str)
 
-#         # Passing extra arguments to the post method of aiohttp
-#         result = await session.execute(query, extra_args={"allow_redirects": False})
+        # Passing extra arguments to the post method of aiohttp
+        result = await session.execute(query, extra_args={"allow_redirects": False})
 
-#         continents = result["continents"]
+        continents = result["continents"]
 
-#         africa = continents[0]
+        africa = continents[0]
 
-#         assert africa["code"] == "AF"
+        assert africa["code"] == "AF"
 
 
 query2_str = """

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,0 +1,1418 @@
+from typing import Mapping
+import io
+import json
+import pytest
+
+from gql import Client, gql
+from gql.cli import get_parser, main
+from gql.transport.exceptions import TransportAlreadyConnected, TransportClosed, TransportProtocolError, TransportQueryError, TransportServerError
+from .conftest import TemporaryFile
+
+query1_str = """
+    query getContinents {
+      continents {
+        code
+        name
+      }
+    }
+"""
+
+query1_server_answer_data = (
+    '{"continents":['
+    '{"code":"AF","name":"Africa"},{"code":"AN","name":"Antarctica"},'
+    '{"code":"AS","name":"Asia"},{"code":"EU","name":"Europe"},'
+    '{"code":"NA","name":"North America"},{"code":"OC","name":"Oceania"},'
+    '{"code":"SA","name":"South America"}]}'
+)
+
+
+query1_server_answer = f'{{"data":{query1_server_answer_data}}}'
+
+# Marking all tests in this file with the httpx marker
+pytestmark = pytest.mark.httpx
+
+
+@pytest.mark.asyncio
+async def test_httpx_query(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+            headers={"dummy": "test1234"},
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        # Execute query asynchronously
+        result = await session.execute(query)
+
+        continents = result["continents"]
+
+        africa = continents[0]
+
+        assert africa["code"] == "AF"
+
+        # Checking response headers are saved in the transport
+        assert hasattr(transport, "response_headers")
+        assert isinstance(transport.response_headers, Mapping)
+        assert transport.response_headers["dummy"] == "test1234"
+
+
+@pytest.mark.asyncio
+async def test_httpx_ignore_backend_content_type(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="text/plain")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        result = await session.execute(query)
+
+        continents = result["continents"]
+
+        africa = continents[0]
+
+        assert africa["code"] == "AF"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="cookies not yet implemented")
+async def test_aiohttp_cookies(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        assert "COOKIE" in request.headers
+        assert "cookie1=val1" == request.headers["COOKIE"]
+
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url), cookies={"cookie1": "val1"})
+
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        # Execute query asynchronously
+        result = await session.execute(query)
+
+        continents = result["continents"]
+
+        africa = continents[0]
+
+        assert africa["code"] == "AF"
+
+
+@pytest.mark.asyncio
+async def test_httpx_error_code_401(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        # Will generate http error code 401
+        return web.Response(
+            text='{"error":"Unauthorized","message":"401 Client Error: Unauthorized"}',
+            content_type="application/json",
+            status=401,
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        with pytest.raises(TransportServerError) as exc_info:
+            await session.execute(query)
+
+        assert "401, message='Unauthorized'" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_httpx_error_code_500(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        # Will generate http error code 500
+        raise Exception("Server error")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        with pytest.raises(TransportServerError) as exc_info:
+            await session.execute(query)
+
+        assert "500, message='Internal Server Error'" in str(exc_info.value)
+
+
+query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
+
+
+@pytest.mark.asyncio
+async def test_httpx_error_code(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_error_answer, content_type="application/json"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        with pytest.raises(TransportQueryError):
+            await session.execute(query)
+
+
+invalid_protocol_responses = [
+    {
+        "response": "{}",
+        "expected_exception": (
+            "Server did not return a GraphQL result: "
+            'No "data" or "errors" keys in answer: {}'
+        ),
+    },
+    {
+        "response": "qlsjfqsdlkj",
+        "expected_exception": (
+            "Server did not return a GraphQL result: Not a JSON answer: qlsjfqsdlkj"
+        ),
+    },
+    {
+        "response": '{"not_data_or_errors": 35}',
+        "expected_exception": (
+            "Server did not return a GraphQL result: "
+            'No "data" or "errors" keys in answer: {"not_data_or_errors": 35}'
+        ),
+    },
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("param", invalid_protocol_responses)
+async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    response = param["response"]
+
+    async def handler(request):
+        return web.Response(text=response, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        with pytest.raises(TransportProtocolError) as exc_info:
+            await session.execute(query)
+
+        assert param["expected_exception"] in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_httpx_subscribe_not_supported(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text="does not matter", content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        with pytest.raises(NotImplementedError):
+            async for result in session.subscribe(query):
+                pass
+
+
+
+@pytest.mark.asyncio
+async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url))
+
+    async with Client(transport=transport) as session:
+
+        with pytest.raises(TransportAlreadyConnected):
+            await session.transport.connect()
+
+
+@pytest.mark.asyncio
+async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    query = gql(query1_str)
+
+    with pytest.raises(TransportClosed):
+        await transport.execute(query)
+
+
+# @pytest.mark.asyncio
+# async def test_httpx_extra_args(event_loop, aiohttp_server):
+#     from aiohttp import web
+#     from gql.transport.httpx_async import HTTPXAsyncTransport
+
+#     async def handler(request):
+#         return web.Response(text=query1_server_answer, content_type="application/json")
+
+#     app = web.Application()
+#     app.router.add_route("POST", "/", handler)
+#     server = await aiohttp_server(app)
+
+#     url = server.make_url("/")
+
+#     # passing extra arguments to aiohttp.ClientSession
+#     from aiohttp import DummyCookieJar
+
+#     jar = DummyCookieJar()
+#     transport = AIOHTTPTransport(
+#         url=url, timeout=10, client_session_args={"version": "1.1", "cookie_jar": jar}
+#     )
+
+#     async with Client(transport=transport) as session:
+
+#         query = gql(query1_str)
+
+#         # Passing extra arguments to the post method of aiohttp
+#         result = await session.execute(query, extra_args={"allow_redirects": False})
+
+#         continents = result["continents"]
+
+#         africa = continents[0]
+
+#         assert africa["code"] == "AF"
+
+
+query2_str = """
+    query getEurope ($code: ID!) {
+      continent (code: $code) {
+        name
+      }
+    }
+"""
+
+query2_server_answer = '{"data": {"continent": {"name": "Europe"}}}'
+
+
+@pytest.mark.asyncio
+async def test_httpx_query_variable_values(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query2_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    async with Client(transport=transport) as session:
+
+        params = {"code": "EU"}
+
+        query = gql(query2_str)
+
+        # Execute query asynchronously
+        result = await session.execute(
+            query, variable_values=params, operation_name="getEurope"
+        )
+
+        continent = result["continent"]
+
+        assert continent["name"] == "Europe"
+
+
+@pytest.mark.asyncio
+async def test_httpx_query_variable_values_fix_issue_292(event_loop, aiohttp_server):
+    """Allow to specify variable_values without keyword.
+
+    See https://github.com/graphql-python/gql/issues/292"""
+
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query2_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    async with Client(transport=transport) as session:
+
+        params = {"code": "EU"}
+
+        query = gql(query2_str)
+
+        # Execute query asynchronously
+        result = await session.execute(query, params, operation_name="getEurope")
+
+        continent = result["continent"]
+
+        assert continent["name"] == "Europe"
+
+
+@pytest.mark.asyncio
+async def test_httpx_execute_running_in_thread(
+    event_loop, aiohttp_server, run_sync_test
+):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        # httpx makes a runtime check for str or httpx.URL
+        transport = HTTPXAsyncTransport(url=str(url))
+
+        client = Client(transport=transport)
+
+        query = gql(query1_str)
+
+        client.execute(query)
+
+    await run_sync_test(event_loop, server, test_code)
+
+
+@pytest.mark.asyncio
+async def test_httpx_subscribe_running_in_thread(
+    event_loop, aiohttp_server, run_sync_test
+):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        # httpx makes a runtime check for str or httpx.URL
+        transport = HTTPXAsyncTransport(url=str(url))
+
+        client = Client(transport=transport)
+
+        query = gql(query1_str)
+
+        # Note: subscriptions are not supported on the aiohttp transport
+        # But we add this test in order to have 100% code coverage
+        # It is to check that we will correctly set an event loop
+        # in the subscribe function if there is none (in a Thread for example)
+        # We cannot test this with the websockets transport because
+        # the websockets transport will set an event loop in its init
+
+        with pytest.raises(NotImplementedError):
+            for result in client.subscribe(query):
+                pass
+
+    await run_sync_test(event_loop, server, test_code)
+
+
+file_upload_server_answer = '{"data":{"success":true}}'
+
+file_upload_mutation_1 = """
+    mutation($file: Upload!) {
+      uploadFile(input:{other_var:$other_var, file:$file}) {
+        success
+      }
+    }
+"""
+
+file_upload_mutation_1_operations = (
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
+    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
+    '{"file": null, "other_var": 42}}'
+)
+
+file_upload_mutation_1_map = '{"0": ["variables.file"]}'
+
+file_1_content = """
+This is a test file
+This file will be sent in the GraphQL mutation
+"""
+
+
+async def single_upload_handler(request):
+
+    from aiohttp import web
+
+    reader = await request.multipart()
+
+    field_0 = await reader.next()
+    assert field_0.name == "operations"
+    field_0_text = await field_0.text()
+    assert field_0_text == file_upload_mutation_1_operations
+
+    field_1 = await reader.next()
+    assert field_1.name == "map"
+    field_1_text = await field_1.text()
+    assert field_1_text == file_upload_mutation_1_map
+
+    field_2 = await reader.next()
+    assert field_2.name == "0"
+    field_2_text = await field_2.text()
+    assert field_2_text == file_1_content
+
+    field_3 = await reader.next()
+    assert field_3 is None
+
+    return web.Response(text=file_upload_server_answer, content_type="application/json")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_file_upload(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    app = web.Application()
+    app.router.add_route("POST", "/", single_upload_handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with TemporaryFile(file_1_content) as test_file:
+
+        async with Client(transport=transport) as session:
+
+            query = gql(file_upload_mutation_1)
+
+            file_path = test_file.filename
+
+            with open(file_path, "rb") as f:
+
+                params = {"file": f, "other_var": 42}
+
+                # Execute query asynchronously
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+            success = result["success"]
+
+            assert success
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_file_upload_without_session(
+    event_loop, aiohttp_server, run_sync_test
+):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    app = web.Application()
+    app.router.add_route("POST", "/", single_upload_handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        # httpx makes a runtime check for str or httpx.URL
+        transport = HTTPXAsyncTransport(url=str(url)) 
+
+        with TemporaryFile(file_1_content) as test_file:
+
+            client = Client(transport=transport)
+
+            query = gql(file_upload_mutation_1)
+
+            file_path = test_file.filename
+
+            with open(file_path, "rb") as f:
+
+                params = {"file": f, "other_var": 42}
+
+                result = client.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+                success = result["success"]
+
+                assert success
+
+    await run_sync_test(event_loop, server, test_code)
+
+
+# This is a sample binary file content containing all possible byte values
+binary_file_content = bytes(range(0, 256))
+
+
+async def binary_upload_handler(request):
+
+    from aiohttp import web
+
+    reader = await request.multipart()
+
+    field_0 = await reader.next()
+    assert field_0.name == "operations"
+    field_0_text = await field_0.text()
+    assert field_0_text == file_upload_mutation_1_operations
+
+    field_1 = await reader.next()
+    assert field_1.name == "map"
+    field_1_text = await field_1.text()
+    assert field_1_text == file_upload_mutation_1_map
+
+    field_2 = await reader.next()
+    assert field_2.name == "0"
+    field_2_binary = await field_2.read()
+    assert field_2_binary == binary_file_content
+
+    field_3 = await reader.next()
+    assert field_3 is None
+
+    return web.Response(text=file_upload_server_answer, content_type="application/json")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_binary_file_upload(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    app = web.Application()
+    app.router.add_route("POST", "/", binary_upload_handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with TemporaryFile(binary_file_content) as test_file:
+
+        async with Client(transport=transport) as session:
+
+            query = gql(file_upload_mutation_1)
+
+            file_path = test_file.filename
+
+            with open(file_path, "rb") as f:
+
+                params = {"file": f, "other_var": 42}
+
+                # Execute query asynchronously
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+            success = result["success"]
+
+            assert success
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_stream_reader_upload(event_loop, aiohttp_server):
+    from aiohttp import web, ClientSession
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def binary_data_handler(request):
+        return web.Response(
+            body=binary_file_content, content_type="binary/octet-stream"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", binary_upload_handler)
+    app.router.add_route("GET", "/binary_data", binary_data_handler)
+
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+    binary_data_url = server.make_url("/binary_data")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    async with Client(transport=transport) as session:
+        query = gql(file_upload_mutation_1)
+        async with ClientSession() as client:
+            async with client.get(binary_data_url) as resp:
+                params = {"file": resp.content, "other_var": 42}
+
+                # Execute query asynchronously
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+    success = result["success"]
+
+    assert success
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_async_generator_upload(event_loop, aiohttp_server):
+    import aiofiles
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    app = web.Application()
+    app.router.add_route("POST", "/", binary_upload_handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with TemporaryFile(binary_file_content) as test_file:
+
+        async with Client(transport=transport) as session:
+
+            query = gql(file_upload_mutation_1)
+
+            file_path = test_file.filename
+
+            async def file_sender(file_name):
+                async with aiofiles.open(file_name, "rb") as f:
+                    chunk = await f.read(64 * 1024)
+                    while chunk:
+                        yield chunk
+                        chunk = await f.read(64 * 1024)
+
+            params = {"file": file_sender(file_path), "other_var": 42}
+
+            # Execute query asynchronously
+            result = await session.execute(
+                query, variable_values=params, upload_files=True
+            )
+
+            success = result["success"]
+
+            assert success
+
+
+file_upload_mutation_2 = """
+    mutation($file1: Upload!, $file2: Upload!) {
+      uploadFile(input:{file1:$file, file2:$file}) {
+        success
+      }
+    }
+"""
+
+file_upload_mutation_2_operations = (
+    '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
+    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
+    '"variables": {"file1": null, "file2": null}}'
+)
+
+file_upload_mutation_2_map = '{"0": ["variables.file1"], "1": ["variables.file2"]}'
+
+file_2_content = """
+This is a second test file
+This file will also be sent in the GraphQL mutation
+"""
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+
+        reader = await request.multipart()
+
+        field_0 = await reader.next()
+        assert field_0.name == "operations"
+        field_0_text = await field_0.text()
+        assert field_0_text == file_upload_mutation_2_operations
+
+        field_1 = await reader.next()
+        assert field_1.name == "map"
+        field_1_text = await field_1.text()
+        assert field_1_text == file_upload_mutation_2_map
+
+        field_2 = await reader.next()
+        assert field_2.name == "0"
+        field_2_text = await field_2.text()
+        assert field_2_text == file_1_content
+
+        field_3 = await reader.next()
+        assert field_3.name == "1"
+        field_3_text = await field_3.text()
+        assert field_3_text == file_2_content
+
+        field_4 = await reader.next()
+        assert field_4 is None
+
+        return web.Response(
+            text=file_upload_server_answer, content_type="application/json"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with TemporaryFile(file_1_content) as test_file_1:
+        with TemporaryFile(file_2_content) as test_file_2:
+
+            async with Client(transport=transport) as session:
+
+                query = gql(file_upload_mutation_2)
+
+                file_path_1 = test_file_1.filename
+                file_path_2 = test_file_2.filename
+
+                f1 = open(file_path_1, "rb")
+                f2 = open(file_path_2, "rb")
+
+                params = {
+                    "file1": f1,
+                    "file2": f2,
+                }
+
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+                f1.close()
+                f2.close()
+
+                success = result["success"]
+
+                assert success
+
+
+file_upload_mutation_3 = """
+    mutation($files: [Upload!]!) {
+      uploadFiles(input:{files:$files}) {
+        success
+      }
+    }
+"""
+
+file_upload_mutation_3_operations = (
+    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: {files: $files})'
+    ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
+)
+
+file_upload_mutation_3_map = '{"0": ["variables.files.0"], "1": ["variables.files.1"]}'
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="file upload not yet implemented")
+async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+
+        reader = await request.multipart()
+
+        field_0 = await reader.next()
+        assert field_0.name == "operations"
+        field_0_text = await field_0.text()
+        assert field_0_text == file_upload_mutation_3_operations
+
+        field_1 = await reader.next()
+        assert field_1.name == "map"
+        field_1_text = await field_1.text()
+        assert field_1_text == file_upload_mutation_3_map
+
+        field_2 = await reader.next()
+        assert field_2.name == "0"
+        field_2_text = await field_2.text()
+        assert field_2_text == file_1_content
+
+        field_3 = await reader.next()
+        assert field_3.name == "1"
+        field_3_text = await field_3.text()
+        assert field_3_text == file_2_content
+
+        field_4 = await reader.next()
+        assert field_4 is None
+
+        return web.Response(
+            text=file_upload_server_answer, content_type="application/json"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with TemporaryFile(file_1_content) as test_file_1:
+        with TemporaryFile(file_2_content) as test_file_2:
+
+            async with Client(transport=transport) as session:
+
+                query = gql(file_upload_mutation_3)
+
+                file_path_1 = test_file_1.filename
+                file_path_2 = test_file_2.filename
+
+                f1 = open(file_path_1, "rb")
+                f2 = open(file_path_2, "rb")
+
+                params = {"files": [f1, f2]}
+
+                # Execute query asynchronously
+                result = await session.execute(
+                    query, variable_values=params, upload_files=True
+                )
+
+                f1.close()
+                f2.close()
+
+                success = result["success"]
+
+                assert success
+
+
+@pytest.mark.asyncio
+async def test_httpx_using_cli(event_loop, aiohttp_server, monkeypatch, capsys):
+    from aiohttp import web
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    parser = get_parser(with_examples=True)
+    args = parser.parse_args([url, "--verbose"])
+
+    # Monkeypatching sys.stdin to simulate getting the query
+    # via the standard input
+    monkeypatch.setattr("sys.stdin", io.StringIO(query1_str))
+
+    exit_code = await main(args)
+
+    assert exit_code == 0
+
+    # Check that the result has been printed on stdout
+    captured = capsys.readouterr()
+    captured_out = str(captured.out).strip()
+
+    expected_answer = json.loads(query1_server_answer_data)
+    print(f"Captured: {captured_out}")
+    received_answer = json.loads(captured_out)
+
+    assert received_answer == expected_answer
+
+
+@pytest.mark.asyncio
+@pytest.mark.script_launch_mode("subprocess")
+async def test_httpx_using_cli_ep(
+    event_loop, aiohttp_server, monkeypatch, script_runner, run_sync_test
+):
+    from aiohttp import web
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    def test_code():
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(query1_str))
+
+        ret = script_runner.run(
+            "gql-cli", url, "--verbose", stdin=io.StringIO(query1_str)
+        )
+
+        assert ret.success
+
+        # Check that the result has been printed on stdout
+        captured_out = str(ret.stdout).strip()
+
+        expected_answer = json.loads(query1_server_answer_data)
+        print(f"Captured: {captured_out}")
+        received_answer = json.loads(captured_out)
+
+        assert received_answer == expected_answer
+
+    await run_sync_test(event_loop, server, test_code)
+
+
+@pytest.mark.asyncio
+async def test_httpx_using_cli_invalid_param(
+    event_loop, aiohttp_server, monkeypatch, capsys
+):
+    from aiohttp import web
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    parser = get_parser(with_examples=True)
+    args = parser.parse_args([url, "--variables", "invalid_param"])
+
+    # Monkeypatching sys.stdin to simulate getting the query
+    # via the standard input
+    monkeypatch.setattr("sys.stdin", io.StringIO(query1_str))
+
+    # Check that the exit_code is an error
+    exit_code = await main(args)
+    assert exit_code == 1
+
+    # Check that the error has been printed on stdout
+    captured = capsys.readouterr()
+    captured_err = str(captured.err).strip()
+    print(f"Captured: {captured_err}")
+
+    expected_error = "Error: Invalid variable: invalid_param"
+
+    assert expected_error in captured_err
+
+
+@pytest.mark.asyncio
+async def test_httpx_using_cli_invalid_query(
+    event_loop, aiohttp_server, monkeypatch, capsys
+):
+    from aiohttp import web
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    parser = get_parser(with_examples=True)
+    args = parser.parse_args([url])
+
+    # Send invalid query on standard input
+    monkeypatch.setattr("sys.stdin", io.StringIO("BLAHBLAH"))
+
+    exit_code = await main(args)
+
+    assert exit_code == 1
+
+    # Check that the error has been printed on stdout
+    captured = capsys.readouterr()
+    captured_err = str(captured.err).strip()
+    print(f"Captured: {captured_err}")
+
+    expected_error = "Syntax Error: Unexpected Name 'BLAHBLAH'"
+
+    assert expected_error in captured_err
+
+
+query1_server_answer_with_extensions = (
+    f'{{"data":{query1_server_answer_data}, "extensions":{{"key1": "val1"}}}}'
+)
+
+
+@pytest.mark.asyncio
+async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_answer_with_extensions, content_type="application/json"
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        execution_result = await session.execute(query, get_execution_result=True)
+
+        assert execution_result.extensions["key1"] == "val1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="not sure if relevant to httpx")
+@pytest.mark.parametrize("ssl_close_timeout", [0, 10])
+async def test_httpx_query_https(event_loop, ssl_httpx_server, ssl_close_timeout):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await ssl_httpx_server(app)
+
+    url = server.make_url("/")
+
+    assert str(url).startswith("https://")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(
+        url=str(url), timeout=10, ssl_close_timeout=ssl_close_timeout
+    )
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        # Execute query asynchronously
+        result = await session.execute(query)
+
+        continents = result["continents"]
+
+        africa = continents[0]
+
+        assert africa["code"] == "AF"
+
+
+@pytest.mark.asyncio
+async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    error_answer = """
+{
+    "errors": [
+        {
+            "errorType": "UnauthorizedException",
+            "message": "Permission denied"
+        }
+    ]
+}
+"""
+
+    async def handler(request):
+        return web.Response(
+            text=error_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    with pytest.raises(TransportQueryError) as exc_info:
+        async with Client(transport=transport, fetch_schema_from_transport=True):
+            pass
+
+    expected_error = (
+        "Error while fetching schema: "
+        "{'errorType': 'UnauthorizedException', 'message': 'Permission denied'}"
+    )
+
+    assert expected_error in str(exc_info.value)
+    assert transport.client is None
+
+
+@pytest.mark.asyncio
+async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    client = Client(transport=transport)
+
+    session = await client.connect_async(reconnecting=True)
+
+    query = gql(query1_str)
+
+    # Execute query asynchronously
+    result = await session.execute(query)
+
+    continents = result["continents"]
+
+    africa = continents[0]
+
+    assert africa["code"] == "AF"
+
+    await client.close_async()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retries", [False, lambda e: e])
+async def test_httpx_reconnecting_session_retries(
+    event_loop, aiohttp_server, retries
+):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    client = Client(transport=transport)
+
+    session = await client.connect_async(
+        reconnecting=True, retry_execute=retries, retry_connect=retries
+    )
+
+    assert session._execute_with_retries == session._execute_once
+    assert session._connect_with_retries == session.transport.connect
+
+    await client.close_async()
+
+
+@pytest.mark.asyncio
+async def test_httpx_reconnecting_session_start_connecting_task_twice(
+    event_loop, aiohttp_server, caplog
+):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(url=str(url)) 
+
+    client = Client(transport=transport)
+
+    session = await client.connect_async(reconnecting=True)
+
+    await session.start_connecting_task()
+
+    print(f"Captured log: {caplog.text}")
+
+    expected_warning = "connect task already started!"
+    assert expected_warning in caplog.text
+
+    await client.close_async()
+
+
+@pytest.mark.asyncio
+async def test_httpx_json_serializer(event_loop, aiohttp_server, caplog):
+    from aiohttp import web
+    from gql.transport.httpx_async import HTTPXAsyncTransport
+
+    async def handler(request):
+
+        request_text = await request.text()
+        print("Received on backend: " + request_text)
+
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    # httpx makes a runtime check for str or httpx.URL
+    transport = HTTPXAsyncTransport(
+        url=str(url),
+        timeout=10,
+        json_serialize=lambda e: json.dumps(e, separators=(",", ":")),
+    )
+
+    async with Client(transport=transport) as session:
+
+        query = gql(query1_str)
+
+        # Execute query asynchronously
+        result = await session.execute(query)
+
+        continents = result["continents"]
+
+        africa = continents[0]
+
+        assert africa["code"] == "AF"
+
+    # Checking that there is no space after the colon in the log
+    expected_log = '"query":"query getContinents'
+    assert expected_log in caplog.text

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,11 +1,18 @@
-from typing import Mapping
 import io
 import json
 import pytest
+from typing import Mapping
 
 from gql import Client, gql
 from gql.cli import get_parser, main
-from gql.transport.exceptions import TransportAlreadyConnected, TransportClosed, TransportProtocolError, TransportQueryError, TransportServerError
+from gql.transport.exceptions import (
+    TransportAlreadyConnected,
+    TransportClosed,
+    TransportProtocolError,
+    TransportQueryError,
+    TransportServerError,
+)
+
 from .conftest import TemporaryFile
 
 query1_str = """
@@ -35,6 +42,7 @@ pytestmark = pytest.mark.httpx
 @pytest.mark.asyncio
 async def test_httpx_query(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -75,6 +83,7 @@ async def test_httpx_query(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 async def test_httpx_ignore_backend_content_type(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -106,6 +115,7 @@ async def test_httpx_ignore_backend_content_type(event_loop, aiohttp_server):
 @pytest.mark.skip(reason="cookies not yet implemented")
 async def test_aiohttp_cookies(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -122,7 +132,6 @@ async def test_aiohttp_cookies(event_loop, aiohttp_server):
 
     # httpx makes a runtime check for str or httpx.URL
     transport = HTTPXAsyncTransport(url=str(url), cookies={"cookie1": "val1"})
-
 
     async with Client(transport=transport) as session:
 
@@ -141,6 +150,7 @@ async def test_aiohttp_cookies(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 async def test_httpx_error_code_401(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -173,6 +183,7 @@ async def test_httpx_error_code_401(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 async def test_httpx_error_code_500(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -204,6 +215,7 @@ query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
 @pytest.mark.asyncio
 async def test_httpx_error_code(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -256,6 +268,7 @@ invalid_protocol_responses = [
 @pytest.mark.parametrize("param", invalid_protocol_responses)
 async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     response = param["response"]
@@ -269,9 +282,8 @@ async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
 
     url = server.make_url("/")
 
-    
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     async with Client(transport=transport) as session:
 
@@ -286,6 +298,7 @@ async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
 @pytest.mark.asyncio
 async def test_httpx_subscribe_not_supported(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -309,10 +322,10 @@ async def test_httpx_subscribe_not_supported(event_loop, aiohttp_server):
                 pass
 
 
-
 @pytest.mark.asyncio
 async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -336,6 +349,7 @@ async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -348,7 +362,7 @@ async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server)
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     query = gql(query1_str)
 
@@ -406,6 +420,7 @@ query2_server_answer = '{"data": {"continent": {"name": "Europe"}}}'
 @pytest.mark.asyncio
 async def test_httpx_query_variable_values(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -418,7 +433,7 @@ async def test_httpx_query_variable_values(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     async with Client(transport=transport) as session:
 
@@ -443,6 +458,7 @@ async def test_httpx_query_variable_values_fix_issue_292(event_loop, aiohttp_ser
     See https://github.com/graphql-python/gql/issues/292"""
 
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -455,7 +471,7 @@ async def test_httpx_query_variable_values_fix_issue_292(event_loop, aiohttp_ser
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     async with Client(transport=transport) as session:
 
@@ -476,6 +492,7 @@ async def test_httpx_execute_running_in_thread(
     event_loop, aiohttp_server, run_sync_test
 ):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -505,6 +522,7 @@ async def test_httpx_subscribe_running_in_thread(
     event_loop, aiohttp_server, run_sync_test
 ):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -593,6 +611,7 @@ async def single_upload_handler(request):
 @pytest.mark.skip(reason="file upload not yet implemented")
 async def test_httpx_file_upload(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     app = web.Application()
@@ -602,7 +621,7 @@ async def test_httpx_file_upload(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with TemporaryFile(file_1_content) as test_file:
 
@@ -632,6 +651,7 @@ async def test_httpx_file_upload_without_session(
     event_loop, aiohttp_server, run_sync_test
 ):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     app = web.Application()
@@ -642,7 +662,7 @@ async def test_httpx_file_upload_without_session(
 
     def test_code():
         # httpx makes a runtime check for str or httpx.URL
-        transport = HTTPXAsyncTransport(url=str(url)) 
+        transport = HTTPXAsyncTransport(url=str(url))
 
         with TemporaryFile(file_1_content) as test_file:
 
@@ -702,6 +722,7 @@ async def binary_upload_handler(request):
 @pytest.mark.skip(reason="file upload not yet implemented")
 async def test_httpx_binary_file_upload(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     app = web.Application()
@@ -711,7 +732,7 @@ async def test_httpx_binary_file_upload(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with TemporaryFile(binary_file_content) as test_file:
 
@@ -738,7 +759,8 @@ async def test_httpx_binary_file_upload(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="file upload not yet implemented")
 async def test_httpx_stream_reader_upload(event_loop, aiohttp_server):
-    from aiohttp import web, ClientSession
+    from aiohttp import ClientSession, web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def binary_data_handler(request):
@@ -756,7 +778,7 @@ async def test_httpx_stream_reader_upload(event_loop, aiohttp_server):
     binary_data_url = server.make_url("/binary_data")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     async with Client(transport=transport) as session:
         query = gql(file_upload_mutation_1)
@@ -779,6 +801,7 @@ async def test_httpx_stream_reader_upload(event_loop, aiohttp_server):
 async def test_httpx_async_generator_upload(event_loop, aiohttp_server):
     import aiofiles
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     app = web.Application()
@@ -788,7 +811,7 @@ async def test_httpx_async_generator_upload(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with TemporaryFile(binary_file_content) as test_file:
 
@@ -843,6 +866,7 @@ This file will also be sent in the GraphQL mutation
 @pytest.mark.skip(reason="file upload not yet implemented")
 async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -883,7 +907,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with TemporaryFile(file_1_content) as test_file_1:
         with TemporaryFile(file_2_content) as test_file_2:
@@ -935,6 +959,7 @@ file_upload_mutation_3_map = '{"0": ["variables.files.0"], "1": ["variables.file
 @pytest.mark.skip(reason="file upload not yet implemented")
 async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -975,7 +1000,7 @@ async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with TemporaryFile(file_1_content) as test_file_1:
         with TemporaryFile(file_2_content) as test_file_2:
@@ -1157,6 +1182,7 @@ query1_server_answer_with_extensions = (
 @pytest.mark.asyncio
 async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -1171,7 +1197,7 @@ async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     async with Client(transport=transport) as session:
 
@@ -1187,6 +1213,7 @@ async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
 @pytest.mark.parametrize("ssl_close_timeout", [0, 10])
 async def test_httpx_query_https(event_loop, ssl_httpx_server, ssl_close_timeout):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -1222,6 +1249,7 @@ async def test_httpx_query_https(event_loop, ssl_httpx_server, ssl_close_timeout
 @pytest.mark.asyncio
 async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     error_answer = """
@@ -1248,7 +1276,7 @@ async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     with pytest.raises(TransportQueryError) as exc_info:
         async with Client(transport=transport, fetch_schema_from_transport=True):
@@ -1266,6 +1294,7 @@ async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -1281,7 +1310,7 @@ async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     client = Client(transport=transport)
 
@@ -1303,10 +1332,9 @@ async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("retries", [False, lambda e: e])
-async def test_httpx_reconnecting_session_retries(
-    event_loop, aiohttp_server, retries
-):
+async def test_httpx_reconnecting_session_retries(event_loop, aiohttp_server, retries):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -1322,7 +1350,7 @@ async def test_httpx_reconnecting_session_retries(
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     client = Client(transport=transport)
 
@@ -1341,6 +1369,7 @@ async def test_httpx_reconnecting_session_start_connecting_task_twice(
     event_loop, aiohttp_server, caplog
 ):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):
@@ -1356,7 +1385,7 @@ async def test_httpx_reconnecting_session_start_connecting_task_twice(
     url = server.make_url("/")
 
     # httpx makes a runtime check for str or httpx.URL
-    transport = HTTPXAsyncTransport(url=str(url)) 
+    transport = HTTPXAsyncTransport(url=str(url))
 
     client = Client(transport=transport)
 
@@ -1375,6 +1404,7 @@ async def test_httpx_reconnecting_session_start_connecting_task_twice(
 @pytest.mark.asyncio
 async def test_httpx_json_serializer(event_loop, aiohttp_server, caplog):
     from aiohttp import web
+
     from gql.transport.httpx_async import HTTPXAsyncTransport
 
     async def handler(request):


### PR DESCRIPTION
Fix #154

Hello, not sure if there is still interest in supporting an httpx transport out of the box. I would be happy to maintain a separate package if that is preferable. Either way, thanks for having a look!

I've really just implemented the bare minimum so far:
- Wiring up the optional dependencies
- Copied over basic transport for `aiohttp`
- Copied over the tests for `aiohttp` - skipping the ones not yet relevant

Would love some guidance on a few things:
1. Is it worth supporting both `httpx.Client` and `httpx.AsyncClient`?
1. I am weighing the trade-offs of adding extra configuration options (such as `cookies`) to the transport vs passing in an instance of `AsyncClient`. Leaning towards the second option. If a client is passed in, transport is not responsible for closing it. A usage example:
    ```python
    transport = HTTPXAsyncTransport(url="...", cookies=httpx.Cookies(), **etc)
    # VS
    async with httpx.AsyncClient(cookies=httpx.Cookies(), **etc) as client:
        transport = HTTPXAsyncTransport(url="...", client=client)
    ```
1. Is it worth trying to reuse the `aiohttp` tests for `httpx` rather than duplicate?