### PR TITLE
Get response headers even with 4xx return code

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -295,6 +295,9 @@ class AIOHTTPTransport(AsyncTransport):
 
         async with self.session.post(self.url, ssl=self.ssl, **post_args) as resp:
 
+            # Saving latest response headers in the transport
+            self.response_headers = resp.headers
+
             async def raise_response_error(resp: aiohttp.ClientResponse, reason: str):
                 # We raise a TransportServerError if the status code is 400 or higher
                 # We raise a TransportProtocolError in the other cases
@@ -324,9 +327,6 @@ class AIOHTTPTransport(AsyncTransport):
 
             if "errors" not in result and "data" not in result:
                 await raise_response_error(resp, 'No "data" or "errors" keys in answer')
-
-            # Saving latest response headers in the transport
-            self.response_headers = resp.headers
 
             return ExecutionResult(
                 errors=result.get("errors"),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -150,6 +150,55 @@ async def test_requests_error_code_401(event_loop, aiohttp_server, run_sync_test
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
+async def test_requests_error_code_429(event_loop, aiohttp_server, run_sync_test):
+    from aiohttp import web
+    from gql.transport.requests import RequestsHTTPTransport
+
+    async def handler(request):
+        # Will generate http error code 429
+        return web.Response(
+            text="""
+<html>
+  <head>
+     <title>Too Many Requests</title>
+  </head>
+  <body>
+     <h1>Too Many Requests</h1>
+     <p>I only allow 50 requests per hour to this Web site per
+        logged in user.  Try again soon.</p>
+  </body>
+</html>""",
+            content_type="text/html",
+            status=429,
+            headers={"Retry-After": "3600"},
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        transport = RequestsHTTPTransport(url=url)
+
+        with Client(transport=transport) as session:
+
+            query = gql(query1_str)
+
+            with pytest.raises(TransportServerError) as exc_info:
+                session.execute(query)
+
+            assert "429, message='Too Many Requests'" in str(exc_info.value)
+
+        # Checking response headers are saved in the transport
+        assert hasattr(transport, "response_headers")
+        assert isinstance(transport.response_headers, Mapping)
+        assert transport.response_headers["Retry-After"] == "3600"
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
 async def test_requests_error_code_500(event_loop, aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport


### PR DESCRIPTION
* In `AIOHTTPTransport`, save the response headers before sending a `TransportServerError`
* Add tests for this for `AIOHTTPTransport` and `RequestsHTTPTransport` (already working)

Related: #366