### PR TITLE
Change aiohttp3.9 python3.12 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.8.0,<4;python_version<='3.11'",
-    "aiohttp>=3.9.0b0,<4;python_version>'3.11'",
+    "aiohttp>=3.8.0,<4;python_version<'3.11'",
+    "aiohttp>=3.9.0b0,<4;python_version>='3.11'",
 ]
 
 install_requests_requires = [


### PR DESCRIPTION
Due to two CVEs, downstream products that may not have upgraded to python3.12 need aiohttp to be at version 3.9.

The update changes the requirement for aiohttp==3.9 to include python>=3.11

See also:
https://nvd.nist.gov/vuln/detail/CVE-2023-49081
https://nvd.nist.gov/vuln/detail/CVE-2023-49082

I've verified the tests and no more tests are failing than before the changes. See https://github.com/graphql-python/gql/issues/457

Thanks,
Oliver