### PR TITLE
Allow to configure the introspection query sent to recover the schema

### DIFF
--- a/docs/gql-cli/intro.rst
+++ b/docs/gql-cli/intro.rst
@@ -78,3 +78,13 @@ Print the GraphQL schema in a file
 .. code-block:: shell
 
     $ gql-cli https://countries.trevorblades.com/graphql --print-schema > schema.graphql
+
+.. note::
+
+    By default, deprecated input fields are not requested from the backend.
+    You can add :code:`--schema-download input_value_deprecation:true` to request them.
+
+.. note::
+
+    You can add :code:`--schema-download descriptions:false` to request a compact schema
+    without comments.

--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -24,7 +24,7 @@ The schema can be provided as a String (which is usually stored in a .graphql fi
 .. note::
     You can download a schema from a server by using :ref:`gql-cli <gql_cli>`
 
-    :code:`$ gql-cli https://SERVER_URL/graphql --print-schema > schema.graphql`
+    :code:`$ gql-cli https://SERVER_URL/graphql --print-schema --schema-download input_value_deprecation:true > schema.graphql`
 
 OR can be created using python classes:
 

--- a/tests/starwars/schema.py
+++ b/tests/starwars/schema.py
@@ -155,6 +155,11 @@ review_input_type = GraphQLInputObjectType(
         "commentary": GraphQLInputField(
             GraphQLString, description="Comment about the movie, optional"
         ),
+        "deprecated_input_field": GraphQLInputField(
+            GraphQLString,
+            description="deprecated field example",
+            deprecation_reason="deprecated for testing",
+        ),
     },
     description="The input object sent when someone is creating a new review",
 )

--- a/tests/starwars/test_introspection.py
+++ b/tests/starwars/test_introspection.py
@@ -1,0 +1,62 @@
+import pytest
+from graphql import print_schema
+
+from gql import Client
+
+from .fixtures import make_starwars_transport
+
+# Marking all tests in this file with the aiohttp marker
+pytestmark = pytest.mark.aiohttp
+
+
+@pytest.mark.asyncio
+async def test_starwars_introspection_args(event_loop, aiohttp_server):
+
+    transport = await make_starwars_transport(aiohttp_server)
+
+    # First fetch the schema from transport using default introspection query
+    # We should receive descriptions in the schema but not deprecated input fields
+    async with Client(
+        transport=transport,
+        fetch_schema_from_transport=True,
+    ) as session:
+
+        schema_str = print_schema(session.client.schema)
+        print(schema_str)
+
+        assert '"""The number of stars this review gave, 1-5"""' in schema_str
+        assert "deprecated_input_field" not in schema_str
+
+    # Then fetch the schema from transport using an introspection query
+    # without requesting descriptions
+    # We should NOT receive descriptions in the schema
+    async with Client(
+        transport=transport,
+        fetch_schema_from_transport=True,
+        introspection_args={
+            "descriptions": False,
+        },
+    ) as session:
+
+        schema_str = print_schema(session.client.schema)
+        print(schema_str)
+
+        assert '"""The number of stars this review gave, 1-5"""' not in schema_str
+        assert "deprecated_input_field" not in schema_str
+
+    # Then fetch the schema from transport using and introspection query
+    # requiring deprecated input fields
+    # We should receive descriptions in the schema and deprecated input fields
+    async with Client(
+        transport=transport,
+        fetch_schema_from_transport=True,
+        introspection_args={
+            "input_value_deprecation": True,
+        },
+    ) as session:
+
+        schema_str = print_schema(session.client.schema)
+        print(schema_str)
+
+        assert '"""The number of stars this review gave, 1-5"""' in schema_str
+        assert "deprecated_input_field" in schema_str


### PR DESCRIPTION
See #399

new `introspection_args` argument to Client to specify the arguments passed to the `get_introspection_query` of graphql-core.
new `--schema-download` argument to the gql-cli script for this functionality