### PR TITLE
chore: Update pytest to 8.3.4 and pytest-asyncio to 0.25.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ dynamic = ["authors", "classifiers", "dependencies", "description", "entry-point
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ console_scripts = [
 
 tests_requires = [
     "parse==1.15.0",
-    "pytest==7.4.2",
-    "pytest-asyncio==0.21.1",
+    "pytest==8.3.4",
+    "pytest-asyncio==0.25.3",
     "pytest-console-scripts==1.4.1",
     "pytest-cov==5.0.0",
     "vcrpy==7.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,9 +639,9 @@ async def client_and_server(server):
     # Generate transport to connect to the server fixture
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         # Yield both client session and server
         yield session, server
@@ -659,9 +659,9 @@ async def aiohttp_client_and_server(server):
     # Generate transport to connect to the server fixture
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         # Yield both client session and server
         yield session, server
@@ -681,9 +681,9 @@ async def aiohttp_client_and_aiohttp_ws_server(aiohttp_ws_server):
     # Generate transport to connect to the server fixture
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         # Yield both client session and server
         yield session, server
@@ -699,12 +699,12 @@ async def client_and_graphqlws_server(graphqlws_server):
     # Generate transport to connect to the server fixture
     path = "/graphql"
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}{path}"
-    sample_transport = WebsocketsTransport(
+    transport = WebsocketsTransport(
         url=url,
         subprotocols=[WebsocketsTransport.GRAPHQLWS_SUBPROTOCOL],
     )
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         # Yield both client session and server
         yield session, graphqlws_server
@@ -720,12 +720,12 @@ async def client_and_aiohttp_websocket_graphql_server(graphqlws_server):
     # Generate transport to connect to the server fixture
     path = "/graphql"
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}{path}"
-    sample_transport = AIOHTTPWebsocketsTransport(
+    transport = AIOHTTPWebsocketsTransport(
         url=url,
         subprotocols=[AIOHTTPWebsocketsTransport.GRAPHQLWS_SUBPROTOCOL],
     )
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         # Yield both client session and server
         yield session, graphqlws_server
@@ -733,11 +733,12 @@ async def client_and_aiohttp_websocket_graphql_server(graphqlws_server):
 
 @pytest_asyncio.fixture
 async def run_sync_test():
-    async def run_sync_test_inner(event_loop, server, test_function):
+    async def run_sync_test_inner(server, test_function):
         """This function will run the test in a different Thread.
 
         This allows us to run sync code while aiohttp server can still run.
         """
+        event_loop = asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=2)
         test_task = event_loop.run_in_executor(executor, test_function)
 

--- a/tests/custom_scalars/test_money.py
+++ b/tests/custom_scalars/test_money.py
@@ -491,7 +491,7 @@ async def make_sync_money_transport(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_custom_scalar_in_output_with_transport(event_loop, aiohttp_server):
+async def test_custom_scalar_in_output_with_transport(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -509,7 +509,7 @@ async def test_custom_scalar_in_output_with_transport(event_loop, aiohttp_server
 
 
 @pytest.mark.asyncio
-async def test_custom_scalar_in_input_query_with_transport(event_loop, aiohttp_server):
+async def test_custom_scalar_in_input_query_with_transport(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -532,7 +532,7 @@ async def test_custom_scalar_in_input_query_with_transport(event_loop, aiohttp_s
 
 @pytest.mark.asyncio
 async def test_custom_scalar_in_input_variable_values_with_transport(
-    event_loop, aiohttp_server
+    aiohttp_server
 ):
 
     transport = await make_money_transport(aiohttp_server)
@@ -556,7 +556,7 @@ async def test_custom_scalar_in_input_variable_values_with_transport(
 
 @pytest.mark.asyncio
 async def test_custom_scalar_in_input_variable_values_split_with_transport(
-    event_loop, aiohttp_server
+    aiohttp_server
 ):
 
     transport = await make_money_transport(aiohttp_server)
@@ -581,7 +581,7 @@ query myquery($amount: Float, $currency: String) {
 
 
 @pytest.mark.asyncio
-async def test_custom_scalar_serialize_variables(event_loop, aiohttp_server):
+async def test_custom_scalar_serialize_variables(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -603,7 +603,7 @@ async def test_custom_scalar_serialize_variables(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_custom_scalar_serialize_variables_no_schema(event_loop, aiohttp_server):
+async def test_custom_scalar_serialize_variables_no_schema(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -623,7 +623,7 @@ async def test_custom_scalar_serialize_variables_no_schema(event_loop, aiohttp_s
 
 @pytest.mark.asyncio
 async def test_custom_scalar_serialize_variables_schema_from_introspection(
-    event_loop, aiohttp_server
+    aiohttp_server
 ):
 
     transport = await make_money_transport(aiohttp_server)
@@ -656,7 +656,7 @@ async def test_custom_scalar_serialize_variables_schema_from_introspection(
 
 
 @pytest.mark.asyncio
-async def test_update_schema_scalars(event_loop, aiohttp_server):
+async def test_update_schema_scalars(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -735,7 +735,7 @@ def test_update_schema_scalars_scalar_type_is_not_a_scalar_in_schema():
 @pytest.mark.asyncio
 @pytest.mark.requests
 async def test_custom_scalar_serialize_variables_sync_transport(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
 
     server, transport = await make_sync_money_transport(aiohttp_server)
@@ -754,13 +754,13 @@ async def test_custom_scalar_serialize_variables_sync_transport(
             print(f"result = {result!r}")
             assert result["toEuros"] == 5
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.asyncio
 @pytest.mark.requests
 async def test_custom_scalar_serialize_variables_sync_transport_2(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     server, transport = await make_sync_money_transport(aiohttp_server)
 
@@ -783,7 +783,7 @@ async def test_custom_scalar_serialize_variables_sync_transport_2(
             assert results[0]["toEuros"] == 5
             assert results[1]["toEuros"] == 5
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 def test_serialize_value_with_invalid_type():
@@ -818,7 +818,7 @@ def test_serialize_value_with_nullable_type():
 
 
 @pytest.mark.asyncio
-async def test_gql_cli_print_schema(event_loop, aiohttp_server, capsys):
+async def test_gql_cli_print_schema(aiohttp_server, capsys):
 
     from gql.cli import get_parser, main
 

--- a/tests/custom_scalars/test_money.py
+++ b/tests/custom_scalars/test_money.py
@@ -531,9 +531,7 @@ async def test_custom_scalar_in_input_query_with_transport(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_custom_scalar_in_input_variable_values_with_transport(
-    aiohttp_server
-):
+async def test_custom_scalar_in_input_variable_values_with_transport(aiohttp_server):
 
     transport = await make_money_transport(aiohttp_server)
 
@@ -556,7 +554,7 @@ async def test_custom_scalar_in_input_variable_values_with_transport(
 
 @pytest.mark.asyncio
 async def test_custom_scalar_in_input_variable_values_split_with_transport(
-    aiohttp_server
+    aiohttp_server,
 ):
 
     transport = await make_money_transport(aiohttp_server)
@@ -623,7 +621,7 @@ async def test_custom_scalar_serialize_variables_no_schema(aiohttp_server):
 
 @pytest.mark.asyncio
 async def test_custom_scalar_serialize_variables_schema_from_introspection(
-    aiohttp_server
+    aiohttp_server,
 ):
 
     transport = await make_money_transport(aiohttp_server)

--- a/tests/starwars/test_introspection.py
+++ b/tests/starwars/test_introspection.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.aiohttp
 
 
 @pytest.mark.asyncio
-async def test_starwars_introspection_args(event_loop, aiohttp_server):
+async def test_starwars_introspection_args(aiohttp_server):
 
     transport = await make_starwars_transport(aiohttp_server)
 

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -1,4 +1,5 @@
 import copy
+
 import pytest
 
 from gql import Client, gql

--- a/tests/starwars/test_validation.py
+++ b/tests/starwars/test_validation.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 from gql import Client, gql
@@ -62,7 +63,8 @@ def introspection_schema():
 
 @pytest.fixture
 def introspection_schema_empty_directives():
-    introspection = StarWarsIntrospection
+    # Create a deep copy to avoid modifying the original
+    introspection = copy.deepcopy(StarWarsIntrospection)
 
     # Simulate an empty dictionary for directives
     introspection["__schema"]["directives"] = []
@@ -72,7 +74,8 @@ def introspection_schema_empty_directives():
 
 @pytest.fixture
 def introspection_schema_no_directives():
-    introspection = StarWarsIntrospection
+    # Create a deep copy to avoid modifying the original
+    introspection = copy.deepcopy(StarWarsIntrospection)
 
     # Simulate no directives key
     del introspection["__schema"]["directives"]

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.aiohttp
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query(event_loop, aiohttp_server):
+async def test_aiohttp_query(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -84,7 +84,7 @@ async def test_aiohttp_query(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_ignore_backend_content_type(event_loop, aiohttp_server):
+async def test_aiohttp_ignore_backend_content_type(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -113,7 +113,7 @@ async def test_aiohttp_ignore_backend_content_type(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_cookies(event_loop, aiohttp_server):
+async def test_aiohttp_cookies(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -146,7 +146,7 @@ async def test_aiohttp_cookies(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_error_code_401(event_loop, aiohttp_server):
+async def test_aiohttp_error_code_401(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -177,7 +177,7 @@ async def test_aiohttp_error_code_401(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_error_code_429(event_loop, aiohttp_server):
+async def test_aiohttp_error_code_429(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -224,7 +224,7 @@ async def test_aiohttp_error_code_429(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_error_code_500(event_loop, aiohttp_server):
+async def test_aiohttp_error_code_500(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -259,7 +259,7 @@ transport_query_error_responses = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("query_error", transport_query_error_responses)
-async def test_aiohttp_error_code(event_loop, aiohttp_server, query_error):
+async def test_aiohttp_error_code(aiohttp_server, query_error):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -314,7 +314,7 @@ invalid_protocol_responses = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("param", invalid_protocol_responses)
-async def test_aiohttp_invalid_protocol(event_loop, aiohttp_server, param):
+async def test_aiohttp_invalid_protocol(aiohttp_server, param):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -342,7 +342,7 @@ async def test_aiohttp_invalid_protocol(event_loop, aiohttp_server, param):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_subscribe_not_supported(event_loop, aiohttp_server):
+async def test_aiohttp_subscribe_not_supported(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -367,7 +367,7 @@ async def test_aiohttp_subscribe_not_supported(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_cannot_connect_twice(event_loop, aiohttp_server):
+async def test_aiohttp_cannot_connect_twice(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -389,7 +389,7 @@ async def test_aiohttp_cannot_connect_twice(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_cannot_execute_if_not_connected(event_loop, aiohttp_server):
+async def test_aiohttp_cannot_execute_if_not_connected(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -411,7 +411,7 @@ async def test_aiohttp_cannot_execute_if_not_connected(event_loop, aiohttp_serve
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_extra_args(event_loop, aiohttp_server):
+async def test_aiohttp_extra_args(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -458,7 +458,7 @@ query2_server_answer = '{"data": {"continent": {"name": "Europe"}}}'
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query_variable_values(event_loop, aiohttp_server):
+async def test_aiohttp_query_variable_values(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -490,7 +490,7 @@ async def test_aiohttp_query_variable_values(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query_variable_values_fix_issue_292(event_loop, aiohttp_server):
+async def test_aiohttp_query_variable_values_fix_issue_292(aiohttp_server):
     """Allow to specify variable_values without keyword.
 
     See https://github.com/graphql-python/gql/issues/292"""
@@ -525,7 +525,7 @@ async def test_aiohttp_query_variable_values_fix_issue_292(event_loop, aiohttp_s
 
 @pytest.mark.asyncio
 async def test_aiohttp_execute_running_in_thread(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -548,12 +548,12 @@ async def test_aiohttp_execute_running_in_thread(
 
         client.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.asyncio
 async def test_aiohttp_subscribe_running_in_thread(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -585,7 +585,7 @@ async def test_aiohttp_subscribe_running_in_thread(
             for result in client.subscribe(query):
                 pass
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_server_answer = '{"data":{"success":true}}'
@@ -640,7 +640,7 @@ async def single_upload_handler(request):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_file_upload(event_loop, aiohttp_server):
+async def test_aiohttp_file_upload(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -705,7 +705,7 @@ async def single_upload_handler_with_content_type(request):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_file_upload_with_content_type(event_loop, aiohttp_server):
+async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -744,7 +744,7 @@ async def test_aiohttp_file_upload_with_content_type(event_loop, aiohttp_server)
 
 @pytest.mark.asyncio
 async def test_aiohttp_file_upload_without_session(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -778,7 +778,7 @@ async def test_aiohttp_file_upload_without_session(
 
                 assert success
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 # This is a sample binary file content containing all possible byte values
@@ -813,7 +813,7 @@ async def binary_upload_handler(request):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_binary_file_upload(event_loop, aiohttp_server):
+async def test_aiohttp_binary_file_upload(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -848,7 +848,7 @@ async def test_aiohttp_binary_file_upload(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_stream_reader_upload(event_loop, aiohttp_server):
+async def test_aiohttp_stream_reader_upload(aiohttp_server):
     from aiohttp import web, ClientSession
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -885,7 +885,7 @@ async def test_aiohttp_stream_reader_upload(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_async_generator_upload(event_loop, aiohttp_server):
+async def test_aiohttp_async_generator_upload(aiohttp_server):
     import aiofiles
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -948,7 +948,7 @@ This file will also be sent in the GraphQL mutation
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_file_upload_two_files(event_loop, aiohttp_server):
+async def test_aiohttp_file_upload_two_files(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1039,7 +1039,7 @@ file_upload_mutation_3_map = '{"0": ["variables.files.0"], "1": ["variables.file
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_file_upload_list_of_two_files(event_loop, aiohttp_server):
+async def test_aiohttp_file_upload_list_of_two_files(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1111,7 +1111,7 @@ async def test_aiohttp_file_upload_list_of_two_files(event_loop, aiohttp_server)
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_using_cli(event_loop, aiohttp_server, monkeypatch, capsys):
+async def test_aiohttp_using_cli(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1148,7 +1148,7 @@ async def test_aiohttp_using_cli(event_loop, aiohttp_server, monkeypatch, capsys
 @pytest.mark.asyncio
 @pytest.mark.script_launch_mode("subprocess")
 async def test_aiohttp_using_cli_ep(
-    event_loop, aiohttp_server, monkeypatch, script_runner, run_sync_test
+    aiohttp_server, monkeypatch, script_runner, run_sync_test
 ):
     from aiohttp import web
 
@@ -1181,12 +1181,12 @@ async def test_aiohttp_using_cli_ep(
 
         assert received_answer == expected_answer
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.asyncio
 async def test_aiohttp_using_cli_invalid_param(
-    event_loop, aiohttp_server, monkeypatch, capsys
+    aiohttp_server, monkeypatch, capsys
 ):
     from aiohttp import web
 
@@ -1222,7 +1222,7 @@ async def test_aiohttp_using_cli_invalid_param(
 
 @pytest.mark.asyncio
 async def test_aiohttp_using_cli_invalid_query(
-    event_loop, aiohttp_server, monkeypatch, capsys
+    aiohttp_server, monkeypatch, capsys
 ):
     from aiohttp import web
 
@@ -1261,7 +1261,7 @@ query1_server_answer_with_extensions = (
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query_with_extensions(event_loop, aiohttp_server):
+async def test_aiohttp_query_with_extensions(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1291,7 +1291,7 @@ async def test_aiohttp_query_with_extensions(event_loop, aiohttp_server):
 @pytest.mark.parametrize("ssl_close_timeout", [0, 10])
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
 async def test_aiohttp_query_https(
-    event_loop, ssl_aiohttp_server, ssl_close_timeout, verify_https
+    ssl_aiohttp_server, ssl_close_timeout, verify_https
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -1339,7 +1339,7 @@ async def test_aiohttp_query_https(
 
 @pytest.mark.skip(reason="We will change the default to fix this in a future version")
 @pytest.mark.asyncio
-async def test_aiohttp_query_https_self_cert_fail(event_loop, ssl_aiohttp_server):
+async def test_aiohttp_query_https_self_cert_fail(ssl_aiohttp_server):
     """By default, we should verify the ssl certificate"""
     from aiohttp.client_exceptions import ClientConnectorCertificateError
     from aiohttp import web
@@ -1372,7 +1372,7 @@ async def test_aiohttp_query_https_self_cert_fail(event_loop, ssl_aiohttp_server
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query_https_self_cert_warn(event_loop, ssl_aiohttp_server):
+async def test_aiohttp_query_https_self_cert_warn(ssl_aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1397,7 +1397,7 @@ async def test_aiohttp_query_https_self_cert_warn(event_loop, ssl_aiohttp_server
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_error_fetching_schema(event_loop, aiohttp_server):
+async def test_aiohttp_error_fetching_schema(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1440,7 +1440,7 @@ async def test_aiohttp_error_fetching_schema(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_reconnecting_session(event_loop, aiohttp_server):
+async def test_aiohttp_reconnecting_session(aiohttp_server):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1479,7 +1479,7 @@ async def test_aiohttp_reconnecting_session(event_loop, aiohttp_server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("retries", [False, lambda e: e])
 async def test_aiohttp_reconnecting_session_retries(
-    event_loop, aiohttp_server, retries
+    aiohttp_server, retries
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -1512,7 +1512,7 @@ async def test_aiohttp_reconnecting_session_retries(
 
 @pytest.mark.asyncio
 async def test_aiohttp_reconnecting_session_start_connecting_task_twice(
-    event_loop, aiohttp_server, caplog
+    aiohttp_server, caplog
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -1546,7 +1546,7 @@ async def test_aiohttp_reconnecting_session_start_connecting_task_twice(
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_json_serializer(event_loop, aiohttp_server, caplog):
+async def test_aiohttp_json_serializer(aiohttp_server, caplog):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1602,7 +1602,7 @@ query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_json_deserializer(event_loop, aiohttp_server):
+async def test_aiohttp_json_deserializer(aiohttp_server):
     from aiohttp import web
     from decimal import Decimal
     from functools import partial
@@ -1641,7 +1641,7 @@ async def test_aiohttp_json_deserializer(event_loop, aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_connector_owner_false(event_loop, aiohttp_server):
+async def test_aiohttp_connector_owner_false(aiohttp_server):
     from aiohttp import web, TCPConnector
     from gql.transport.aiohttp import AIOHTTPTransport
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -524,9 +524,7 @@ async def test_aiohttp_query_variable_values_fix_issue_292(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_execute_running_in_thread(
-    aiohttp_server, run_sync_test
-):
+async def test_aiohttp_execute_running_in_thread(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -552,9 +550,7 @@ async def test_aiohttp_execute_running_in_thread(
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_subscribe_running_in_thread(
-    aiohttp_server, run_sync_test
-):
+async def test_aiohttp_subscribe_running_in_thread(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -743,9 +739,7 @@ async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_file_upload_without_session(
-    aiohttp_server, run_sync_test
-):
+async def test_aiohttp_file_upload_without_session(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1185,9 +1179,7 @@ async def test_aiohttp_using_cli_ep(
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_using_cli_invalid_param(
-    aiohttp_server, monkeypatch, capsys
-):
+async def test_aiohttp_using_cli_invalid_param(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1221,9 +1213,7 @@ async def test_aiohttp_using_cli_invalid_param(
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_using_cli_invalid_query(
-    aiohttp_server, monkeypatch, capsys
-):
+async def test_aiohttp_using_cli_invalid_query(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1290,9 +1280,7 @@ async def test_aiohttp_query_with_extensions(aiohttp_server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ssl_close_timeout", [0, 10])
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
-async def test_aiohttp_query_https(
-    ssl_aiohttp_server, ssl_close_timeout, verify_https
-):
+async def test_aiohttp_query_https(ssl_aiohttp_server, ssl_close_timeout, verify_https):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -1478,9 +1466,7 @@ async def test_aiohttp_reconnecting_session(aiohttp_server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("retries", [False, lambda e: e])
-async def test_aiohttp_reconnecting_session_retries(
-    aiohttp_server, retries
-):
+async def test_aiohttp_reconnecting_session_retries(aiohttp_server, retries):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
 

--- a/tests/test_aiohttp_online.py
+++ b/tests/test_aiohttp_online.py
@@ -11,7 +11,7 @@ from gql.transport.exceptions import TransportQueryError
 @pytest.mark.aiohttp
 @pytest.mark.online
 @pytest.mark.asyncio
-async def test_aiohttp_simple_query(event_loop):
+async def test_aiohttp_simple_query():
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -56,7 +56,7 @@ async def test_aiohttp_simple_query(event_loop):
 @pytest.mark.aiohttp
 @pytest.mark.online
 @pytest.mark.asyncio
-async def test_aiohttp_invalid_query(event_loop):
+async def test_aiohttp_invalid_query():
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -85,7 +85,7 @@ async def test_aiohttp_invalid_query(event_loop):
 @pytest.mark.online
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @pytest.mark.asyncio
-async def test_aiohttp_two_queries_in_parallel_using_two_tasks(event_loop):
+async def test_aiohttp_two_queries_in_parallel_using_two_tasks():
 
     from gql.transport.aiohttp import AIOHTTPTransport
 

--- a/tests/test_aiohttp_websocket_exceptions.py
+++ b/tests/test_aiohttp_websocket_exceptions.py
@@ -40,9 +40,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_aiohttp_websocket_invalid_query(
-    aiohttp_client_and_server, query_str
-):
+async def test_aiohttp_websocket_invalid_query(aiohttp_client_and_server, query_str):
 
     session, server = aiohttp_client_and_server
 
@@ -115,9 +113,7 @@ async def server_no_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_aiohttp_websocket_server_does_not_send_ack(
-    server, query_str
-):
+async def test_aiohttp_websocket_server_does_not_send_ack(server, query_str):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -241,9 +237,7 @@ sending_bytes = [b"\x01\x02\x03"]
     ],
     indirect=True,
 )
-async def test_aiohttp_websocket_transport_protocol_errors(
-    aiohttp_client_and_server
-):
+async def test_aiohttp_websocket_transport_protocol_errors(aiohttp_client_and_server):
 
     session, server = aiohttp_client_and_server
 
@@ -301,9 +295,7 @@ async def server_closing_after_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_closing_after_ack], indirect=True)
-async def test_aiohttp_websocket_server_closing_after_ack(
-    aiohttp_client_and_server
-):
+async def test_aiohttp_websocket_server_closing_after_ack(aiohttp_client_and_server):
 
     session, server = aiohttp_client_and_server
 
@@ -325,9 +317,7 @@ async def server_sending_invalid_query_errors(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
-async def test_aiohttp_websocket_server_sending_invalid_query_errors(
-    server
-):
+async def test_aiohttp_websocket_server_sending_invalid_query_errors(server):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -373,9 +363,7 @@ async def test_aiohttp_websocket_non_regression_bug_105(server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
-async def test_aiohttp_websocket_using_cli_invalid_query(
-    server, monkeypatch, capsys
-):
+async def test_aiohttp_websocket_using_cli_invalid_query(server, monkeypatch, capsys):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")

--- a/tests/test_aiohttp_websocket_exceptions.py
+++ b/tests/test_aiohttp_websocket_exceptions.py
@@ -41,7 +41,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_invalid_query(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -82,7 +82,7 @@ async def server_invalid_subscription(ws):
 @pytest.mark.parametrize("server", [server_invalid_subscription], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_subscription_str])
 async def test_aiohttp_websocket_invalid_subscription(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -116,7 +116,7 @@ async def server_no_ack(ws):
 @pytest.mark.parametrize("server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_server_does_not_send_ack(
-    event_loop, server, query_str
+    server, query_str
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -141,7 +141,7 @@ async def server_connection_error(ws):
 @pytest.mark.parametrize("server", [server_connection_error], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_sending_invalid_data(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -171,7 +171,7 @@ async def server_invalid_payload(ws):
 @pytest.mark.parametrize("server", [server_invalid_payload], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_sending_invalid_payload(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -242,7 +242,7 @@ sending_bytes = [b"\x01\x02\x03"]
     indirect=True,
 )
 async def test_aiohttp_websocket_transport_protocol_errors(
-    event_loop, aiohttp_client_and_server
+    aiohttp_client_and_server
 ):
 
     session, server = aiohttp_client_and_server
@@ -261,7 +261,7 @@ async def server_without_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_without_ack], indirect=True)
-async def test_aiohttp_websocket_server_does_not_ack(event_loop, server):
+async def test_aiohttp_websocket_server_does_not_ack(server):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -280,7 +280,7 @@ async def server_closing_directly(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_closing_directly], indirect=True)
-async def test_aiohttp_websocket_server_closing_directly(event_loop, server):
+async def test_aiohttp_websocket_server_closing_directly(server):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -302,7 +302,7 @@ async def server_closing_after_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_closing_after_ack], indirect=True)
 async def test_aiohttp_websocket_server_closing_after_ack(
-    event_loop, aiohttp_client_and_server
+    aiohttp_client_and_server
 ):
 
     session, server = aiohttp_client_and_server
@@ -326,7 +326,7 @@ async def server_sending_invalid_query_errors(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
 async def test_aiohttp_websocket_server_sending_invalid_query_errors(
-    event_loop, server
+    server
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -342,7 +342,7 @@ async def test_aiohttp_websocket_server_sending_invalid_query_errors(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
-async def test_aiohttp_websocket_non_regression_bug_105(event_loop, server):
+async def test_aiohttp_websocket_non_regression_bug_105(server):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
     # This test will check a fix to a race condition which happens if the user is trying
@@ -374,7 +374,7 @@ async def test_aiohttp_websocket_non_regression_bug_105(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
 async def test_aiohttp_websocket_using_cli_invalid_query(
-    event_loop, server, monkeypatch, capsys
+    server, monkeypatch, capsys
 ):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"

--- a/tests/test_aiohttp_websocket_graphqlws_exceptions.py
+++ b/tests/test_aiohttp_websocket_graphqlws_exceptions.py
@@ -40,7 +40,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.parametrize("graphqlws_server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_graphqlws_invalid_query(
-    event_loop, client_and_aiohttp_websocket_graphql_server, query_str
+    client_and_aiohttp_websocket_graphql_server, query_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -83,7 +83,7 @@ async def server_invalid_subscription(ws):
 )
 @pytest.mark.parametrize("query_str", [invalid_subscription_str])
 async def test_aiohttp_websocket_graphqlws_invalid_subscription(
-    event_loop, client_and_aiohttp_websocket_graphql_server, query_str
+    client_and_aiohttp_websocket_graphql_server, query_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -111,7 +111,7 @@ async def server_no_ack(ws):
 @pytest.mark.parametrize("graphqlws_server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_aiohttp_websocket_graphqlws_server_does_not_send_ack(
-    event_loop, graphqlws_server, query_str
+    graphqlws_server, query_str
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -143,7 +143,7 @@ async def server_invalid_query(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_invalid_query], indirect=True)
 async def test_aiohttp_websocket_graphqlws_sending_invalid_query(
-    event_loop, client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -197,7 +197,7 @@ sending_bytes = [b"\x01\x02\x03"]
     indirect=True,
 )
 async def test_aiohttp_websocket_graphqlws_transport_protocol_errors(
-    event_loop, client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -217,7 +217,7 @@ async def server_without_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_without_ack], indirect=True)
 async def test_aiohttp_websocket_graphqlws_server_does_not_ack(
-    event_loop, graphqlws_server
+    graphqlws_server
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -238,7 +238,7 @@ async def server_closing_directly(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_directly], indirect=True)
 async def test_aiohttp_websocket_graphqlws_server_closing_directly(
-    event_loop, graphqlws_server
+    graphqlws_server
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -261,7 +261,7 @@ async def server_closing_after_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_after_ack], indirect=True)
 async def test_aiohttp_websocket_graphqlws_server_closing_after_ack(
-    event_loop, client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server
 ):
 
     session, _ = client_and_aiohttp_websocket_graphql_server

--- a/tests/test_aiohttp_websocket_graphqlws_exceptions.py
+++ b/tests/test_aiohttp_websocket_graphqlws_exceptions.py
@@ -143,7 +143,7 @@ async def server_invalid_query(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_invalid_query], indirect=True)
 async def test_aiohttp_websocket_graphqlws_sending_invalid_query(
-    client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server,
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -197,7 +197,7 @@ sending_bytes = [b"\x01\x02\x03"]
     indirect=True,
 )
 async def test_aiohttp_websocket_graphqlws_transport_protocol_errors(
-    client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server,
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -216,9 +216,7 @@ async def server_without_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_without_ack], indirect=True)
-async def test_aiohttp_websocket_graphqlws_server_does_not_ack(
-    graphqlws_server
-):
+async def test_aiohttp_websocket_graphqlws_server_does_not_ack(graphqlws_server):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
@@ -237,9 +235,7 @@ async def server_closing_directly(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_directly], indirect=True)
-async def test_aiohttp_websocket_graphqlws_server_closing_directly(
-    graphqlws_server
-):
+async def test_aiohttp_websocket_graphqlws_server_closing_directly(graphqlws_server):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -261,7 +257,7 @@ async def server_closing_after_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_after_ack], indirect=True)
 async def test_aiohttp_websocket_graphqlws_server_closing_after_ack(
-    client_and_aiohttp_websocket_graphql_server
+    client_and_aiohttp_websocket_graphql_server,
 ):
 
     session, _ = client_and_aiohttp_websocket_graphql_server

--- a/tests/test_aiohttp_websocket_graphqlws_subscription.py
+++ b/tests/test_aiohttp_websocket_graphqlws_subscription.py
@@ -229,7 +229,7 @@ countdown_subscription_str = """
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -252,7 +252,7 @@ async def test_aiohttp_websocket_graphqlws_subscription(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_break(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -283,7 +283,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_break(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_task_cancel(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -322,7 +322,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_task_cancel(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_close_transport(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -387,7 +387,7 @@ async def server_countdown_close_connection_in_middle(ws):
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_server_connection_closed(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
     session, _ = client_and_aiohttp_websocket_graphql_server
 
@@ -408,7 +408,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_server_connection_closed
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_operation_name(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -438,7 +438,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_operation_name(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive(
-    event_loop, client_and_aiohttp_websocket_graphql_server, subscription_str
+    client_and_aiohttp_websocket_graphql_server, subscription_str
 ):
 
     session, server = client_and_aiohttp_websocket_graphql_server
@@ -468,7 +468,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive_with_timeout_ok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -502,7 +502,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive_with_time
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive_with_timeout_nok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -537,7 +537,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_keepalive_with_time
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_ping_interval_ok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -573,7 +573,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_ping_interval_ok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_with_ping_interval_nok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -606,7 +606,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_ping_interval_nok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_manual_pings_with_payload(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -648,7 +648,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_manual_pings_with_payloa
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_manual_pong_with_payload(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -781,7 +781,7 @@ def test_aiohttp_websocket_graphqlws_subscription_sync_graceful_shutdown(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_graphqlws_subscription_running_in_thread(
-    event_loop, graphqlws_server, subscription_str, run_sync_test
+    graphqlws_server, subscription_str, run_sync_test
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -805,7 +805,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_running_in_thread(
 
         assert count == -1
 
-    await run_sync_test(event_loop, graphqlws_server, test_code)
+    await run_sync_test(graphqlws_server, test_code)
 
 
 @pytest.mark.asyncio
@@ -815,7 +815,7 @@ async def test_aiohttp_websocket_graphqlws_subscription_running_in_thread(
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 @pytest.mark.parametrize("execute_instead_of_subscribe", [False, True])
 async def test_aiohttp_websocket_graphqlws_subscription_reconnecting_session(
-    event_loop, graphqlws_server, subscription_str, execute_instead_of_subscribe
+    graphqlws_server, subscription_str, execute_instead_of_subscribe
 ):
 
     from gql.transport.exceptions import TransportClosed

--- a/tests/test_aiohttp_websocket_query.py
+++ b/tests/test_aiohttp_websocket_query.py
@@ -52,7 +52,7 @@ server1_answers = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_starting_client_in_context_manager(
-    event_loop, aiohttp_ws_server
+    aiohttp_ws_server
 ):
 
     server = aiohttp_ws_server
@@ -101,7 +101,7 @@ async def test_aiohttp_websocket_starting_client_in_context_manager(
 @pytest.mark.parametrize("ssl_close_timeout", [0, 10])
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
 async def test_aiohttp_websocket_using_ssl_connection(
-    event_loop, ws_ssl_server, ssl_close_timeout, verify_https
+    ws_ssl_server, ssl_close_timeout, verify_https
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -152,7 +152,7 @@ async def test_aiohttp_websocket_using_ssl_connection(
 @pytest.mark.parametrize("ssl_close_timeout", [10])
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_aiohttp_websocket_using_ssl_connection_self_cert_fail(
-    event_loop, ws_ssl_server, ssl_close_timeout, verify_https
+    ws_ssl_server, ssl_close_timeout, verify_https
 ):
 
     from aiohttp.client_exceptions import ClientConnectorCertificateError
@@ -201,7 +201,7 @@ async def test_aiohttp_websocket_using_ssl_connection_self_cert_fail(
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_simple_query(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -225,7 +225,7 @@ server1_two_answers_in_series = [
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_two_queries_in_series(
-    event_loop, aiohttp_client_and_aiohttp_ws_server, query_str
+    aiohttp_client_and_aiohttp_ws_server, query_str
 ):
 
     session, server = aiohttp_client_and_aiohttp_ws_server
@@ -262,7 +262,7 @@ async def server1_two_queries_in_parallel(ws):
 @pytest.mark.parametrize("server", [server1_two_queries_in_parallel], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_two_queries_in_parallel(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -310,7 +310,7 @@ async def server_closing_while_we_are_doing_something_else(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_server_closing_after_first_query(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -342,7 +342,7 @@ ignore_invalid_id_answers = [
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_ignore_invalid_id(
-    event_loop, aiohttp_client_and_aiohttp_ws_server, query_str
+    aiohttp_client_and_aiohttp_ws_server, query_str
 ):
 
     session, server = aiohttp_client_and_aiohttp_ws_server
@@ -379,7 +379,7 @@ async def assert_client_is_working(session):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_multiple_connections_in_series(
-    event_loop, aiohttp_ws_server
+    aiohttp_ws_server
 ):
 
     server = aiohttp_ws_server
@@ -407,7 +407,7 @@ async def test_aiohttp_websocket_multiple_connections_in_series(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_multiple_connections_in_parallel(
-    event_loop, aiohttp_ws_server
+    aiohttp_ws_server
 ):
 
     server = aiohttp_ws_server
@@ -431,7 +431,7 @@ async def test_aiohttp_websocket_multiple_connections_in_parallel(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_trying_to_connect_to_already_connected_transport(
-    event_loop, aiohttp_ws_server
+    aiohttp_ws_server
 ):
     server = aiohttp_ws_server
 
@@ -482,7 +482,7 @@ async def server_with_authentication_in_connection_init_payload(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_connect_success_with_authentication_in_connection_init(
-    event_loop, server, query_str
+    server, query_str
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -518,7 +518,7 @@ async def test_aiohttp_websocket_connect_success_with_authentication_in_connecti
 @pytest.mark.parametrize("query_str", [query1_str])
 @pytest.mark.parametrize("init_payload", [{}, {"Authorization": "invalid_code"}])
 async def test_aiohttp_websocket_connect_failed_with_authentication_in_connection_init(
-    event_loop, server, query_str, init_payload
+    server, query_str, init_payload
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -585,7 +585,7 @@ def test_aiohttp_websocket_execute_sync(aiohttp_ws_server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_add_extra_parameters_to_connect(
-    event_loop, aiohttp_ws_server
+    aiohttp_ws_server
 ):
 
     server = aiohttp_ws_server
@@ -628,7 +628,7 @@ async def server_sending_keep_alive_before_connection_ack(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_non_regression_bug_108(
-    event_loop, aiohttp_client_and_server, query_str
+    aiohttp_client_and_server, query_str
 ):
 
     # This test will check that we now ignore keepalive message
@@ -653,7 +653,7 @@ async def test_aiohttp_websocket_non_regression_bug_108(
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 @pytest.mark.parametrize("transport_arg", [[], ["--transport=aiohttp_websockets"]])
 async def test_aiohttp_websocket_using_cli(
-    event_loop, aiohttp_ws_server, transport_arg, monkeypatch, capsys
+    aiohttp_ws_server, transport_arg, monkeypatch, capsys
 ):
 
     """
@@ -717,7 +717,7 @@ server1_answers_with_extensions = [
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_aiohttp_websocket_simple_query_with_extensions(
-    event_loop, aiohttp_client_and_aiohttp_ws_server, query_str
+    aiohttp_client_and_aiohttp_ws_server, query_str
 ):
 
     session, server = aiohttp_client_and_aiohttp_ws_server
@@ -731,7 +731,7 @@ async def test_aiohttp_websocket_simple_query_with_extensions(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
-async def test_aiohttp_websocket_connector_owner_false(event_loop, aiohttp_ws_server):
+async def test_aiohttp_websocket_connector_owner_false(aiohttp_ws_server):
 
     server = aiohttp_ws_server
 

--- a/tests/test_aiohttp_websocket_query.py
+++ b/tests/test_aiohttp_websocket_query.py
@@ -51,9 +51,7 @@ server1_answers = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
-async def test_aiohttp_websocket_starting_client_in_context_manager(
-    aiohttp_ws_server
-):
+async def test_aiohttp_websocket_starting_client_in_context_manager(aiohttp_ws_server):
 
     server = aiohttp_ws_server
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -200,9 +198,7 @@ async def test_aiohttp_websocket_using_ssl_connection_self_cert_fail(
 @pytest.mark.websockets
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_aiohttp_websocket_simple_query(
-    aiohttp_client_and_server, query_str
-):
+async def test_aiohttp_websocket_simple_query(aiohttp_client_and_server, query_str):
 
     session, server = aiohttp_client_and_server
 
@@ -378,9 +374,7 @@ async def assert_client_is_working(session):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
-async def test_aiohttp_websocket_multiple_connections_in_series(
-    aiohttp_ws_server
-):
+async def test_aiohttp_websocket_multiple_connections_in_series(aiohttp_ws_server):
 
     server = aiohttp_ws_server
 
@@ -406,9 +400,7 @@ async def test_aiohttp_websocket_multiple_connections_in_series(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
-async def test_aiohttp_websocket_multiple_connections_in_parallel(
-    aiohttp_ws_server
-):
+async def test_aiohttp_websocket_multiple_connections_in_parallel(aiohttp_ws_server):
 
     server = aiohttp_ws_server
 
@@ -431,7 +423,7 @@ async def test_aiohttp_websocket_multiple_connections_in_parallel(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
 async def test_aiohttp_websocket_trying_to_connect_to_already_connected_transport(
-    aiohttp_ws_server
+    aiohttp_ws_server,
 ):
     server = aiohttp_ws_server
 
@@ -584,9 +576,7 @@ def test_aiohttp_websocket_execute_sync(aiohttp_ws_server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aiohttp_ws_server", [server1_answers], indirect=True)
-async def test_aiohttp_websocket_add_extra_parameters_to_connect(
-    aiohttp_ws_server
-):
+async def test_aiohttp_websocket_add_extra_parameters_to_connect(aiohttp_ws_server):
 
     server = aiohttp_ws_server
 

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -726,9 +726,7 @@ async def test_aiohttp_websocket_subscription_running_in_thread(
         {"schema": StarWarsTypeDef},
     ],
 )
-async def test_async_aiohttp_client_validation(
-    server, subscription_str, client_params
-):
+async def test_async_aiohttp_client_validation(server, subscription_str, client_params):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -194,7 +194,7 @@ countdown_subscription_str = """
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -217,7 +217,7 @@ async def test_aiohttp_websocket_subscription(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_get_execution_result(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -242,7 +242,7 @@ async def test_aiohttp_websocket_subscription_get_execution_result(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_break(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -273,7 +273,7 @@ async def test_aiohttp_websocket_subscription_break(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_task_cancel(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -312,7 +312,7 @@ async def test_aiohttp_websocket_subscription_task_cancel(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_close_transport(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, _ = aiohttp_client_and_server
@@ -377,7 +377,7 @@ async def server_countdown_close_connection_in_middle(ws):
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_server_connection_closed(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -401,7 +401,7 @@ async def test_aiohttp_websocket_subscription_server_connection_closed(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_slow_consumer(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -426,7 +426,7 @@ async def test_aiohttp_websocket_subscription_slow_consumer(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_with_operation_name(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -457,7 +457,7 @@ WITH_KEEPALIVE = True
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_with_keepalive(
-    event_loop, aiohttp_client_and_server, subscription_str
+    aiohttp_client_and_server, subscription_str
 ):
 
     session, server = aiohttp_client_and_server
@@ -480,7 +480,7 @@ async def test_aiohttp_websocket_subscription_with_keepalive(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_with_keepalive_with_timeout_ok(
-    event_loop, server, subscription_str
+    server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -510,7 +510,7 @@ async def test_aiohttp_websocket_subscription_with_keepalive_with_timeout_ok(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_with_keepalive_with_timeout_nok(
-    event_loop, server, subscription_str
+    server, subscription_str
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -688,7 +688,7 @@ def test_aiohttp_websocket_subscription_sync_graceful_shutdown(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_aiohttp_websocket_subscription_running_in_thread(
-    event_loop, server, subscription_str, run_sync_test
+    server, subscription_str, run_sync_test
 ):
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -712,7 +712,7 @@ async def test_aiohttp_websocket_subscription_running_in_thread(
 
         assert count == -1
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.asyncio
@@ -727,7 +727,7 @@ async def test_aiohttp_websocket_subscription_running_in_thread(
     ],
 )
 async def test_async_aiohttp_client_validation(
-    event_loop, server, subscription_str, client_params
+    server, subscription_str, client_params
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
@@ -763,7 +763,7 @@ async def test_async_aiohttp_client_validation(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_subscribe_on_closing_transport(event_loop, server, subscription_str):
+async def test_subscribe_on_closing_transport(server, subscription_str):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 
@@ -786,7 +786,7 @@ async def test_subscribe_on_closing_transport(event_loop, server, subscription_s
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_subscribe_on_null_transport(event_loop, server, subscription_str):
+async def test_subscribe_on_null_transport(server, subscription_str):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
 

--- a/tests/test_appsync_http.py
+++ b/tests/test_appsync_http.py
@@ -9,7 +9,7 @@ from gql import Client, gql
 @pytest.mark.aiohttp
 @pytest.mark.botocore
 async def test_appsync_iam_mutation(
-    event_loop, aiohttp_server, fake_credentials_factory
+    aiohttp_server, fake_credentials_factory
 ):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport

--- a/tests/test_appsync_http.py
+++ b/tests/test_appsync_http.py
@@ -8,9 +8,7 @@ from gql import Client, gql
 @pytest.mark.asyncio
 @pytest.mark.aiohttp
 @pytest.mark.botocore
-async def test_appsync_iam_mutation(
-    aiohttp_server, fake_credentials_factory
-):
+async def test_appsync_iam_mutation(aiohttp_server, fake_credentials_factory):
     from aiohttp import web
     from gql.transport.aiohttp import AIOHTTPTransport
     from gql.transport.appsync_auth import AppSyncIAMAuthentication

--- a/tests/test_appsync_websockets.py
+++ b/tests/test_appsync_websockets.py
@@ -616,9 +616,7 @@ async def test_appsync_subscription_iam_not_allowed(server):
 @pytest.mark.parametrize(
     "server", [realtime_appsync_server_not_json_answer], indirect=True
 )
-async def test_appsync_subscription_server_sending_a_not_json_answer(
-    server
-):
+async def test_appsync_subscription_server_sending_a_not_json_answer(server):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -644,9 +642,7 @@ async def test_appsync_subscription_server_sending_a_not_json_answer(
 @pytest.mark.parametrize(
     "server", [realtime_appsync_server_error_without_id], indirect=True
 )
-async def test_appsync_subscription_server_sending_an_error_without_an_id(
-    server
-):
+async def test_appsync_subscription_server_sending_an_error_without_an_id(server):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -670,9 +666,7 @@ async def test_appsync_subscription_server_sending_an_error_without_an_id(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [realtime_appsync_server_keepalive], indirect=True)
-async def test_appsync_subscription_variable_values_and_operation_name(
-    server
-):
+async def test_appsync_subscription_variable_values_and_operation_name(server):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport

--- a/tests/test_appsync_websockets.py
+++ b/tests/test_appsync_websockets.py
@@ -404,7 +404,7 @@ async def default_transport_test(transport):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [realtime_appsync_server_keepalive], indirect=True)
-async def test_appsync_subscription_api_key(event_loop, server):
+async def test_appsync_subscription_api_key(server):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -424,7 +424,7 @@ async def test_appsync_subscription_api_key(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.botocore
 @pytest.mark.parametrize("server", [realtime_appsync_server], indirect=True)
-async def test_appsync_subscription_iam_with_token(event_loop, server):
+async def test_appsync_subscription_iam_with_token(server):
 
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -451,7 +451,7 @@ async def test_appsync_subscription_iam_with_token(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.botocore
 @pytest.mark.parametrize("server", [realtime_appsync_server], indirect=True)
-async def test_appsync_subscription_iam_without_token(event_loop, server):
+async def test_appsync_subscription_iam_without_token(server):
 
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -477,7 +477,7 @@ async def test_appsync_subscription_iam_without_token(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.botocore
 @pytest.mark.parametrize("server", [realtime_appsync_server], indirect=True)
-async def test_appsync_execute_method_not_allowed(event_loop, server):
+async def test_appsync_execute_method_not_allowed(server):
 
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -524,7 +524,7 @@ mutation createMessage($message: String!) {
 
 @pytest.mark.asyncio
 @pytest.mark.botocore
-async def test_appsync_fetch_schema_from_transport_not_allowed(event_loop):
+async def test_appsync_fetch_schema_from_transport_not_allowed():
 
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -552,7 +552,7 @@ async def test_appsync_fetch_schema_from_transport_not_allowed(event_loop):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [realtime_appsync_server], indirect=True)
-async def test_appsync_subscription_api_key_unauthorized(event_loop, server):
+async def test_appsync_subscription_api_key_unauthorized(server):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -577,7 +577,7 @@ async def test_appsync_subscription_api_key_unauthorized(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.botocore
 @pytest.mark.parametrize("server", [realtime_appsync_server], indirect=True)
-async def test_appsync_subscription_iam_not_allowed(event_loop, server):
+async def test_appsync_subscription_iam_not_allowed(server):
 
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
@@ -617,7 +617,7 @@ async def test_appsync_subscription_iam_not_allowed(event_loop, server):
     "server", [realtime_appsync_server_not_json_answer], indirect=True
 )
 async def test_appsync_subscription_server_sending_a_not_json_answer(
-    event_loop, server
+    server
 ):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
@@ -645,7 +645,7 @@ async def test_appsync_subscription_server_sending_a_not_json_answer(
     "server", [realtime_appsync_server_error_without_id], indirect=True
 )
 async def test_appsync_subscription_server_sending_an_error_without_an_id(
-    event_loop, server
+    server
 ):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication
@@ -671,7 +671,7 @@ async def test_appsync_subscription_server_sending_an_error_without_an_id(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [realtime_appsync_server_keepalive], indirect=True)
 async def test_appsync_subscription_variable_values_and_operation_name(
-    event_loop, server
+    server
 ):
 
     from gql.transport.appsync_auth import AppSyncApiKeyAuthentication

--- a/tests/test_async_client_validation.py
+++ b/tests/test_async_client_validation.py
@@ -85,9 +85,7 @@ starwars_invalid_subscription_str = """
         {"schema": StarWarsTypeDef},
     ],
 )
-async def test_async_client_validation(
-    server, subscription_str, client_params
-):
+async def test_async_client_validation(server, subscription_str, client_params):
 
     from gql.transport.websockets import WebsocketsTransport
 
@@ -192,7 +190,7 @@ hero_server_answers = (
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_valid_query(
-    client_and_server
+    client_and_server,
 ):
     session, server = client_and_server
     client = session.client
@@ -230,7 +228,7 @@ async def test_async_client_validation_fetch_schema_from_server_valid_query(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_invalid_query(
-    client_and_server
+    client_and_server,
 ):
     session, server = client_and_server
 
@@ -256,7 +254,7 @@ async def test_async_client_validation_fetch_schema_from_server_invalid_query(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_with_client_argument(
-    server
+    server,
 ):
 
     from gql.transport.websockets import WebsocketsTransport

--- a/tests/test_async_client_validation.py
+++ b/tests/test_async_client_validation.py
@@ -86,7 +86,7 @@ starwars_invalid_subscription_str = """
     ],
 )
 async def test_async_client_validation(
-    event_loop, server, subscription_str, client_params
+    server, subscription_str, client_params
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -133,7 +133,7 @@ async def test_async_client_validation(
     ],
 )
 async def test_async_client_validation_invalid_query(
-    event_loop, server, subscription_str, client_params
+    server, subscription_str, client_params
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -166,7 +166,7 @@ async def test_async_client_validation_invalid_query(
     [{"schema": StarWarsSchema, "introspection": StarWarsIntrospection}],
 )
 async def test_async_client_validation_different_schemas_parameters_forbidden(
-    event_loop, server, subscription_str, client_params
+    server, subscription_str, client_params
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -192,7 +192,7 @@ hero_server_answers = (
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_valid_query(
-    event_loop, client_and_server
+    client_and_server
 ):
     session, server = client_and_server
     client = session.client
@@ -230,7 +230,7 @@ async def test_async_client_validation_fetch_schema_from_server_valid_query(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_invalid_query(
-    event_loop, client_and_server
+    client_and_server
 ):
     session, server = client_and_server
 
@@ -256,7 +256,7 @@ async def test_async_client_validation_fetch_schema_from_server_invalid_query(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [hero_server_answers], indirect=True)
 async def test_async_client_validation_fetch_schema_from_server_with_client_argument(
-    event_loop, server
+    server
 ):
 
     from gql.transport.websockets import WebsocketsTransport

--- a/tests/test_graphqlws_exceptions.py
+++ b/tests/test_graphqlws_exceptions.py
@@ -39,9 +39,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_graphqlws_invalid_query(
-    client_and_graphqlws_server, query_str
-):
+async def test_graphqlws_invalid_query(client_and_graphqlws_server, query_str):
 
     session, server = client_and_graphqlws_server
 
@@ -82,9 +80,7 @@ async def server_invalid_subscription(ws):
     "graphqlws_server", [server_invalid_subscription], indirect=True
 )
 @pytest.mark.parametrize("query_str", [invalid_subscription_str])
-async def test_graphqlws_invalid_subscription(
-    client_and_graphqlws_server, query_str
-):
+async def test_graphqlws_invalid_subscription(client_and_graphqlws_server, query_str):
 
     session, server = client_and_graphqlws_server
 
@@ -110,9 +106,7 @@ async def server_no_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_graphqlws_server_does_not_send_ack(
-    graphqlws_server, query_str
-):
+async def test_graphqlws_server_does_not_send_ack(graphqlws_server, query_str):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
@@ -194,9 +188,7 @@ sending_bytes = [b"\x01\x02\x03"]
     ],
     indirect=True,
 )
-async def test_graphqlws_transport_protocol_errors(
-    client_and_graphqlws_server
-):
+async def test_graphqlws_transport_protocol_errors(client_and_graphqlws_server):
 
     session, server = client_and_graphqlws_server
 
@@ -253,9 +245,7 @@ async def server_closing_after_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_after_ack], indirect=True)
-async def test_graphqlws_server_closing_after_ack(
-    client_and_graphqlws_server
-):
+async def test_graphqlws_server_closing_after_ack(client_and_graphqlws_server):
 
     session, server = client_and_graphqlws_server
 

--- a/tests/test_graphqlws_exceptions.py
+++ b/tests/test_graphqlws_exceptions.py
@@ -40,7 +40,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.parametrize("graphqlws_server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_graphqlws_invalid_query(
-    event_loop, client_and_graphqlws_server, query_str
+    client_and_graphqlws_server, query_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -83,7 +83,7 @@ async def server_invalid_subscription(ws):
 )
 @pytest.mark.parametrize("query_str", [invalid_subscription_str])
 async def test_graphqlws_invalid_subscription(
-    event_loop, client_and_graphqlws_server, query_str
+    client_and_graphqlws_server, query_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -111,7 +111,7 @@ async def server_no_ack(ws):
 @pytest.mark.parametrize("graphqlws_server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_graphqlws_server_does_not_send_ack(
-    event_loop, graphqlws_server, query_str
+    graphqlws_server, query_str
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -142,7 +142,7 @@ async def server_invalid_query(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_invalid_query], indirect=True)
-async def test_graphqlws_sending_invalid_query(event_loop, client_and_graphqlws_server):
+async def test_graphqlws_sending_invalid_query(client_and_graphqlws_server):
 
     session, server = client_and_graphqlws_server
 
@@ -195,7 +195,7 @@ sending_bytes = [b"\x01\x02\x03"]
     indirect=True,
 )
 async def test_graphqlws_transport_protocol_errors(
-    event_loop, client_and_graphqlws_server
+    client_and_graphqlws_server
 ):
 
     session, server = client_and_graphqlws_server
@@ -214,7 +214,7 @@ async def server_without_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_without_ack], indirect=True)
-async def test_graphqlws_server_does_not_ack(event_loop, graphqlws_server):
+async def test_graphqlws_server_does_not_ack(graphqlws_server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
@@ -233,7 +233,7 @@ async def server_closing_directly(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_directly], indirect=True)
-async def test_graphqlws_server_closing_directly(event_loop, graphqlws_server):
+async def test_graphqlws_server_closing_directly(graphqlws_server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
@@ -254,7 +254,7 @@ async def server_closing_after_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_closing_after_ack], indirect=True)
 async def test_graphqlws_server_closing_after_ack(
-    event_loop, client_and_graphqlws_server
+    client_and_graphqlws_server
 ):
 
     session, server = client_and_graphqlws_server

--- a/tests/test_graphqlws_subscription.py
+++ b/tests/test_graphqlws_subscription.py
@@ -228,9 +228,7 @@ countdown_subscription_str = """
 @pytest.mark.asyncio
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_graphqlws_subscription(
-    client_and_graphqlws_server, subscription_str
-):
+async def test_graphqlws_subscription(client_and_graphqlws_server, subscription_str):
 
     session, server = client_and_graphqlws_server
 

--- a/tests/test_graphqlws_subscription.py
+++ b/tests/test_graphqlws_subscription.py
@@ -229,7 +229,7 @@ countdown_subscription_str = """
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -252,7 +252,7 @@ async def test_graphqlws_subscription(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_break(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -283,7 +283,7 @@ async def test_graphqlws_subscription_break(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_task_cancel(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -322,7 +322,7 @@ async def test_graphqlws_subscription_task_cancel(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_close_transport(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -387,7 +387,7 @@ async def server_countdown_close_connection_in_middle(ws):
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_server_connection_closed(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
     session, server = client_and_graphqlws_server
 
@@ -410,7 +410,7 @@ async def test_graphqlws_subscription_server_connection_closed(
 @pytest.mark.parametrize("graphqlws_server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_operation_name(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -440,7 +440,7 @@ async def test_graphqlws_subscription_with_operation_name(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_keepalive(
-    event_loop, client_and_graphqlws_server, subscription_str
+    client_and_graphqlws_server, subscription_str
 ):
 
     session, server = client_and_graphqlws_server
@@ -470,7 +470,7 @@ async def test_graphqlws_subscription_with_keepalive(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_keepalive_with_timeout_ok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -502,7 +502,7 @@ async def test_graphqlws_subscription_with_keepalive_with_timeout_ok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_keepalive_with_timeout_nok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -535,7 +535,7 @@ async def test_graphqlws_subscription_with_keepalive_with_timeout_nok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_ping_interval_ok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -571,7 +571,7 @@ async def test_graphqlws_subscription_with_ping_interval_ok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_with_ping_interval_nok(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -604,7 +604,7 @@ async def test_graphqlws_subscription_with_ping_interval_nok(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_manual_pings_with_payload(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -646,7 +646,7 @@ async def test_graphqlws_subscription_manual_pings_with_payload(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_manual_pong_answers_with_payload(
-    event_loop, graphqlws_server, subscription_str
+    graphqlws_server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -777,7 +777,7 @@ def test_graphqlws_subscription_sync_graceful_shutdown(
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_graphqlws_subscription_running_in_thread(
-    event_loop, graphqlws_server, subscription_str, run_sync_test
+    graphqlws_server, subscription_str, run_sync_test
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -801,7 +801,7 @@ async def test_graphqlws_subscription_running_in_thread(
 
         assert count == -1
 
-    await run_sync_test(event_loop, graphqlws_server, test_code)
+    await run_sync_test(graphqlws_server, test_code)
 
 
 @pytest.mark.asyncio
@@ -811,7 +811,7 @@ async def test_graphqlws_subscription_running_in_thread(
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 @pytest.mark.parametrize("execute_instead_of_subscribe", [False, True])
 async def test_graphqlws_subscription_reconnecting_session(
-    event_loop, graphqlws_server, subscription_str, execute_instead_of_subscribe
+    graphqlws_server, subscription_str, execute_instead_of_subscribe
 ):
 
     from gql.transport.websockets import WebsocketsTransport

--- a/tests/test_http_async_sync.py
+++ b/tests/test_http_async_sync.py
@@ -7,7 +7,7 @@ from gql import Client, gql
 @pytest.mark.online
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fetch_schema_from_transport", [True, False])
-async def test_async_client_async_transport(event_loop, fetch_schema_from_transport):
+async def test_async_client_async_transport(fetch_schema_from_transport):
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -51,7 +51,7 @@ async def test_async_client_async_transport(event_loop, fetch_schema_from_transp
 @pytest.mark.online
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fetch_schema_from_transport", [True, False])
-async def test_async_client_sync_transport(event_loop, fetch_schema_from_transport):
+async def test_async_client_sync_transport(fetch_schema_from_transport):
 
     from gql.transport.requests import RequestsHTTPTransport
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -36,7 +36,7 @@ query1_server_answer = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_query(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -74,14 +74,14 @@ async def test_httpx_query(event_loop, aiohttp_server, run_sync_test):
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
 async def test_httpx_query_https(
-    event_loop, ssl_aiohttp_server, run_sync_test, verify_https
+    ssl_aiohttp_server, run_sync_test, verify_https
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -134,14 +134,14 @@ async def test_httpx_query_https(
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_httpx_query_https_self_cert_fail(
-    event_loop, ssl_aiohttp_server, run_sync_test, verify_https
+    ssl_aiohttp_server, run_sync_test, verify_https
 ):
     """By default, we should verify the ssl certificate"""
     from aiohttp import web
@@ -186,12 +186,12 @@ async def test_httpx_query_https_self_cert_fail(
 
         assert expected_error in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cookies(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_cookies(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -223,12 +223,12 @@ async def test_httpx_cookies(event_loop, aiohttp_server, run_sync_test):
 
             assert africa["code"] == "AF"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_401(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_error_code_401(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -258,12 +258,12 @@ async def test_httpx_error_code_401(event_loop, aiohttp_server, run_sync_test):
 
             assert "Client error '401 Unauthorized'" in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_429(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_error_code_429(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -312,7 +312,7 @@ async def test_httpx_error_code_429(event_loop, aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_500(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_error_code_500(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -336,7 +336,7 @@ async def test_httpx_error_code_500(event_loop, aiohttp_server, run_sync_test):
             with pytest.raises(TransportServerError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
@@ -344,7 +344,7 @@ query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_error_code(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -369,7 +369,7 @@ async def test_httpx_error_code(event_loop, aiohttp_server, run_sync_test):
             with pytest.raises(TransportQueryError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 invalid_protocol_responses = [
@@ -383,7 +383,7 @@ invalid_protocol_responses = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
 async def test_httpx_invalid_protocol(
-    event_loop, aiohttp_server, response, run_sync_test
+    aiohttp_server, response, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -407,12 +407,12 @@ async def test_httpx_invalid_protocol(
             with pytest.raises(TransportProtocolError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_cannot_connect_twice(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -433,13 +433,13 @@ async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server, run_sync_t
             with pytest.raises(TransportAlreadyConnected):
                 session.transport.connect()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_cannot_execute_if_not_connected(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -461,7 +461,7 @@ async def test_httpx_cannot_execute_if_not_connected(
         with pytest.raises(TransportClosed):
             transport.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_answer_with_extensions = (
@@ -477,7 +477,7 @@ query1_server_answer_with_extensions = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query_with_extensions(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_query_with_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -503,7 +503,7 @@ async def test_httpx_query_with_extensions(event_loop, aiohttp_server, run_sync_
 
             assert execution_result.extensions["key1"] == "val1"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_server_answer = '{"data":{"success":true}}'
@@ -532,7 +532,7 @@ This file will be sent in the GraphQL mutation
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_file_upload(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -587,13 +587,13 @@ async def test_httpx_file_upload(event_loop, aiohttp_server, run_sync_test):
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_file_upload_with_content_type(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -655,13 +655,13 @@ async def test_httpx_file_upload_with_content_type(
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_file_upload_additional_headers(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -719,12 +719,12 @@ async def test_httpx_file_upload_additional_headers(
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_binary_file_upload(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_binary_file_upload(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -785,7 +785,7 @@ async def test_httpx_binary_file_upload(event_loop, aiohttp_server, run_sync_tes
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_mutation_2_operations = (
@@ -797,7 +797,7 @@ file_upload_mutation_2_operations = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_two_files(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_file_upload_two_files(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -883,7 +883,7 @@ async def test_httpx_file_upload_two_files(event_loop, aiohttp_server, run_sync_
                     f1.close()
                     f2.close()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_mutation_3_operations = (
@@ -896,7 +896,7 @@ file_upload_mutation_3_operations = (
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_file_upload_list_of_two_files(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
@@ -981,12 +981,12 @@ async def test_httpx_file_upload_list_of_two_files(
                     f1.close()
                     f2.close()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_fetching_schema(event_loop, aiohttp_server, run_sync_test):
+async def test_httpx_error_fetching_schema(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -1028,4 +1028,4 @@ async def test_httpx_error_fetching_schema(event_loop, aiohttp_server, run_sync_
         assert expected_error in str(exc_info.value)
         assert transport.client is None
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -80,9 +80,7 @@ async def test_httpx_query(aiohttp_server, run_sync_test):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
-async def test_httpx_query_https(
-    ssl_aiohttp_server, run_sync_test, verify_https
-):
+async def test_httpx_query_https(ssl_aiohttp_server, run_sync_test, verify_https):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -382,9 +380,7 @@ invalid_protocol_responses = [
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
-async def test_httpx_invalid_protocol(
-    aiohttp_server, response, run_sync_test
-):
+async def test_httpx_invalid_protocol(aiohttp_server, response, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -438,9 +434,7 @@ async def test_httpx_cannot_connect_twice(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cannot_execute_if_not_connected(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_cannot_execute_if_not_connected(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -592,9 +586,7 @@ async def test_httpx_file_upload(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_with_content_type(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_file_upload_with_content_type(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -660,9 +652,7 @@ async def test_httpx_file_upload_with_content_type(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_additional_headers(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_file_upload_additional_headers(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 
@@ -895,9 +885,7 @@ file_upload_mutation_3_operations = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_list_of_two_files(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_file_upload_list_of_two_files(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXTransport
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -536,9 +536,7 @@ async def test_httpx_query_variable_values_fix_issue_292(aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_execute_running_in_thread(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_execute_running_in_thread(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -565,9 +563,7 @@ async def test_httpx_execute_running_in_thread(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_subscribe_running_in_thread(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_subscribe_running_in_thread(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -690,9 +686,7 @@ async def test_httpx_file_upload(aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_without_session(
-    aiohttp_server, run_sync_test
-):
+async def test_httpx_file_upload_without_session(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1060,9 +1054,7 @@ async def test_httpx_using_cli_ep(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_using_cli_invalid_param(
-    aiohttp_server, monkeypatch, capsys
-):
+async def test_httpx_using_cli_invalid_param(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1097,9 +1089,7 @@ async def test_httpx_using_cli_invalid_param(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_using_cli_invalid_query(
-    aiohttp_server, monkeypatch, capsys
-):
+async def test_httpx_using_cli_invalid_query(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1210,9 +1200,7 @@ async def test_httpx_query_https(ssl_aiohttp_server, verify_https):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
-async def test_httpx_query_https_self_cert_fail(
-    ssl_aiohttp_server, verify_https
-):
+async def test_httpx_query_https_self_cert_fail(ssl_aiohttp_server, verify_https):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
     from httpx import ConnectError

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -46,7 +46,7 @@ pytestmark = pytest.mark.httpx
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query(event_loop, aiohttp_server):
+async def test_httpx_query(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -86,7 +86,7 @@ async def test_httpx_query(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_ignore_backend_content_type(event_loop, aiohttp_server):
+async def test_httpx_ignore_backend_content_type(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -116,7 +116,7 @@ async def test_httpx_ignore_backend_content_type(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cookies(event_loop, aiohttp_server):
+async def test_httpx_cookies(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -150,7 +150,7 @@ async def test_httpx_cookies(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_401(event_loop, aiohttp_server):
+async def test_httpx_error_code_401(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -182,7 +182,7 @@ async def test_httpx_error_code_401(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_429(event_loop, aiohttp_server):
+async def test_httpx_error_code_429(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -230,7 +230,7 @@ async def test_httpx_error_code_429(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_code_500(event_loop, aiohttp_server):
+async def test_httpx_error_code_500(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -266,7 +266,7 @@ transport_query_error_responses = [
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("query_error", transport_query_error_responses)
-async def test_httpx_error_code(event_loop, aiohttp_server, query_error):
+async def test_httpx_error_code(aiohttp_server, query_error):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -322,7 +322,7 @@ invalid_protocol_responses = [
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("param", invalid_protocol_responses)
-async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
+async def test_httpx_invalid_protocol(aiohttp_server, param):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -351,7 +351,7 @@ async def test_httpx_invalid_protocol(event_loop, aiohttp_server, param):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_subscribe_not_supported(event_loop, aiohttp_server):
+async def test_httpx_subscribe_not_supported(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -377,7 +377,7 @@ async def test_httpx_subscribe_not_supported(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server):
+async def test_httpx_cannot_connect_twice(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -400,7 +400,7 @@ async def test_httpx_cannot_connect_twice(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server):
+async def test_httpx_cannot_execute_if_not_connected(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -423,7 +423,7 @@ async def test_httpx_cannot_execute_if_not_connected(event_loop, aiohttp_server)
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_extra_args(event_loop, aiohttp_server):
+async def test_httpx_extra_args(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
     import httpx
@@ -468,7 +468,7 @@ query2_server_answer = '{"data": {"continent": {"name": "Europe"}}}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query_variable_values(event_loop, aiohttp_server):
+async def test_httpx_query_variable_values(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -501,7 +501,7 @@ async def test_httpx_query_variable_values(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query_variable_values_fix_issue_292(event_loop, aiohttp_server):
+async def test_httpx_query_variable_values_fix_issue_292(aiohttp_server):
     """Allow to specify variable_values without keyword.
 
     See https://github.com/graphql-python/gql/issues/292"""
@@ -537,7 +537,7 @@ async def test_httpx_query_variable_values_fix_issue_292(event_loop, aiohttp_ser
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_execute_running_in_thread(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
@@ -560,13 +560,13 @@ async def test_httpx_execute_running_in_thread(
 
         client.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_subscribe_running_in_thread(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
@@ -598,7 +598,7 @@ async def test_httpx_subscribe_running_in_thread(
             for result in client.subscribe(query):
                 pass
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_server_answer = '{"data":{"success":true}}'
@@ -654,7 +654,7 @@ async def single_upload_handler(request):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload(event_loop, aiohttp_server):
+async def test_httpx_file_upload(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -691,7 +691,7 @@ async def test_httpx_file_upload(event_loop, aiohttp_server):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_file_upload_without_session(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
@@ -725,7 +725,7 @@ async def test_httpx_file_upload_without_session(
 
                 assert success
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 # This is a sample binary file content containing all possible byte values
@@ -761,7 +761,7 @@ async def binary_upload_handler(request):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_binary_file_upload(event_loop, aiohttp_server):
+async def test_httpx_binary_file_upload(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -819,7 +819,7 @@ This file will also be sent in the GraphQL mutation
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_two_files(event_loop, aiohttp_server):
+async def test_httpx_file_upload_two_files(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -911,7 +911,7 @@ file_upload_mutation_3_map = '{"0": ["variables.files.0"], "1": ["variables.file
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
+async def test_httpx_file_upload_list_of_two_files(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -984,7 +984,7 @@ async def test_httpx_file_upload_list_of_two_files(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_using_cli(event_loop, aiohttp_server, monkeypatch, capsys):
+async def test_httpx_using_cli(aiohttp_server, monkeypatch, capsys):
     from aiohttp import web
 
     async def handler(request):
@@ -1022,7 +1022,7 @@ async def test_httpx_using_cli(event_loop, aiohttp_server, monkeypatch, capsys):
 @pytest.mark.asyncio
 @pytest.mark.script_launch_mode("subprocess")
 async def test_httpx_using_cli_ep(
-    event_loop, aiohttp_server, monkeypatch, script_runner, run_sync_test
+    aiohttp_server, monkeypatch, script_runner, run_sync_test
 ):
     from aiohttp import web
 
@@ -1055,13 +1055,13 @@ async def test_httpx_using_cli_ep(
 
         assert received_answer == expected_answer
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_using_cli_invalid_param(
-    event_loop, aiohttp_server, monkeypatch, capsys
+    aiohttp_server, monkeypatch, capsys
 ):
     from aiohttp import web
 
@@ -1098,7 +1098,7 @@ async def test_httpx_using_cli_invalid_param(
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_using_cli_invalid_query(
-    event_loop, aiohttp_server, monkeypatch, capsys
+    aiohttp_server, monkeypatch, capsys
 ):
     from aiohttp import web
 
@@ -1138,7 +1138,7 @@ query1_server_answer_with_extensions = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
+async def test_httpx_query_with_extensions(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1167,7 +1167,7 @@ async def test_httpx_query_with_extensions(event_loop, aiohttp_server):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
-async def test_httpx_query_https(event_loop, ssl_aiohttp_server, verify_https):
+async def test_httpx_query_https(ssl_aiohttp_server, verify_https):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1211,7 +1211,7 @@ async def test_httpx_query_https(event_loop, ssl_aiohttp_server, verify_https):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_httpx_query_https_self_cert_fail(
-    event_loop, ssl_aiohttp_server, verify_https
+    ssl_aiohttp_server, verify_https
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
@@ -1250,7 +1250,7 @@ async def test_httpx_query_https_self_cert_fail(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
+async def test_httpx_error_fetching_schema(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1294,7 +1294,7 @@ async def test_httpx_error_fetching_schema(event_loop, aiohttp_server):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
+async def test_httpx_reconnecting_session(aiohttp_server):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1333,7 +1333,7 @@ async def test_httpx_reconnecting_session(event_loop, aiohttp_server):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("retries", [False, lambda e: e])
-async def test_httpx_reconnecting_session_retries(event_loop, aiohttp_server, retries):
+async def test_httpx_reconnecting_session_retries(aiohttp_server, retries):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1366,7 +1366,7 @@ async def test_httpx_reconnecting_session_retries(event_loop, aiohttp_server, re
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_httpx_reconnecting_session_start_connecting_task_twice(
-    event_loop, aiohttp_server, caplog
+    aiohttp_server, caplog
 ):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
@@ -1401,7 +1401,7 @@ async def test_httpx_reconnecting_session_start_connecting_task_twice(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_json_serializer(event_loop, aiohttp_server, caplog):
+async def test_httpx_json_serializer(aiohttp_server, caplog):
     from aiohttp import web
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -1458,7 +1458,7 @@ query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_json_deserializer(event_loop, aiohttp_server):
+async def test_httpx_json_deserializer(aiohttp_server):
     from aiohttp import web
     from decimal import Decimal
     from functools import partial

--- a/tests/test_httpx_online.py
+++ b/tests/test_httpx_online.py
@@ -11,7 +11,7 @@ from gql.transport.exceptions import TransportQueryError
 @pytest.mark.httpx
 @pytest.mark.online
 @pytest.mark.asyncio
-async def test_httpx_simple_query(event_loop):
+async def test_httpx_simple_query():
 
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -56,7 +56,7 @@ async def test_httpx_simple_query(event_loop):
 @pytest.mark.httpx
 @pytest.mark.online
 @pytest.mark.asyncio
-async def test_httpx_invalid_query(event_loop):
+async def test_httpx_invalid_query():
 
     from gql.transport.httpx import HTTPXAsyncTransport
 
@@ -85,7 +85,7 @@ async def test_httpx_invalid_query(event_loop):
 @pytest.mark.online
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @pytest.mark.asyncio
-async def test_httpx_two_queries_in_parallel_using_two_tasks(event_loop):
+async def test_httpx_two_queries_in_parallel_using_two_tasks():
 
     from gql.transport.httpx import HTTPXAsyncTransport
 

--- a/tests/test_phoenix_channel_exceptions.py
+++ b/tests/test_phoenix_channel_exceptions.py
@@ -407,9 +407,7 @@ def subscription_server(
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query2_str])
-async def test_phoenix_channel_subscription_protocol_error(
-    server, query_str
-):
+async def test_phoenix_channel_subscription_protocol_error(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,

--- a/tests/test_phoenix_channel_exceptions.py
+++ b/tests/test_phoenix_channel_exceptions.py
@@ -161,7 +161,7 @@ async def no_connection_ack_phoenix_server(ws):
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_phoenix_channel_query_protocol_error(event_loop, server, query_str):
+async def test_phoenix_channel_query_protocol_error(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
@@ -191,7 +191,7 @@ async def test_phoenix_channel_query_protocol_error(event_loop, server, query_st
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_phoenix_channel_query_error(event_loop, server, query_str):
+async def test_phoenix_channel_query_error(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
@@ -408,7 +408,7 @@ def subscription_server(
 )
 @pytest.mark.parametrize("query_str", [query2_str])
 async def test_phoenix_channel_subscription_protocol_error(
-    event_loop, server, query_str
+    server, query_str
 ):
 
     from gql.transport.phoenix_channel_websockets import (
@@ -439,7 +439,7 @@ server_error_server_answer = '{"event":"phx_error", "ref":2, "topic":"test_topic
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_phoenix_channel_server_error(event_loop, server, query_str):
+async def test_phoenix_channel_server_error(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
@@ -468,7 +468,7 @@ async def test_phoenix_channel_server_error(event_loop, server, query_str):
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query2_str])
-async def test_phoenix_channel_unsubscribe_error(event_loop, server, query_str):
+async def test_phoenix_channel_unsubscribe_error(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
@@ -498,7 +498,7 @@ async def test_phoenix_channel_unsubscribe_error(event_loop, server, query_str):
     indirect=True,
 )
 @pytest.mark.parametrize("query_str", [query2_str])
-async def test_phoenix_channel_unsubscribe_error_forcing(event_loop, server, query_str):
+async def test_phoenix_channel_unsubscribe_error_forcing(server, query_str):
 
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,

--- a/tests/test_phoenix_channel_query.py
+++ b/tests/test_phoenix_channel_query.py
@@ -52,7 +52,7 @@ async def query_server(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [query_server], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_phoenix_channel_query(event_loop, server, query_str):
+async def test_phoenix_channel_query(server, query_str):
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
     )
@@ -75,7 +75,7 @@ async def test_phoenix_channel_query(event_loop, server, query_str):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ws_ssl_server", [query_server], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_phoenix_channel_query_ssl(event_loop, ws_ssl_server, query_str):
+async def test_phoenix_channel_query_ssl(ws_ssl_server, query_str):
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
     )
@@ -108,7 +108,7 @@ async def test_phoenix_channel_query_ssl(event_loop, ws_ssl_server, query_str):
 @pytest.mark.parametrize("query_str", [query1_str])
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_phoenix_channel_query_ssl_self_cert_fail(
-    event_loop, ws_ssl_server, query_str, verify_https
+    ws_ssl_server, query_str, verify_https
 ):
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
@@ -204,7 +204,7 @@ async def subscription_server(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [subscription_server], indirect=True)
 @pytest.mark.parametrize("query_str", [query2_str])
-async def test_phoenix_channel_subscription(event_loop, server, query_str):
+async def test_phoenix_channel_subscription(server, query_str):
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
     )

--- a/tests/test_phoenix_channel_subscription.py
+++ b/tests/test_phoenix_channel_subscription.py
@@ -174,7 +174,7 @@ countdown_subscription_str = """
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 @pytest.mark.parametrize("end_count", [0, 5])
 async def test_phoenix_channel_subscription(
-    event_loop, server, subscription_str, end_count
+    server, subscription_str, end_count
 ):
     """Parameterized test.
 
@@ -224,7 +224,7 @@ async def test_phoenix_channel_subscription(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_phoenix_channel_subscription_no_break(
-    event_loop, server, subscription_str
+    server, subscription_str
 ):
     import logging
 
@@ -369,7 +369,7 @@ heartbeat_subscription_str = """
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [phoenix_heartbeat_server], indirect=True)
 @pytest.mark.parametrize("subscription_str", [heartbeat_subscription_str])
-async def test_phoenix_channel_heartbeat(event_loop, server, subscription_str):
+async def test_phoenix_channel_heartbeat(server, subscription_str):
     from gql.transport.phoenix_channel_websockets import (
         PhoenixChannelWebsocketsTransport,
     )

--- a/tests/test_phoenix_channel_subscription.py
+++ b/tests/test_phoenix_channel_subscription.py
@@ -173,9 +173,7 @@ countdown_subscription_str = """
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 @pytest.mark.parametrize("end_count", [0, 5])
-async def test_phoenix_channel_subscription(
-    server, subscription_str, end_count
-):
+async def test_phoenix_channel_subscription(server, subscription_str, end_count):
     """Parameterized test.
 
     :param end_count: Target count at which the test will 'break' to unsubscribe.
@@ -223,9 +221,7 @@ async def test_phoenix_channel_subscription(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_phoenix_channel_subscription_no_break(
-    server, subscription_str
-):
+async def test_phoenix_channel_subscription_no_break(server, subscription_str):
     import logging
 
     from gql.transport.phoenix_channel_websockets import (

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -40,7 +40,7 @@ query1_server_answer = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_query(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -78,14 +78,14 @@ async def test_requests_query(event_loop, aiohttp_server, run_sync_test):
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
 async def test_requests_query_https(
-    event_loop, ssl_aiohttp_server, run_sync_test, verify_https
+    ssl_aiohttp_server, run_sync_test, verify_https
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -142,14 +142,14 @@ async def test_requests_query_https(
                 assert isinstance(transport.response_headers, Mapping)
                 assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_requests_query_https_self_cert_fail(
-    event_loop, ssl_aiohttp_server, run_sync_test, verify_https
+    ssl_aiohttp_server, run_sync_test, verify_https
 ):
     """By default, we should verify the ssl certificate"""
     from aiohttp import web
@@ -192,12 +192,12 @@ async def test_requests_query_https_self_cert_fail(
 
         assert expected_error in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_cookies(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_cookies(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -229,12 +229,12 @@ async def test_requests_cookies(event_loop, aiohttp_server, run_sync_test):
 
             assert africa["code"] == "AF"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_401(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_401(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -264,12 +264,12 @@ async def test_requests_error_code_401(event_loop, aiohttp_server, run_sync_test
 
             assert "401 Client Error: Unauthorized" in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_429(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_429(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -318,7 +318,7 @@ async def test_requests_error_code_429(event_loop, aiohttp_server, run_sync_test
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_500(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_500(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -342,7 +342,7 @@ async def test_requests_error_code_500(event_loop, aiohttp_server, run_sync_test
             with pytest.raises(TransportServerError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
@@ -350,7 +350,7 @@ query1_server_error_answer = '{"errors": ["Error 1", "Error 2"]}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -375,7 +375,7 @@ async def test_requests_error_code(event_loop, aiohttp_server, run_sync_test):
             with pytest.raises(TransportQueryError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 invalid_protocol_responses = [
@@ -389,7 +389,7 @@ invalid_protocol_responses = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
 async def test_requests_invalid_protocol(
-    event_loop, aiohttp_server, response, run_sync_test
+    aiohttp_server, response, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -413,12 +413,12 @@ async def test_requests_invalid_protocol(
             with pytest.raises(TransportProtocolError):
                 session.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_cannot_connect_twice(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_cannot_connect_twice(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -439,13 +439,13 @@ async def test_requests_cannot_connect_twice(event_loop, aiohttp_server, run_syn
             with pytest.raises(TransportAlreadyConnected):
                 session.transport.connect()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_cannot_execute_if_not_connected(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -467,7 +467,7 @@ async def test_requests_cannot_execute_if_not_connected(
         with pytest.raises(TransportClosed):
             transport.execute(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_answer_with_extensions = (
@@ -484,7 +484,7 @@ query1_server_answer_with_extensions = (
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_query_with_extensions(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -511,7 +511,7 @@ async def test_requests_query_with_extensions(
 
             assert execution_result.extensions["key1"] == "val1"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_server_answer = '{"data":{"success":true}}'
@@ -540,7 +540,7 @@ This file will be sent in the GraphQL mutation
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_file_upload(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_file_upload(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -595,13 +595,13 @@ async def test_requests_file_upload(event_loop, aiohttp_server, run_sync_test):
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_file_upload_with_content_type(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -663,13 +663,13 @@ async def test_requests_file_upload_with_content_type(
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_file_upload_additional_headers(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -727,12 +727,12 @@ async def test_requests_file_upload_additional_headers(
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_binary_file_upload(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_binary_file_upload(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -793,7 +793,7 @@ async def test_requests_binary_file_upload(event_loop, aiohttp_server, run_sync_
 
                     assert execution_result.data["success"]
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_mutation_2_operations = (
@@ -806,7 +806,7 @@ file_upload_mutation_2_operations = (
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_file_upload_two_files(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -893,7 +893,7 @@ async def test_requests_file_upload_two_files(
                     f1.close()
                     f2.close()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 file_upload_mutation_3_operations = (
@@ -906,7 +906,7 @@ file_upload_mutation_3_operations = (
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_file_upload_list_of_two_files(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -991,13 +991,13 @@ async def test_requests_file_upload_list_of_two_files(
                     f1.close()
                     f2.close()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_error_fetching_schema(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -1040,13 +1040,13 @@ async def test_requests_error_fetching_schema(
         assert expected_error in str(exc_info.value)
         assert transport.session is None
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_json_serializer(
-    event_loop, aiohttp_server, run_sync_test, caplog
+    aiohttp_server, run_sync_test, caplog
 ):
     import json
     from aiohttp import web
@@ -1091,7 +1091,7 @@ async def test_requests_json_serializer(
         expected_log = '"query":"query getContinents'
         assert expected_log in caplog.text
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query_float_str = """
@@ -1107,7 +1107,7 @@ query_float_server_answer = f'{{"data":{query_float_server_answer_data}}}'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_json_deserializer(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_json_deserializer(aiohttp_server, run_sync_test):
     import json
     from aiohttp import web
     from decimal import Decimal
@@ -1146,4 +1146,4 @@ async def test_requests_json_deserializer(event_loop, aiohttp_server, run_sync_t
 
             assert pi == Decimal("3.141592653589793238462643383279502884197")
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -84,9 +84,7 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("verify_https", ["disabled", "cert_provided"])
-async def test_requests_query_https(
-    ssl_aiohttp_server, run_sync_test, verify_https
-):
+async def test_requests_query_https(ssl_aiohttp_server, run_sync_test, verify_https):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
     import warnings
@@ -388,9 +386,7 @@ invalid_protocol_responses = [
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
-async def test_requests_invalid_protocol(
-    aiohttp_server, response, run_sync_test
-):
+async def test_requests_invalid_protocol(aiohttp_server, response, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -444,9 +440,7 @@ async def test_requests_cannot_connect_twice(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_cannot_execute_if_not_connected(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_cannot_execute_if_not_connected(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -483,9 +477,7 @@ query1_server_answer_with_extensions = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query_with_extensions(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -600,9 +592,7 @@ async def test_requests_file_upload(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_file_upload_with_content_type(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_file_upload_with_content_type(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -668,9 +658,7 @@ async def test_requests_file_upload_with_content_type(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_file_upload_additional_headers(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_file_upload_additional_headers(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -805,9 +793,7 @@ file_upload_mutation_2_operations = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_file_upload_two_files(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -905,9 +891,7 @@ file_upload_mutation_3_operations = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_file_upload_list_of_two_files(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_file_upload_list_of_two_files(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -996,9 +980,7 @@ async def test_requests_file_upload_list_of_two_files(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_fetching_schema(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_error_fetching_schema(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -1045,9 +1027,7 @@ async def test_requests_error_fetching_schema(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_json_serializer(
-    aiohttp_server, run_sync_test, caplog
-):
+async def test_requests_json_serializer(aiohttp_server, run_sync_test, caplog):
     import json
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport

--- a/tests/test_requests_batch.py
+++ b/tests/test_requests_batch.py
@@ -48,7 +48,7 @@ query1_server_answer_twice_list = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_query(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -86,13 +86,13 @@ async def test_requests_query(event_loop, aiohttp_server, run_sync_test):
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_query_auto_batch_enabled(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -134,13 +134,13 @@ async def test_requests_query_auto_batch_enabled(
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_query_auto_batch_enabled_two_requests(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -194,12 +194,12 @@ async def test_requests_query_auto_batch_enabled_two_requests(
         for thread in threads:
             thread.join()
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_cookies(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_cookies(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -233,12 +233,12 @@ async def test_requests_cookies(event_loop, aiohttp_server, run_sync_test):
 
             assert africa["code"] == "AF"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_401(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_401(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -268,13 +268,13 @@ async def test_requests_error_code_401(event_loop, aiohttp_server, run_sync_test
 
             assert "401 Client Error: Unauthorized" in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_error_code_401_auto_batch_enabled(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -308,12 +308,12 @@ async def test_requests_error_code_401_auto_batch_enabled(
 
             assert "401 Client Error: Unauthorized" in str(exc_info.value)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_429(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_429(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -362,7 +362,7 @@ async def test_requests_error_code_429(event_loop, aiohttp_server, run_sync_test
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code_500(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code_500(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -386,7 +386,7 @@ async def test_requests_error_code_500(event_loop, aiohttp_server, run_sync_test
             with pytest.raises(TransportServerError):
                 session.execute_batch(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_error_answer_list = '[{"errors": ["Error 1", "Error 2"]}]'
@@ -394,7 +394,7 @@ query1_server_error_answer_list = '[{"errors": ["Error 1", "Error 2"]}]'
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_error_code(event_loop, aiohttp_server, run_sync_test):
+async def test_requests_error_code(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -419,7 +419,7 @@ async def test_requests_error_code(event_loop, aiohttp_server, run_sync_test):
             with pytest.raises(TransportQueryError):
                 session.execute_batch(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 invalid_protocol_responses = [
@@ -438,7 +438,7 @@ invalid_protocol_responses = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
 async def test_requests_invalid_protocol(
-    event_loop, aiohttp_server, response, run_sync_test
+    aiohttp_server, response, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -462,13 +462,13 @@ async def test_requests_invalid_protocol(
             with pytest.raises(TransportProtocolError):
                 session.execute_batch(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_cannot_execute_if_not_connected(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -492,7 +492,7 @@ async def test_requests_cannot_execute_if_not_connected(
         with pytest.raises(TransportClosed):
             transport.execute_batch(query)
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 query1_server_answer_with_extensions_list = (
@@ -509,7 +509,7 @@ query1_server_answer_with_extensions_list = (
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 async def test_requests_query_with_extensions(
-    event_loop, aiohttp_server, run_sync_test
+    aiohttp_server, run_sync_test
 ):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
@@ -537,7 +537,7 @@ async def test_requests_query_with_extensions(
 
             assert execution_results[0].extensions["key1"] == "val1"
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)
 
 
 ONLINE_URL = "https://countries.trevorblades.com/"

--- a/tests/test_requests_batch.py
+++ b/tests/test_requests_batch.py
@@ -91,9 +91,7 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query_auto_batch_enabled(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_query_auto_batch_enabled(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -437,9 +435,7 @@ invalid_protocol_responses = [
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response", invalid_protocol_responses)
-async def test_requests_invalid_protocol(
-    aiohttp_server, response, run_sync_test
-):
+async def test_requests_invalid_protocol(aiohttp_server, response, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -467,9 +463,7 @@ async def test_requests_invalid_protocol(
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_cannot_execute_if_not_connected(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_cannot_execute_if_not_connected(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 
@@ -508,9 +502,7 @@ query1_server_answer_with_extensions_list = (
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query_with_extensions(
-    aiohttp_server, run_sync_test
-):
+async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
     from gql.transport.requests import RequestsHTTPTransport
 

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -42,7 +42,7 @@ invalid_query1_server = [invalid_query1_server_answer]
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_websocket_invalid_query(event_loop, client_and_server, query_str):
+async def test_websocket_invalid_query(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -81,7 +81,7 @@ async def server_invalid_subscription(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_invalid_subscription], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_subscription_str])
-async def test_websocket_invalid_subscription(event_loop, client_and_server, query_str):
+async def test_websocket_invalid_subscription(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -113,7 +113,7 @@ async def server_no_ack(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_no_ack], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_websocket_server_does_not_send_ack(event_loop, server, query_str):
+async def test_websocket_server_does_not_send_ack(server, query_str):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -136,7 +136,7 @@ async def server_connection_error(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_connection_error], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_websocket_sending_invalid_data(event_loop, client_and_server, query_str):
+async def test_websocket_sending_invalid_data(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -165,7 +165,7 @@ async def server_invalid_payload(ws):
 @pytest.mark.parametrize("server", [server_invalid_payload], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
 async def test_websocket_sending_invalid_payload(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     session, server = client_and_server
@@ -235,7 +235,7 @@ sending_bytes = [b"\x01\x02\x03"]
     ],
     indirect=True,
 )
-async def test_websocket_transport_protocol_errors(event_loop, client_and_server):
+async def test_websocket_transport_protocol_errors(client_and_server):
 
     session, server = client_and_server
 
@@ -253,7 +253,7 @@ async def server_without_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_without_ack], indirect=True)
-async def test_websocket_server_does_not_ack(event_loop, server):
+async def test_websocket_server_does_not_ack(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -272,7 +272,7 @@ async def server_closing_directly(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_closing_directly], indirect=True)
-async def test_websocket_server_closing_directly(event_loop, server):
+async def test_websocket_server_closing_directly(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -292,7 +292,7 @@ async def server_closing_after_ack(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_closing_after_ack], indirect=True)
-async def test_websocket_server_closing_after_ack(event_loop, client_and_server):
+async def test_websocket_server_closing_after_ack(client_and_server):
 
     session, server = client_and_server
 
@@ -319,7 +319,7 @@ async def server_sending_invalid_query_errors(ws):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
-async def test_websocket_server_sending_invalid_query_errors(event_loop, server):
+async def test_websocket_server_sending_invalid_query_errors(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -334,7 +334,7 @@ async def test_websocket_server_sending_invalid_query_errors(event_loop, server)
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_sending_invalid_query_errors], indirect=True)
-async def test_websocket_non_regression_bug_105(event_loop, server):
+async def test_websocket_non_regression_bug_105(server):
     from gql.transport.websockets import WebsocketsTransport
 
     # This test will check a fix to a race condition which happens if the user is trying
@@ -364,7 +364,7 @@ async def test_websocket_non_regression_bug_105(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
 async def test_websocket_using_cli_invalid_query(
-    event_loop, server, monkeypatch, capsys
+    server, monkeypatch, capsys
 ):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -164,9 +164,7 @@ async def server_invalid_payload(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_invalid_payload], indirect=True)
 @pytest.mark.parametrize("query_str", [invalid_query_str])
-async def test_websocket_sending_invalid_payload(
-    client_and_server, query_str
-):
+async def test_websocket_sending_invalid_payload(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -363,9 +361,7 @@ async def test_websocket_non_regression_bug_105(server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [invalid_query1_server], indirect=True)
-async def test_websocket_using_cli_invalid_query(
-    server, monkeypatch, capsys
-):
+async def test_websocket_using_cli_invalid_query(server, monkeypatch, capsys):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -51,7 +51,7 @@ server1_answers = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_starting_client_in_context_manager(event_loop, server):
+async def test_websocket_starting_client_in_context_manager(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -91,7 +91,7 @@ async def test_websocket_starting_client_in_context_manager(event_loop, server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ws_ssl_server", [server1_answers], indirect=True)
-async def test_websocket_using_ssl_connection(event_loop, ws_ssl_server):
+async def test_websocket_using_ssl_connection(ws_ssl_server):
     import websockets
     from gql.transport.websockets import WebsocketsTransport
 
@@ -136,7 +136,7 @@ async def test_websocket_using_ssl_connection(event_loop, ws_ssl_server):
 @pytest.mark.parametrize("ws_ssl_server", [server1_answers], indirect=True)
 @pytest.mark.parametrize("verify_https", ["explicitely_enabled", "default"])
 async def test_websocket_using_ssl_connection_self_cert_fail(
-    event_loop, ws_ssl_server, verify_https
+    ws_ssl_server, verify_https
 ):
     from gql.transport.websockets import WebsocketsTransport
     from ssl import SSLCertVerificationError
@@ -178,7 +178,7 @@ async def test_websocket_using_ssl_connection_self_cert_fail(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_simple_query(event_loop, client_and_server, query_str):
+async def test_websocket_simple_query(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -199,7 +199,7 @@ server1_two_answers_in_series = [
 @pytest.mark.parametrize("server", [server1_two_answers_in_series], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_two_queries_in_series(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     session, server = client_and_server
@@ -235,7 +235,7 @@ async def server1_two_queries_in_parallel(ws):
 @pytest.mark.parametrize("server", [server1_two_queries_in_parallel], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_two_queries_in_parallel(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     session, server = client_and_server
@@ -282,7 +282,7 @@ async def server_closing_while_we_are_doing_something_else(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_server_closing_after_first_query(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     session, server = client_and_server
@@ -311,7 +311,7 @@ ignore_invalid_id_answers = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [ignore_invalid_id_answers], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_ignore_invalid_id(event_loop, client_and_server, query_str):
+async def test_websocket_ignore_invalid_id(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -346,7 +346,7 @@ async def assert_client_is_working(session):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_multiple_connections_in_series(event_loop, server):
+async def test_websocket_multiple_connections_in_series(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -369,7 +369,7 @@ async def test_websocket_multiple_connections_in_series(event_loop, server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_multiple_connections_in_parallel(event_loop, server):
+async def test_websocket_multiple_connections_in_parallel(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -389,7 +389,7 @@ async def test_websocket_multiple_connections_in_parallel(event_loop, server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
 async def test_websocket_trying_to_connect_to_already_connected_transport(
-    event_loop, server
+    server
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -437,7 +437,7 @@ async def server_with_authentication_in_connection_init_payload(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_connect_success_with_authentication_in_connection_init(
-    event_loop, server, query_str
+    server, query_str
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -472,7 +472,7 @@ async def test_websocket_connect_success_with_authentication_in_connection_init(
 @pytest.mark.parametrize("query_str", [query1_str])
 @pytest.mark.parametrize("init_payload", [{}, {"Authorization": "invalid_code"}])
 async def test_websocket_connect_failed_with_authentication_in_connection_init(
-    event_loop, server, query_str, init_payload
+    server, query_str, init_payload
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -534,7 +534,7 @@ def test_websocket_execute_sync(server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_add_extra_parameters_to_connect(event_loop, server):
+async def test_websocket_add_extra_parameters_to_connect(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -567,7 +567,7 @@ async def server_sending_keep_alive_before_connection_ack(ws):
 )
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_non_regression_bug_108(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     # This test will check that we now ignore keepalive message
@@ -590,7 +590,7 @@ async def test_websocket_non_regression_bug_108(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_using_cli(event_loop, server, monkeypatch, capsys):
+async def test_websocket_using_cli(server, monkeypatch, capsys):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
@@ -642,7 +642,7 @@ server1_answers_with_extensions = [
 @pytest.mark.parametrize("server", [server1_answers_with_extensions], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
 async def test_websocket_simple_query_with_extensions(
-    event_loop, client_and_server, query_str
+    client_and_server, query_str
 ):
 
     session, server = client_and_server
@@ -656,7 +656,7 @@ async def test_websocket_simple_query_with_extensions(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_adapter_connection_closed(event_loop, server):
+async def test_websocket_adapter_connection_closed(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -680,7 +680,7 @@ async def test_websocket_adapter_connection_closed(event_loop, server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_transport_closed_in_receive(event_loop, server):
+async def test_websocket_transport_closed_in_receive(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -198,9 +198,7 @@ server1_two_answers_in_series = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_two_answers_in_series], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_two_queries_in_series(
-    client_and_server, query_str
-):
+async def test_websocket_two_queries_in_series(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -234,9 +232,7 @@ async def server1_two_queries_in_parallel(ws):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_two_queries_in_parallel], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_two_queries_in_parallel(
-    client_and_server, query_str
-):
+async def test_websocket_two_queries_in_parallel(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -281,9 +277,7 @@ async def server_closing_while_we_are_doing_something_else(ws):
     "server", [server_closing_while_we_are_doing_something_else], indirect=True
 )
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_server_closing_after_first_query(
-    client_and_server, query_str
-):
+async def test_websocket_server_closing_after_first_query(client_and_server, query_str):
 
     session, server = client_and_server
 
@@ -388,9 +382,7 @@ async def test_websocket_multiple_connections_in_parallel(server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websocket_trying_to_connect_to_already_connected_transport(
-    server
-):
+async def test_websocket_trying_to_connect_to_already_connected_transport(server):
     from gql.transport.websockets import WebsocketsTransport
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -566,9 +558,7 @@ async def server_sending_keep_alive_before_connection_ack(ws):
     "server", [server_sending_keep_alive_before_connection_ack], indirect=True
 )
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_non_regression_bug_108(
-    client_and_server, query_str
-):
+async def test_websocket_non_regression_bug_108(client_and_server, query_str):
 
     # This test will check that we now ignore keepalive message
     # arriving before the connection_ack
@@ -641,9 +631,7 @@ server1_answers_with_extensions = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers_with_extensions], indirect=True)
 @pytest.mark.parametrize("query_str", [query1_str])
-async def test_websocket_simple_query_with_extensions(
-    client_and_server, query_str
-):
+async def test_websocket_simple_query_with_extensions(client_and_server, query_str):
 
     session, server = client_and_server
 

--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -172,9 +172,7 @@ async def test_websocket_subscription_get_execution_result(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_websocket_subscription_break(
-    client_and_server, subscription_str
-):
+async def test_websocket_subscription_break(client_and_server, subscription_str):
 
     session, server = client_and_server
 
@@ -203,9 +201,7 @@ async def test_websocket_subscription_break(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_websocket_subscription_task_cancel(
-    client_and_server, subscription_str
-):
+async def test_websocket_subscription_task_cancel(client_and_server, subscription_str):
 
     session, server = client_and_server
 

--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -126,7 +126,7 @@ countdown_subscription_str = """
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
-async def test_websocket_subscription(event_loop, client_and_server, subscription_str):
+async def test_websocket_subscription(client_and_server, subscription_str):
 
     session, server = client_and_server
 
@@ -148,7 +148,7 @@ async def test_websocket_subscription(event_loop, client_and_server, subscriptio
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_get_execution_result(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -173,7 +173,7 @@ async def test_websocket_subscription_get_execution_result(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_break(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -204,7 +204,7 @@ async def test_websocket_subscription_break(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_task_cancel(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -243,7 +243,7 @@ async def test_websocket_subscription_task_cancel(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_close_transport(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -308,7 +308,7 @@ async def server_countdown_close_connection_in_middle(ws):
 )
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_server_connection_closed(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
     session, server = client_and_server
 
@@ -331,7 +331,7 @@ async def test_websocket_subscription_server_connection_closed(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_slow_consumer(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -356,7 +356,7 @@ async def test_websocket_subscription_slow_consumer(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_with_operation_name(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -387,7 +387,7 @@ WITH_KEEPALIVE = True
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_with_keepalive(
-    event_loop, client_and_server, subscription_str
+    client_and_server, subscription_str
 ):
 
     session, server = client_and_server
@@ -410,7 +410,7 @@ async def test_websocket_subscription_with_keepalive(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_with_keepalive_with_timeout_ok(
-    event_loop, server, subscription_str
+    server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -447,7 +447,7 @@ async def test_websocket_subscription_with_keepalive_with_timeout_ok(
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_with_keepalive_with_timeout_nok(
-    event_loop, server, subscription_str
+    server, subscription_str
 ):
 
     from gql.transport.websockets import WebsocketsTransport
@@ -623,7 +623,7 @@ def test_websocket_subscription_sync_graceful_shutdown(server, subscription_str)
 @pytest.mark.parametrize("server", [server_countdown], indirect=True)
 @pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
 async def test_websocket_subscription_running_in_thread(
-    event_loop, server, subscription_str, run_sync_test
+    server, subscription_str, run_sync_test
 ):
     from gql.transport.websockets import WebsocketsTransport
 
@@ -647,4 +647,4 @@ async def test_websocket_subscription_running_in_thread(
 
         assert count == -1
 
-    await run_sync_test(event_loop, server, test_code)
+    await run_sync_test(server, test_code)

--- a/tests/test_websockets_adapter.py
+++ b/tests/test_websockets_adapter.py
@@ -33,7 +33,7 @@ server1_answers = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websockets_adapter_simple_query(event_loop, server):
+async def test_websockets_adapter_simple_query(server):
     from gql.transport.common.adapters.websockets import WebSocketsAdapter
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
@@ -65,7 +65,7 @@ async def test_websockets_adapter_simple_query(event_loop, server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", [server1_answers], indirect=True)
-async def test_websockets_adapter_edge_cases(event_loop, server):
+async def test_websockets_adapter_edge_cases(server):
     from gql.transport.common.adapters.websockets import WebSocketsAdapter
 
     url = f"ws://{server.hostname}:{server.port}/graphql"


### PR DESCRIPTION
Remove obsolete `event_loop` argument in tests.