### PR TITLE
Chore update graphql core to 3.3.0 and dropping support for Python 3.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Build wheel and source tarball

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
             python-version: "pypy3.8"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -43,9 +43,9 @@ jobs:
         dependency: ["aiohttp", "requests", "websockets"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies with only ${{ matrix.dependency }} extra dependency
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install test dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-latest, windows-latest]
         exclude:
-          - os: windows-latest
-            python-version: "3.6"
           - os: windows-latest
             python-version: "3.7"
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.8"]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -18,7 +18,7 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
           - os: windows-latest
-            python-version: "pypy3"
+            python-version: "pypy3.8"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GQL
 
-This is a GraphQL client for Python 3.6+.
+This is a GraphQL client for Python 3.7+.
 Plays nicely with `graphene`, `graphql-core`, `graphql-js` and any other GraphQL implementation compatible with the spec.
 
 GQL architecture is inspired by `React-Relay` and `Apollo-Client`.

--- a/docs/gql-cli/intro.rst
+++ b/docs/gql-cli/intro.rst
@@ -3,7 +3,7 @@
 gql-cli
 =======
 
-GQL provides a python 3.6+ script, called `gql-cli` which allows you to execute
+GQL provides a python 3.7+ script, called `gql-cli` which allows you to execute
 GraphQL queries directly from the terminal.
 
 This script supports http(s) or websockets protocols.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-`GQL 3`_ is a `GraphQL`_ Client for Python 3.6+ which plays nicely with other
+`GQL 3`_ is a `GraphQL`_ Client for Python 3.7+ which plays nicely with other
 graphql implementations compatible with the spec.
 
 Under the hood, it uses `GraphQL-core`_ which is a Python port of `GraphQL.js`_,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-core>=3.3.0a1,<3.4",
+    "graphql-core>=3.3.0a2,<3.4",
     "yarl>=1.6,<2.0",
     "backoff>=1.11.1,<3.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-core>=3.2,<3.3",
+    "graphql-core>=3.3.0a1,<3.4",
     "yarl>=1.6,<2.0",
     "backoff>=1.11.1,<3.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,7 @@ install_requests_requires = [
 ]
 
 install_websockets_requires = [
-    "websockets>=9,<10;python_version<='3.6'",
-    "websockets>=10,<11;python_version>'3.6'",
+    "websockets>=10,<11",
 ]
 
 install_botocore_requires = [
@@ -82,7 +81,6 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/custom_scalars/test_json.py
+++ b/tests/custom_scalars/test_json.py
@@ -203,7 +203,7 @@ def test_json_value_input_in_dsl_argument():
     assert (
         str(query)
         == """addPlayer(
-  player: {name: "Tim", level: 0, is_connected: false, score: 5, friends: ["Lea"]}
+  player: { name: "Tim", level: 0, is_connected: false, score: 5, friends: ["Lea"] }
 )"""
     )
 
@@ -237,6 +237,6 @@ def test_json_value_input_with_none_list_in_dsl_argument():
     assert (
         str(query)
         == """addPlayer(
-  player: {name: "Bob", level: 9001, is_connected: true, score: 666.66, friends: null}
+  player: { name: "Bob", level: 9001, is_connected: true, score: 666.66, friends: null }
 )"""
     )

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -205,7 +205,7 @@ def test_add_variable_definitions_with_default_value_input_object(ds):
     assert (
         print_ast(query)
         == """
-mutation ($review: ReviewInput = {stars: 5, commentary: "Wow!"}, $episode: Episode) {
+mutation ($review: ReviewInput = { stars: 5, commentary: "Wow!" }, $episode: Episode) {
   createReview(review: $review, episode: $episode) {
     stars
     commentary
@@ -229,7 +229,7 @@ def test_add_variable_definitions_in_input_object(ds):
         print_ast(query)
         == """mutation ($stars: Int, $commentary: String, $episode: Episode) {
   createReview(
-    review: {stars: $stars, commentary: $commentary}
+    review: { stars: $stars, commentary: $commentary }
     episode: $episode
   ) {
     stars
@@ -554,7 +554,7 @@ def test_multiple_operations(ds):
 mutation CreateReviewMutation {
   createReview(
     episode: JEDI
-    review: {stars: 5, commentary: "This is a great movie!"}
+    review: { stars: 5, commentary: "This is a great movie!" }
   ) {
     stars
     commentary

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -905,7 +905,8 @@ file_upload_mutation_3 = """
 """
 
 file_upload_mutation_3_operations = (
-    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: { files: $files })'
+    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles('
+    "input: { files: $files })"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -535,15 +535,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{other_var:$other_var, file:$file}) {
+      uploadFile(input:{ other_var:$other_var, file:$file }) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
-    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
+    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -810,7 +810,7 @@ file_upload_mutation_2 = """
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -898,14 +898,14 @@ async def test_aiohttp_file_upload_two_files(event_loop, aiohttp_server):
 
 file_upload_mutation_3 = """
     mutation($files: [Upload!]!) {
-      uploadFiles(input:{files:$files}) {
+      uploadFiles(input:{ files:$files }) {
         success
       }
     }
 """
 
 file_upload_mutation_3_operations = (
-    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: {files: $files})'
+    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: { files: $files })'
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -350,15 +350,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{other_var:$other_var, file:$file}) {
+      uploadFile(input:{ other_var:$other_var, file:$file }) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
-    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
+    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -562,7 +562,7 @@ async def test_requests_binary_file_upload(event_loop, aiohttp_server, run_sync_
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -661,7 +661,7 @@ async def test_requests_file_upload_two_files(
 
 
 file_upload_mutation_3_operations = (
-    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: {files: $files})'
+    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: { files: $files })'
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -661,7 +661,8 @@ async def test_requests_file_upload_two_files(
 
 
 file_upload_mutation_3_operations = (
-    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles(input: { files: $files })'
+    '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles'
+    "(input: { files: $files })"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
     black,flake8,import-order,mypy,manifest,
-    py{36,37,38,39,310,py3}
+    py{37,38,39,310,py3}
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -28,7 +27,7 @@ deps = -e.[test]
 commands =
     pip install -U setuptools
     ; run "tox -- tests -s" to show output for debugging
-    py{36,37,39,310,py3}: pytest {posargs:tests}
+    py{37,39,310,py3}: pytest {posargs:tests}
     py{38}: pytest {posargs:tests --cov-report=term-missing --cov=gql}
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    pypy3: pypy3
+    pypy-3: pypy3
 
 [testenv]
 conda_channels = conda-forge


### PR DESCRIPTION
* Following [graphql-core update to 3.3.0a1](https://github.com/graphql-python/graphql-core/releases/tag/v3.3.0a1)
* Adding spaces in tests following graphql-core update
* Dropping support for Python 3.6

