### PR TITLE
Add quotes to the pip installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ The complete documentation for GQL can be found at
 
 You can install GQL with all the optional dependencies using pip:
 
-    pip install gql[all]
+```bash
+# Quotes may be required on certain shells such as zsh.
+pip install "gql[all]"
+```
 
 > **NOTE**: See also [the documentation](https://gql.readthedocs.io/en/latest/intro.html#less-dependencies) to install GQL with less extra dependencies depending on the transports you would like to use or for alternative installation methods.
 


### PR DESCRIPTION
This is required when using certain shells such as zsh, as zsh tries to expand it otherwise, leading to a syntax error.

macOS defaults to zsh since 10.15, so this is more likely to be encountered nowadays.

- See https://github.com/graphql-python/gql/issues/389. I ran into the same issue today :slightly_smiling_face: 