### PR TITLE
Chore bump test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ console_scripts = [
 ]
 
 tests_requires = [
-    "parse==1.15.0",
+    "parse==1.20.2",
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
     "pytest-console-scripts==1.4.1",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_requires = [
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
     "pytest-console-scripts==1.4.1",
-    "pytest-cov==5.0.0",
+    "pytest-cov==6.0.0",
     "vcrpy==7.0.0",
     "aiofiles",
 ]


### PR DESCRIPTION
-  Bump `parse` to 1.20.2
-  Bump `pytest`-cov to 6.0.0