### PR TITLE
Handle JSON response being `None`

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -321,7 +321,7 @@ class AIOHTTPTransport(AsyncTransport):
 
             except Exception:
                 await raise_response_error(resp, "Not a JSON answer")
-            
+
             if result is None:
                 await raise_response_error(resp, "Not a JSON answer")
 

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -321,6 +321,9 @@ class AIOHTTPTransport(AsyncTransport):
 
             except Exception:
                 await raise_response_error(resp, "Not a JSON answer")
+            
+            if result is None:
+                await raise_response_error(resp, "Not a JSON answer")
 
             if "errors" not in result and "data" not in result:
                 await raise_response_error(resp, 'No "data" or "errors" keys in answer')

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -299,6 +299,12 @@ invalid_protocol_responses = [
             'No "data" or "errors" keys in answer: {"not_data_or_errors": 35}'
         ),
     },
+    {
+        "response": "",
+        "expected_exception": (
+            "Server did not return a GraphQL result: Not a JSON answer: "
+        ),
+    },
 ]
 
 


### PR DESCRIPTION
I just hit this strange case. Not sure what the server returned, but it certainly wasn't JSON. It may have been an empty response body.

However, `"errors" not in result` attempts to use `result` as an iterable, which fails when it is of type `None` with an unexpected error. This fix should make the error more intelligent.

```
  File "/Users/jonathanleitschuh/code/personal/security-research/moderne-campaign/venv/lib/python3.8/site-packages/gql/client.py", line 388, in execute
    data = loop.run_until_complete(
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/Users/jonathanleitschuh/code/personal/security-research/moderne-campaign/venv/lib/python3.8/site-packages/gql/client.py", line 285, in execute_async
    return await session.execute(
  File "/Users/jonathanleitschuh/code/personal/security-research/moderne-campaign/venv/lib/python3.8/site-packages/gql/client.py", line 1220, in execute
    result = await self._execute(
  File "/Users/jonathanleitschuh/code/personal/security-research/moderne-campaign/venv/lib/python3.8/site-packages/gql/client.py", line 1126, in _execute
    result = await asyncio.wait_for(
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/tasks.py", line 494, in wait_for
    return fut.result()
  File "/Users/jonathanleitschuh/code/personal/security-research/moderne-campaign/venv/lib/python3.8/site-packages/gql/transport/aiohttp.py", line 325, in execute
    if "errors" not in result and "data" not in result:
TypeError: argument of type 'NoneType' is not iterable
```