### PR TITLE
Chore fix tests failing vcrpy urllib3 dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ tests_requires = [
     "pytest-asyncio==0.21.1",
     "pytest-console-scripts==1.4.1",
     "pytest-cov==5.0.0",
-    "vcrpy==7.0.0",
+    "vcrpy==4.4.0;python_version<='3.8'",
+    "vcrpy==7.0.0;python_version>'3.8'",
     "aiofiles",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_requires = [
     "pytest-asyncio==0.21.1",
     "pytest-console-scripts==1.4.1",
     "pytest-cov==5.0.0",
-    "vcrpy==4.4.0",
+    "vcrpy==7.0.0",
     "aiofiles",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,6 @@ deps = -e.[test]
 ; Prevent installing issues: https://github.com/ContinuumIO/anaconda-issues/issues/542
 commands =
     pip install -U setuptools
-    pip install -e .[test]
-    pip freeze
     ; run "tox -- tests -s" to show output for debugging
     py{39,310,311,312,py3}: pytest {posargs:tests}
     py{38}: pytest {posargs:tests --cov-report=term-missing --cov=gql}

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ deps = -e.[test]
 ; Prevent installing issues: https://github.com/ContinuumIO/anaconda-issues/issues/542
 commands =
     pip install -U setuptools
+    pip install -e .[test]
+    pip freeze
     ; run "tox -- tests -s" to show output for debugging
     py{39,310,311,312,py3}: pytest {posargs:tests}
     py{38}: pytest {posargs:tests --cov-report=term-missing --cov=gql}


### PR DESCRIPTION
Tests are failing with vcrpy because of a change in urllib3.
This [PR](https://github.com/kevin1024/vcrpy/pull/889) solved the problem in vcrpy version 7.0.0

So, bumping vcrpy to 7.0.0