### PR TITLE
Bump pytest-cov dev-dependency to 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_requires = [
     "pytest==7.4.2",
     "pytest-asyncio==0.21.1",
     "pytest-console-scripts==1.3.1",
-    "pytest-cov==3.0.0",
+    "pytest-cov==5.0.0",
     "mock==4.0.2",
     "vcrpy==4.4.0",
     "aiofiles",


### PR DESCRIPTION
Should fix warning appearing when running tests with coverage