### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "gql"
+readme = "README.md"
+requires-python = ">=3.8.1"
+dynamic = ["authors", "classifiers", "dependencies", "description", "entry-points", "keywords", "license", "optional-dependencies", "scripts", "version"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
My `setuptools` knowledge is a bit rusty, especially when it comes to how to use the entry points while developing.

This change adds a minimal `pyproject.toml` which makes a call like `uv run gql-cli ...` available.