### PR TITLE
Adjust aiohttp pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.8.0,<3.9.0",
+    "aiohttp>=3.8.0,<4",
 ]
 
 install_requests_requires = [


### PR DESCRIPTION
Update `aiohttp` pin to allow versions other then `3.8.x` with `<4`.

**Background**: It looks like aiohttp will add support for Python `3.12` only in `3.9.0`. By pinning `<3.9` this packages unnecessarily constraints what versions downstream packages or apps can install. With semantic versioning everything up to `<4.0` should be backwards compatible.