### PR TITLE
chore: upgrade GitHub workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Build wheel and source tarball

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Build wheel and source tarball
       run: |
         pip install wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,4 +73,7 @@ jobs:
       - name: Test with coverage
         run: pytest --cov=gql --cov-report=xml --cov-report=term-missing tests
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+          with:
+            fail_ci_if_error: false
+            token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies with only ${{ matrix.dependency }} extra dependency
         run: |
           python -m pip install --upgrade pip wheel
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.12"]
         os: [ubuntu-24.04, windows-latest]
         exclude:
           - os: windows-latest
@@ -20,7 +20,7 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
           - os: windows-latest
-            python-version: "pypy3.8"
+            python-version: "pypy3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         exclude:
           - os: windows-latest
             python-version: "3.9"
@@ -38,7 +38,7 @@ jobs:
           TOXENV: ${{ matrix.toxenv }}
 
   single_extra:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,7 @@ jobs:
         run: pytest tests --${{ matrix.dependency }}-only
 
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.10"]
         os: [ubuntu-24.04, windows-latest]
         exclude:
           - os: windows-latest
@@ -20,7 +20,7 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
           - os: windows-latest
-            python-version: "pypy3.12"
+            python-version: "pypy3.10"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,6 @@ jobs:
         run: pytest --cov=gql --cov-report=xml --cov-report=term-missing tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-          with:
-            fail_ci_if_error: false
-            token: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,4 +73,4 @@ jobs:
       - name: Test with coverage
         run: pytest --cov=gql --cov-report=xml --cov-report=term-missing tests
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
             python-version: "pypy3.8"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -45,9 +45,9 @@ jobs:
         dependency: ["aiohttp", "requests", "httpx", "websockets"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install dependencies with only ${{ matrix.dependency }} extra dependency
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install test dependencies

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_requires = [
     "parse==1.15.0",
     "pytest==7.4.2",
     "pytest-asyncio==0.21.1",
-    "pytest-console-scripts==1.3.1",
+    "pytest-console-scripts==1.4.1",
     "pytest-cov==5.0.0",
     "vcrpy==4.4.0",
     "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_requires = [
 dev_requires = [
     "black==22.3.0",
     "check-manifest>=0.42,<1",
-    "flake8==3.8.1",
+    "flake8==7.1.1",
     "isort==4.3.21",
     "mypy==1.10",
     "sphinx>=5.3.0,<6",

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1162,7 +1162,8 @@ async def test_aiohttp_using_cli_ep(
         monkeypatch.setattr("sys.stdin", io.StringIO(query1_str))
 
         ret = script_runner.run(
-            "gql-cli", url, "--verbose", stdin=io.StringIO(query1_str)
+            ["gql-cli", url, "--verbose"],
+            stdin=io.StringIO(query1_str),
         )
 
         assert ret.success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -372,7 +372,7 @@ def test_cli_get_transport_no_protocol(parser):
 
 @pytest.mark.script_launch_mode("subprocess")
 def test_cli_ep_version(script_runner):
-    ret = script_runner.run("gql-cli", "--version")
+    ret = script_runner.run(["gql-cli", "--version"])
 
     assert ret.success
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1036,7 +1036,8 @@ async def test_httpx_using_cli_ep(
         monkeypatch.setattr("sys.stdin", io.StringIO(query1_str))
 
         ret = script_runner.run(
-            "gql-cli", url, "--verbose", stdin=io.StringIO(query1_str)
+            ["gql-cli", url, "--verbose"],
+            stdin=io.StringIO(query1_str),
         )
 
         assert ret.success

--- a/tox.ini
+++ b/tox.ini
@@ -32,37 +32,37 @@ commands =
     py{38}: pytest {posargs:tests --cov-report=term-missing --cov=gql}
 
 [testenv:black]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     black --check gql tests
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     flake8 gql tests
 
 [testenv:import-order]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     isort --recursive --check-only --diff gql tests
 
 [testenv:mypy]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     mypy gql tests
 
 [testenv:docs]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     sphinx-build -b html -nEW docs docs/_build/html
 
 [testenv:manifest]
-basepython = python3.8
+basepython = python
 deps = -e.[dev]
 commands =
     check-manifest -v


### PR DESCRIPTION
- Bump GitHub actions:
  * actions/checkout@v4
  * actions/setup-python@v5
  * codecov/codecov-action@v4

- Bump Ubuntu 20.04 to 24.04
- Bump default Python version to 3.12 instead of 3.8
- Bump pypy version to 3.10 instead of 3.8

With Python 3.12, the following dev/tests dependencies needed to be updated:

- pytest-console-scripts to 1.4.1
- flake8 to 7.1.1

