### PR TITLE
Make `AsyncTransport` and `Transport` proper abstract base classes

### DIFF
--- a/gql/transport/async_transport.py
+++ b/gql/transport/async_transport.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncGenerator, Dict, Optional
 from graphql import DocumentNode, ExecutionResult
 
 
-class AsyncTransport:
+class AsyncTransport(abc.ABC):
     @abc.abstractmethod
     async def connect(self):
         """Coroutine used to create a connection to the specified address"""

--- a/gql/transport/transport.py
+++ b/gql/transport/transport.py
@@ -3,7 +3,7 @@ import abc
 from graphql import DocumentNode, ExecutionResult
 
 
-class Transport:
+class Transport(abc.ABC):
     @abc.abstractmethod
     def execute(self, document: DocumentNode, *args, **kwargs) -> ExecutionResult:
         """Execute GraphQL query.


### PR DESCRIPTION
The `@abc.abstractmethod` decorator requires that the class’s metaclass be `abc.ABCMeta` or derived from it. Usually this is satisfied by inherit from `abc.ABC`.

See: https://docs.python.org/3/library/abc.html#abc.abstractmethod