### PR TITLE
Fix test for introspection type recursion level change in graphql-core v3.3.0a7

### DIFF
--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -1007,6 +1007,7 @@ def test_get_introspection_query_ast(option):
             specified_by_url=option,
             directive_is_repeatable=option,
             schema_description=option,
+            input_value_deprecation=option,
             type_recursion_level=9,
         )
         assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -992,10 +992,25 @@ def test_get_introspection_query_ast(option):
         schema_description=option,
     )
 
-    assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
-    assert node_tree(dsl_introspection_query) == node_tree(
-        gql(print_ast(dsl_introspection_query))
-    )
+    try:
+        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert node_tree(dsl_introspection_query) == node_tree(
+            gql(print_ast(dsl_introspection_query))
+        )
+    except AssertionError:
+
+        # From graphql-core version 3.3.0a7, there is two more type recursion levels
+        dsl_introspection_query = get_introspection_query_ast(
+            descriptions=option,
+            specified_by_url=option,
+            directive_is_repeatable=option,
+            schema_description=option,
+            type_recursion_level=9,
+        )
+        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert node_tree(dsl_introspection_query) == node_tree(
+            gql(print_ast(dsl_introspection_query))
+        )
 
 
 def test_typename_aliased(ds):


### PR DESCRIPTION
From graphql-core version 3.3.0a7, the default introspection query has now two more recursion levels.

Fixing the test in gql to allow both versions.