### PR TITLE
Bump vcrpy and requests_toolbelt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_aiohttp_requires = [
 
 install_requests_requires = [
     "requests>=2.26,<3",
-    "requests_toolbelt>=0.9.1,<1",
+    "requests_toolbelt>=1.0.0,<2",
 ]
 
 install_httpx_requires = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_requires = [
     "pytest-console-scripts==1.3.1",
     "pytest-cov==3.0.0",
     "mock==4.0.2",
-    "vcrpy==4.0.2",
+    "vcrpy==5.1.0",
     "aiofiles",
 ]
 
@@ -44,7 +44,6 @@ install_aiohttp_requires = [
 install_requests_requires = [
     "requests>=2.26,<3",
     "requests_toolbelt>=0.9.1,<1",
-    "urllib3>=1.26,<2",
 ]
 
 install_httpx_requires = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_requires = [
     "pytest-console-scripts==1.3.1",
     "pytest-cov==3.0.0",
     "mock==4.0.2",
-    "vcrpy==5.1.0",
+    "vcrpy==4.4.0",
     "aiofiles",
 ]
 


### PR DESCRIPTION
Bump vcrpy to version 4.4.0 which will restrict the urllib3 version for us when needed.

Now the urllib3 restriction in gql can be removed, fixing issue #439