### PR TITLE
Restrict urllib3 to versions 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ install_aiohttp_requires = [
 install_requests_requires = [
     "requests>=2.26,<3",
     "requests_toolbelt>=0.9.1,<1",
-    "urllib3>=1.26",
+    "urllib3>=1.26,<2",
 ]
 
 install_httpx_requires = [


### PR DESCRIPTION
This should solve the bug which appeared with the new version 2.30 of requests.