### PR TITLE
DSLSchema transform type attribute assert into AttributeError

### DIFF
--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -295,7 +295,11 @@ class DSLSchema:
         if type_def is None:
             raise AttributeError(f"Type '{name}' not found in the schema!")
 
-        assert isinstance(type_def, (GraphQLObjectType, GraphQLInterfaceType))
+        if not isinstance(type_def, (GraphQLObjectType, GraphQLInterfaceType)):
+            raise AttributeError(
+                f'Type "{name} ({type_def!r})" is not valid as an attribute of'
+                " DSLSchema. Only Object types or Interface types are accepted."
+            )
 
         return DSLType(type_def, self)
 


### PR DESCRIPTION
Better error for `DSLSchema` invalid attributes.
Changing an `assert` into an `AttributeError`.

See PR #406 