### PR TITLE
Fix importing DirectiveLocation directly from graphql

### DIFF
--- a/gql/utilities/build_client_schema.py
+++ b/gql/utilities/build_client_schema.py
@@ -1,10 +1,7 @@
-from graphql import GraphQLSchema, IntrospectionQuery
+from graphql import DirectiveLocation, GraphQLSchema, IntrospectionQuery
 from graphql import build_client_schema as build_client_schema_orig
 from graphql.pyutils import inspect
-from graphql.utilities.get_introspection_query import (
-    DirectiveLocation,
-    IntrospectionDirective,
-)
+from graphql.utilities.get_introspection_query import IntrospectionDirective
 
 __all__ = ["build_client_schema"]
 


### PR DESCRIPTION
It should fix running gql with [graphql-core 3.3.0a5](https://github.com/graphql-python/graphql-core/releases/tag/v3.3.0a5)