### PR TITLE
Wire httpx transport in gql-cli

### DIFF
--- a/gql/cli.py
+++ b/gql/cli.py
@@ -157,6 +157,7 @@ def get_parser(with_examples: bool = False) -> ArgumentParser:
         choices=[
             "auto",
             "aiohttp",
+            "httpx",
             "phoenix",
             "websockets",
             "aiohttp_websockets",
@@ -329,6 +330,11 @@ def get_transport(args: Namespace) -> Optional[AsyncTransport]:
         from gql.transport.aiohttp import AIOHTTPTransport
 
         return AIOHTTPTransport(url=args.server, **transport_args)
+
+    elif transport_name == "httpx":
+        from gql.transport.httpx import HTTPXAsyncTransport
+
+        return HTTPXAsyncTransport(url=args.server, **transport_args)
 
     elif transport_name == "phoenix":
         from gql.transport.phoenix_channel_websockets import (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,6 +190,22 @@ def test_cli_get_transport_aiohttp(parser, url):
     assert isinstance(transport, AIOHTTPTransport)
 
 
+@pytest.mark.httpx
+@pytest.mark.parametrize(
+    "url",
+    ["http://your_server.com", "https://your_server.com"],
+)
+def test_cli_get_transport_httpx(parser, url):
+
+    from gql.transport.httpx import HTTPXAsyncTransport
+
+    args = parser.parse_args([url, "--transport", "httpx"])
+
+    transport = get_transport(args)
+
+    assert isinstance(transport, HTTPXAsyncTransport)
+
+
 @pytest.mark.websockets
 @pytest.mark.parametrize(
     "url",


### PR DESCRIPTION
I thought that I had some problem with the `aiohttp` backend and tried to use `httpx` instead just to discover that it wasn't available.

My problem was somewhere else but this change makes the `httpx` backend available for the `gql-cli` command.