### PR TITLE
Modify tests to work with multiple versions of graphql-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-core>=3.3.0a3,<3.4",
+    "graphql-core==3.2.3",
     "yarl>=1.6,<2.0",
     "backoff>=1.11.1,<3.0",
     "anyio>=3.0,<5",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-core==3.2.3",
+    "graphql-core>=3.3.0a3,<3.4",
     "yarl>=1.6,<2.0",
     "backoff>=1.11.1,<3.0",
     "anyio>=3.0,<5",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import ssl
 import sys
 import tempfile
@@ -506,3 +507,15 @@ pytest_plugins = [
     "tests.fixtures.aws.fake_session",
     "tests.fixtures.aws.fake_signer",
 ]
+
+
+def strip_braces_spaces(s):
+    """Allow to ignore differences in graphql-core syntax between versions"""
+
+    # Strip spaces after starting braces
+    strip_front = s.replace("{ ", "{")
+
+    # Strip spaces before closing braces only if one space is present
+    strip_back = re.sub(r"([^\s]) }", r"\1}", strip_front)
+
+    return strip_back

--- a/tests/custom_scalars/test_json.py
+++ b/tests/custom_scalars/test_json.py
@@ -18,6 +18,8 @@ from graphql.utilities import value_from_ast_untyped
 from gql import Client, gql
 from gql.dsl import DSLSchema
 
+from ..conftest import strip_braces_spaces
+
 # Marking all tests in this file with the aiohttp marker
 pytestmark = pytest.mark.aiohttp
 
@@ -201,9 +203,9 @@ def test_json_value_input_in_dsl_argument():
     print(str(query))
 
     assert (
-        str(query)
+        strip_braces_spaces(str(query))
         == """addPlayer(
-  player: { name: "Tim", level: 0, is_connected: false, score: 5, friends: ["Lea"] }
+  player: {name: "Tim", level: 0, is_connected: false, score: 5, friends: ["Lea"]}
 )"""
     )
 
@@ -235,8 +237,8 @@ def test_json_value_input_with_none_list_in_dsl_argument():
     print(str(query))
 
     assert (
-        str(query)
+        strip_braces_spaces(str(query))
         == """addPlayer(
-  player: { name: "Bob", level: 9001, is_connected: true, score: 666.66, friends: null }
+  player: {name: "Bob", level: 9001, is_connected: true, score: 666.66, friends: null}
 )"""
     )

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -14,7 +14,7 @@ from gql.transport.exceptions import (
     TransportServerError,
 )
 
-from .conftest import TemporaryFile
+from .conftest import TemporaryFile, strip_braces_spaces
 
 query1_str = """
     query getContinents {
@@ -588,15 +588,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{ other_var:$other_var, file:$file }) {
+      uploadFile(input:{other_var:$other_var, file:$file}) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
-    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
+    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -617,7 +617,7 @@ async def single_upload_handler(request):
     field_0 = await reader.next()
     assert field_0.name == "operations"
     field_0_text = await field_0.text()
-    assert field_0_text == file_upload_mutation_1_operations
+    assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
     field_1 = await reader.next()
     assert field_1.name == "map"
@@ -679,7 +679,7 @@ async def single_upload_handler_with_content_type(request):
     field_0 = await reader.next()
     assert field_0.name == "operations"
     field_0_text = await field_0.text()
-    assert field_0_text == file_upload_mutation_1_operations
+    assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
     field_1 = await reader.next()
     assert field_1.name == "map"
@@ -790,7 +790,7 @@ async def binary_upload_handler(request):
     field_0 = await reader.next()
     assert field_0.name == "operations"
     field_0_text = await field_0.text()
-    assert field_0_text == file_upload_mutation_1_operations
+    assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
     field_1 = await reader.next()
     assert field_1.name == "map"
@@ -931,7 +931,7 @@ file_upload_mutation_2 = """
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -955,7 +955,7 @@ async def test_aiohttp_file_upload_two_files(event_loop, aiohttp_server):
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_2_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_2_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -1019,7 +1019,7 @@ async def test_aiohttp_file_upload_two_files(event_loop, aiohttp_server):
 
 file_upload_mutation_3 = """
     mutation($files: [Upload!]!) {
-      uploadFiles(input:{ files:$files }) {
+      uploadFiles(input:{files:$files}) {
         success
       }
     }
@@ -1027,7 +1027,7 @@ file_upload_mutation_3 = """
 
 file_upload_mutation_3_operations = (
     '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles('
-    "input: { files: $files })"
+    "input: {files: $files})"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 
@@ -1046,7 +1046,7 @@ async def test_aiohttp_file_upload_list_of_two_files(event_loop, aiohttp_server)
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_3_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_3_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -10,7 +10,8 @@ from gql.transport.exceptions import (
     TransportQueryError,
     TransportServerError,
 )
-from tests.conftest import TemporaryFile
+
+from .conftest import TemporaryFile, strip_braces_spaces
 
 # Marking all tests in this file with the httpx marker
 pytestmark = pytest.mark.httpx
@@ -397,15 +398,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{ other_var:$other_var, file:$file }) {
+      uploadFile(input:{other_var:$other_var, file:$file}) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
-    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
+    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -431,7 +432,7 @@ async def test_httpx_file_upload(event_loop, aiohttp_server, run_sync_test):
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -493,7 +494,7 @@ async def test_httpx_file_upload_with_content_type(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -563,7 +564,7 @@ async def test_httpx_file_upload_additional_headers(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -627,7 +628,7 @@ async def test_httpx_binary_file_upload(event_loop, aiohttp_server, run_sync_tes
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -677,7 +678,7 @@ async def test_httpx_binary_file_upload(event_loop, aiohttp_server, run_sync_tes
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -710,7 +711,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server, run_sync_
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_2_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_2_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -775,7 +776,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server, run_sync_
 
 file_upload_mutation_3_operations = (
     '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles'
-    "(input: { files: $files })"
+    "(input: {files: $files})"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 
@@ -812,7 +813,7 @@ async def test_httpx_file_upload_list_of_two_files(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_3_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_3_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -14,7 +14,7 @@ from gql.transport.exceptions import (
     TransportServerError,
 )
 
-from .conftest import TemporaryFile, get_localhost_ssl_context
+from .conftest import TemporaryFile, get_localhost_ssl_context, strip_braces_spaces
 
 query1_str = """
     query getContinents {
@@ -601,15 +601,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{ other_var:$other_var, file:$file }) {
+      uploadFile(input:{other_var:$other_var, file:$file}) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
-    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
+    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -630,7 +630,7 @@ async def single_upload_handler(request):
     field_0 = await reader.next()
     assert field_0.name == "operations"
     field_0_text = await field_0.text()
-    assert field_0_text == file_upload_mutation_1_operations
+    assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
     field_1 = await reader.next()
     assert field_1.name == "map"
@@ -737,7 +737,7 @@ async def binary_upload_handler(request):
     field_0 = await reader.next()
     assert field_0.name == "operations"
     field_0_text = await field_0.text()
-    assert field_0_text == file_upload_mutation_1_operations
+    assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
     field_1 = await reader.next()
     assert field_1.name == "map"
@@ -801,7 +801,7 @@ file_upload_mutation_2 = """
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -826,7 +826,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_2_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_2_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -890,7 +890,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
 
 file_upload_mutation_3 = """
     mutation($files: [Upload!]!) {
-      uploadFiles(input:{ files:$files }) {
+      uploadFiles(input:{files:$files}) {
         success
       }
     }
@@ -898,7 +898,7 @@ file_upload_mutation_3 = """
 
 file_upload_mutation_3_operations = (
     '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles('
-    "input: { files: $files })"
+    "input: {files: $files})"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 
@@ -918,7 +918,7 @@ async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_3_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_3_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -10,7 +10,8 @@ from gql.transport.exceptions import (
     TransportQueryError,
     TransportServerError,
 )
-from tests.conftest import TemporaryFile
+
+from .conftest import TemporaryFile, strip_braces_spaces
 
 # Marking all tests in this file with the requests marker
 pytestmark = pytest.mark.requests
@@ -399,15 +400,15 @@ file_upload_server_answer = '{"data":{"success":true}}'
 
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
-      uploadFile(input:{ other_var:$other_var, file:$file }) {
+      uploadFile(input:{other_var:$other_var, file:$file}) {
         success
       }
     }
 """
 
 file_upload_mutation_1_operations = (
-    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: { other_var: '
-    '$other_var, file: $file }) {\\n    success\\n  }\\n}", "variables": '
+    '{"query": "mutation ($file: Upload!) {\\n  uploadFile(input: {other_var: '
+    '$other_var, file: $file}) {\\n    success\\n  }\\n}", "variables": '
     '{"file": null, "other_var": 42}}'
 )
 
@@ -433,7 +434,7 @@ async def test_requests_file_upload(event_loop, aiohttp_server, run_sync_test):
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -495,7 +496,7 @@ async def test_requests_file_upload_with_content_type(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -565,7 +566,7 @@ async def test_requests_file_upload_additional_headers(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -629,7 +630,7 @@ async def test_requests_binary_file_upload(event_loop, aiohttp_server, run_sync_
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_1_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_1_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -679,7 +680,7 @@ async def test_requests_binary_file_upload(event_loop, aiohttp_server, run_sync_
 
 file_upload_mutation_2_operations = (
     '{"query": "mutation ($file1: Upload!, $file2: Upload!) {\\n  '
-    'uploadFile(input: { file1: $file, file2: $file }) {\\n    success\\n  }\\n}", '
+    'uploadFile(input: {file1: $file, file2: $file}) {\\n    success\\n  }\\n}", '
     '"variables": {"file1": null, "file2": null}}'
 )
 
@@ -714,7 +715,7 @@ async def test_requests_file_upload_two_files(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_2_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_2_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"
@@ -779,7 +780,7 @@ async def test_requests_file_upload_two_files(
 
 file_upload_mutation_3_operations = (
     '{"query": "mutation ($files: [Upload!]!) {\\n  uploadFiles'
-    "(input: { files: $files })"
+    "(input: {files: $files})"
     ' {\\n    success\\n  }\\n}", "variables": {"files": [null, null]}}'
 )
 
@@ -816,7 +817,7 @@ async def test_requests_file_upload_list_of_two_files(
         field_0 = await reader.next()
         assert field_0.name == "operations"
         field_0_text = await field_0.text()
-        assert field_0_text == file_upload_mutation_3_operations
+        assert strip_braces_spaces(field_0_text) == file_upload_mutation_3_operations
 
         field_1 = await reader.next()
         assert field_1.name == "map"


### PR DESCRIPTION
This would allow to easily maintain a stable version of gql using stable version of graphql-core 3.2.3