### PR TITLE
Allow graphql-core 3.2.4 by retrofitting introspection commits

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -29,7 +29,6 @@ from graphql import (
     GraphQLSchema,
     IntrospectionQuery,
     build_ast_schema,
-    get_introspection_query,
     parse,
     validate,
 )
@@ -39,7 +38,7 @@ from .transport.async_transport import AsyncTransport
 from .transport.exceptions import TransportClosed, TransportQueryError
 from .transport.local_schema import LocalSchemaTransport
 from .transport.transport import Transport
-from .utilities import build_client_schema
+from .utilities import build_client_schema, get_introspection_query_ast
 from .utilities import parse_result as parse_result_fn
 from .utilities import serialize_variable_values
 from .utils import str_first_element
@@ -98,8 +97,8 @@ class Client:
         :param transport: The provided :ref:`transport <Transports>`.
         :param fetch_schema_from_transport: Boolean to indicate that if we want to fetch
                 the schema from the transport using an introspection query.
-        :param introspection_args: arguments passed to the get_introspection_query
-                method of graphql-core.
+        :param introspection_args: arguments passed to the
+                :meth:`gql.utilities.get_introspection_query_ast` method.
         :param execute_timeout: The maximum time in seconds for the execution of a
                 request before a TimeoutError is raised. Only used for async transports.
                 Passing None results in waiting forever for a response.
@@ -1289,8 +1288,10 @@ class SyncClientSession:
 
         Don't use this function and instead set the fetch_schema_from_transport
         attribute to True"""
-        introspection_query = get_introspection_query(**self.client.introspection_args)
-        execution_result = self.transport.execute(parse(introspection_query))
+        introspection_query = get_introspection_query_ast(
+            **self.client.introspection_args
+        )
+        execution_result = self.transport.execute(introspection_query)
 
         self.client._build_schema_from_introspection(execution_result)
 
@@ -1657,8 +1658,10 @@ class AsyncClientSession:
 
         Don't use this function and instead set the fetch_schema_from_transport
         attribute to True"""
-        introspection_query = get_introspection_query(**self.client.introspection_args)
-        execution_result = await self.transport.execute(parse(introspection_query))
+        introspection_query = get_introspection_query_ast(
+            **self.client.introspection_args
+        )
+        execution_result = await self.transport.execute(introspection_query)
 
         self.client._build_schema_from_introspection(execution_result)
 

--- a/gql/utilities/node_tree.py
+++ b/gql/utilities/node_tree.py
@@ -19,7 +19,7 @@ def _node_tree_recursive(
         results.append("  " * indent + f"{type(obj).__name__}")
 
         try:
-            keys = obj.keys
+            keys = sorted(obj.keys)
         except AttributeError:
             # If the object has no keys attribute, print its repr and return.
             results.append("  " * (indent + 1) + repr(obj))
@@ -69,6 +69,9 @@ def node_tree(
     """Method which returns a tree of Node elements as a String.
 
     Useful to debug deep DocumentNode instances created by gql or dsl_gql.
+
+    NOTE: from gql version 3.6.0b4 the elements of each node are sorted to ignore
+          small changes in graphql-core
 
     WARNING: the output of this method is not guaranteed and may change without notice.
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-core>=3.2,<3.2.4",
+    "graphql-core>=3.2,<3.2.5",
     "yarl>=1.6,<2.0",
     "backoff>=1.11.1,<3.0",
     "anyio>=3.0,<5",

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -984,18 +984,36 @@ def test_get_introspection_query_ast(option):
         specified_by_url=option,
         directive_is_repeatable=option,
         schema_description=option,
+        input_value_deprecation=option,
     )
     dsl_introspection_query = get_introspection_query_ast(
         descriptions=option,
         specified_by_url=option,
         directive_is_repeatable=option,
         schema_description=option,
+        input_value_deprecation=option,
     )
 
-    assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
-    assert node_tree(dsl_introspection_query) == node_tree(
-        gql(print_ast(dsl_introspection_query))
-    )
+    try:
+        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert node_tree(dsl_introspection_query) == node_tree(
+            gql(print_ast(dsl_introspection_query))
+        )
+    except AssertionError:
+
+        # From graphql-core version 3.3.0a7, there is two more type recursion levels
+        dsl_introspection_query = get_introspection_query_ast(
+            descriptions=option,
+            specified_by_url=option,
+            directive_is_repeatable=option,
+            schema_description=option,
+            input_value_deprecation=option,
+            type_recursion_level=9,
+        )
+        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert node_tree(dsl_introspection_query) == node_tree(
+            gql(print_ast(dsl_introspection_query))
+        )
 
 
 def test_typename_aliased(ds):
@@ -1028,11 +1046,10 @@ def test_node_tree_with_loc(ds):
 
     node_tree_result = """
 DocumentNode
-  loc:
-    Location
-      <Location 0:43>
   definitions:
     OperationDefinitionNode
+      directives:
+        empty tuple
       loc:
         Location
           <Location 0:43>
@@ -1043,10 +1060,8 @@ DocumentNode
               <Location 6:17>
           value:
             'GetHeroName'
-      directives:
-        empty tuple
-      variable_definitions:
-        empty tuple
+      operation:
+        <OperationType.QUERY: 'query'>
       selection_set:
         SelectionSetNode
           loc:
@@ -1054,13 +1069,15 @@ DocumentNode
               <Location 18:43>
           selections:
             FieldNode
+              alias:
+                None
+              arguments:
+                empty tuple
+              directives:
+                empty tuple
               loc:
                 Location
                   <Location 22:41>
-              directives:
-                empty tuple
-              alias:
-                None
               name:
                 NameNode
                   loc:
@@ -1068,8 +1085,6 @@ DocumentNode
                       <Location 22:26>
                   value:
                     'hero'
-              arguments:
-                empty tuple
               nullability_assertion:
                 None
               selection_set:
@@ -1079,13 +1094,15 @@ DocumentNode
                       <Location 27:41>
                   selections:
                     FieldNode
+                      alias:
+                        None
+                      arguments:
+                        empty tuple
+                      directives:
+                        empty tuple
                       loc:
                         Location
                           <Location 33:37>
-                      directives:
-                        empty tuple
-                      alias:
-                        None
                       name:
                         NameNode
                           loc:
@@ -1093,23 +1110,23 @@ DocumentNode
                               <Location 33:37>
                           value:
                             'name'
-                      arguments:
-                        empty tuple
                       nullability_assertion:
                         None
                       selection_set:
                         None
-      operation:
-        <OperationType.QUERY: 'query'>
+      variable_definitions:
+        empty tuple
+  loc:
+    Location
+      <Location 0:43>
 """.strip()
 
     node_tree_result_stable = """
 DocumentNode
-  loc:
-    Location
-      <Location 0:43>
   definitions:
     OperationDefinitionNode
+      directives:
+        empty tuple
       loc:
         Location
           <Location 0:43>
@@ -1120,10 +1137,8 @@ DocumentNode
               <Location 6:17>
           value:
             'GetHeroName'
-      directives:
-        empty tuple
-      variable_definitions:
-        empty tuple
+      operation:
+        <OperationType.QUERY: 'query'>
       selection_set:
         SelectionSetNode
           loc:
@@ -1131,13 +1146,15 @@ DocumentNode
               <Location 18:43>
           selections:
             FieldNode
+              alias:
+                None
+              arguments:
+                empty tuple
+              directives:
+                empty tuple
               loc:
                 Location
                   <Location 22:41>
-              directives:
-                empty tuple
-              alias:
-                None
               name:
                 NameNode
                   loc:
@@ -1145,8 +1162,6 @@ DocumentNode
                       <Location 22:26>
                   value:
                     'hero'
-              arguments:
-                empty tuple
               selection_set:
                 SelectionSetNode
                   loc:
@@ -1154,13 +1169,15 @@ DocumentNode
                       <Location 27:41>
                   selections:
                     FieldNode
+                      alias:
+                        None
+                      arguments:
+                        empty tuple
+                      directives:
+                        empty tuple
                       loc:
                         Location
                           <Location 33:37>
-                      directives:
-                        empty tuple
-                      alias:
-                        None
                       name:
                         NameNode
                           loc:
@@ -1168,13 +1185,16 @@ DocumentNode
                               <Location 33:37>
                           value:
                             'name'
-                      arguments:
-                        empty tuple
                       selection_set:
                         None
-      operation:
-        <OperationType.QUERY: 'query'>
+      variable_definitions:
+        empty tuple
+  loc:
+    Location
+      <Location 0:43>
 """.strip()
+
+    print(node_tree(document, ignore_loc=False))
 
     try:
         assert node_tree(document, ignore_loc=False) == node_tree_result


### PR DESCRIPTION
Retrofit the commits of master branch into the stable branch to allow to use graphql-core 3.2.4 which works with Python 3.14

- #523
- #524
- #521

Bump graphql-core to <3.2.5

Fix issue #534