### PR TITLE
Adding json_deserialize parameter to aiohttp and httpx transports

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -106,7 +106,7 @@ class Client:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums. Default: False.
         :param parse_results: Whether gql will try to parse the serialized output
-                sent by the backend. Can be used to unserialize custom scalars or enums.
+                sent by the backend. Can be used to deserialize custom scalars or enums.
         :param batch_interval: Time to wait in seconds for batching requests together.
                 Batching is disabled (by default) if 0.
         :param batch_max: Maximum number of requests in a single batch.
@@ -892,7 +892,7 @@ class SyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
 
         The extra arguments are passed to the transport execute method."""
@@ -1006,7 +1006,7 @@ class SyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
         :param get_execution_result: return the full ExecutionResult instance instead of
             only the "data" field. Necessary if you want to get the "extensions" field.
@@ -1057,7 +1057,7 @@ class SyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
         :param validate_document: Whether we still need to validate the document.
 
@@ -1151,7 +1151,7 @@ class SyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
         :param get_execution_result: return the full ExecutionResult instance instead of
             only the "data" field. Necessary if you want to get the "extensions" field.
@@ -1333,7 +1333,7 @@ class AsyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
 
         The extra arguments are passed to the transport subscribe method."""
@@ -1454,7 +1454,7 @@ class AsyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
         :param get_execution_result: yield the full ExecutionResult instance instead of
             only the "data" field. Necessary if you want to get the "extensions" field.
@@ -1511,7 +1511,7 @@ class AsyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
 
         The extra arguments are passed to the transport execute method."""
@@ -1617,7 +1617,7 @@ class AsyncClientSession:
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
-        :param parse_result: Whether gql will unserialize the result.
+        :param parse_result: Whether gql will deserialize the result.
             By default use the parse_results argument of the client.
         :param get_execution_result: return the full ExecutionResult instance instead of
             only the "data" field. Necessary if you want to get the "extensions" field.

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -50,6 +50,7 @@ class AIOHTTPTransport(AsyncTransport):
         timeout: Optional[int] = None,
         ssl_close_timeout: Optional[Union[int, float]] = 10,
         json_serialize: Callable = json.dumps,
+        json_unserialize: Callable = json.loads,
         client_session_args: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Initialize the transport with the given aiohttp parameters.
@@ -64,6 +65,8 @@ class AIOHTTPTransport(AsyncTransport):
                                   to close properly
         :param json_serialize: Json serializer callable.
                 By default json.dumps() function
+        :param json_unserialize: Json unserializer callable.
+                By default json.loads() function
         :param client_session_args: Dict of extra args passed to
                 `aiohttp.ClientSession`_
 
@@ -81,6 +84,7 @@ class AIOHTTPTransport(AsyncTransport):
         self.session: Optional[aiohttp.ClientSession] = None
         self.response_headers: Optional[CIMultiDictProxy[str]]
         self.json_serialize: Callable = json_serialize
+        self.json_unserialize: Callable = json_unserialize
 
     async def connect(self) -> None:
         """Coroutine which will create an aiohttp ClientSession() as self.session.
@@ -328,7 +332,7 @@ class AIOHTTPTransport(AsyncTransport):
                 )
 
             try:
-                result = await resp.json(content_type=None)
+                result = await resp.json(loads=self.json_unserialize, content_type=None)
 
                 if log.isEnabledFor(logging.INFO):
                     result_text = await resp.text()

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -50,7 +50,7 @@ class AIOHTTPTransport(AsyncTransport):
         timeout: Optional[int] = None,
         ssl_close_timeout: Optional[Union[int, float]] = 10,
         json_serialize: Callable = json.dumps,
-        json_unserialize: Callable = json.loads,
+        json_deserialize: Callable = json.loads,
         client_session_args: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Initialize the transport with the given aiohttp parameters.
@@ -65,7 +65,7 @@ class AIOHTTPTransport(AsyncTransport):
                                   to close properly
         :param json_serialize: Json serializer callable.
                 By default json.dumps() function
-        :param json_unserialize: Json unserializer callable.
+        :param json_deserialize: Json deserializer callable.
                 By default json.loads() function
         :param client_session_args: Dict of extra args passed to
                 `aiohttp.ClientSession`_
@@ -84,7 +84,7 @@ class AIOHTTPTransport(AsyncTransport):
         self.session: Optional[aiohttp.ClientSession] = None
         self.response_headers: Optional[CIMultiDictProxy[str]]
         self.json_serialize: Callable = json_serialize
-        self.json_unserialize: Callable = json_unserialize
+        self.json_deserialize: Callable = json_deserialize
 
     async def connect(self) -> None:
         """Coroutine which will create an aiohttp ClientSession() as self.session.
@@ -332,7 +332,7 @@ class AIOHTTPTransport(AsyncTransport):
                 )
 
             try:
-                result = await resp.json(loads=self.json_unserialize, content_type=None)
+                result = await resp.json(loads=self.json_deserialize, content_type=None)
 
                 if log.isEnabledFor(logging.INFO):
                     result_text = await resp.text()

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -38,7 +38,7 @@ class _HTTPXTransport:
         self,
         url: Union[str, httpx.URL],
         json_serialize: Callable = json.dumps,
-        json_unserialize: Callable = json.loads,
+        json_deserialize: Callable = json.loads,
         **kwargs,
     ):
         """Initialize the transport with the given httpx parameters.
@@ -46,13 +46,13 @@ class _HTTPXTransport:
         :param url: The GraphQL server URL. Example: 'https://server.com:PORT/path'.
         :param json_serialize: Json serializer callable.
                 By default json.dumps() function.
-        :param json_unserialize: Json unserializer callable.
+        :param json_deserialize: Json deserializer callable.
                 By default json.loads() function.
         :param kwargs: Extra args passed to the `httpx` client.
         """
         self.url = url
         self.json_serialize = json_serialize
-        self.json_unserialize = json_unserialize
+        self.json_deserialize = json_deserialize
         self.kwargs = kwargs
 
     def _prepare_request(
@@ -150,10 +150,10 @@ class _HTTPXTransport:
 
         try:
             result: Dict[str, Any]
-            if self.json_unserialize == json.loads:
+            if self.json_deserialize == json.loads:
                 result = response.json()
             else:
-                result = self.json_unserialize(response.content)
+                result = self.json_deserialize(response.content)
 
         except Exception:
             self._raise_response_error(response, "Not a JSON answer")

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -149,11 +149,7 @@ class _HTTPXTransport:
             log.debug("<<< %s", response.text)
 
         try:
-            result: Dict[str, Any]
-            if self.json_deserialize == json.loads:
-                result = response.json()
-            else:
-                result = self.json_deserialize(response.content)
+            result: Dict[str, Any] = self.json_deserialize(response.content)
 
         except Exception:
             self._raise_response_error(response, "Not a JSON answer")

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1523,7 +1523,7 @@ query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_json_unserializer(event_loop, aiohttp_server):
+async def test_aiohttp_json_deserializer(event_loop, aiohttp_server):
     from aiohttp import web
     from decimal import Decimal
     from functools import partial
@@ -1546,7 +1546,7 @@ async def test_aiohttp_json_unserializer(event_loop, aiohttp_server):
     transport = AIOHTTPTransport(
         url=url,
         timeout=10,
-        json_unserialize=json_loads,
+        json_deserialize=json_loads,
     )
 
     async with Client(transport=transport) as session:

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1404,7 +1404,7 @@ query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_json_unserializer(event_loop, aiohttp_server):
+async def test_httpx_json_deserializer(event_loop, aiohttp_server):
     from aiohttp import web
     from decimal import Decimal
     from functools import partial
@@ -1427,7 +1427,7 @@ async def test_httpx_json_unserializer(event_loop, aiohttp_server):
     transport = HTTPXAsyncTransport(
         url=url,
         timeout=10,
-        json_unserialize=json_loads,
+        json_deserialize=json_loads,
     )
 
     async with Client(transport=transport) as session:

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1402,6 +1402,7 @@ query_float_server_answer_data = '{"pi": 3.1415926535897932384626433832795028841
 query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 
+@pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_json_unserializer(event_loop, aiohttp_server):
     from aiohttp import web


### PR DESCRIPTION
Allow users to overwrite the `json.loads` method used to parse the json received from the backend.