### PR TITLE
Always close transport when an exception appears during the transport connect

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -786,7 +786,11 @@ class Client:
             self.session = ReconnectingAsyncClientSession(client=self, **kwargs)
             await self.session.start_connecting_task()
         else:
-            await self.transport.connect()
+            try:
+                await self.transport.connect()
+            except Exception as e:
+                await self.transport.close()
+                raise e
             self.session = AsyncClientSession(client=self)
 
         # Get schema from transport if needed

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -441,7 +441,6 @@ async def test_websocket_connect_failed_with_authentication_in_connection_init(
 
             await session.execute(query1)
 
-    await asyncio.sleep(1)
     assert transport.websocket is None
 
 


### PR DESCRIPTION
It should ensure that the transport is always cleaned properly before exiting the context manager.