### PR TITLE
Chore bump aiohttp to 3.11.2

### DIFF
--- a/gql/transport/common/adapters/aiohttp.py
+++ b/gql/transport/common/adapters/aiohttp.py
@@ -4,7 +4,7 @@ from ssl import SSLContext
 from typing import Any, Dict, Literal, Mapping, Optional, Union
 
 import aiohttp
-from aiohttp import BasicAuth, Fingerprint, WSMsgType
+from aiohttp import BasicAuth, ClientWSTimeout, Fingerprint, WSMsgType
 from aiohttp.typedefs import LooseHeaders, StrOrURL
 from multidict import CIMultiDictProxy
 
@@ -132,6 +132,11 @@ class AIOHTTPWebSocketsAdapter(AdapterConnection):
 
             self.session = aiohttp.ClientSession(**client_session_args)
 
+        ws_timeout = ClientWSTimeout(
+            ws_receive=self.receive_timeout,
+            ws_close=self.websocket_close_timeout,
+        )
+
         connect_args: Dict[str, Any] = {
             "url": self.url,
             "headers": self.headers,
@@ -142,8 +147,7 @@ class AIOHTTPWebSocketsAdapter(AdapterConnection):
             "proxy": self.proxy,
             "proxy_auth": self.proxy_auth,
             "proxy_headers": self.proxy_headers,
-            "timeout": self.websocket_close_timeout,
-            "receive_timeout": self.receive_timeout,
+            "timeout": ws_timeout,
         }
 
         if self.subprotocols:

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.8.0,<4;python_version<='3.11'",
-    "aiohttp>=3.9.0b0,<4;python_version>'3.11'",
+    "aiohttp>=3.11.2,<4",
 ]
 
 install_requests_requires = [


### PR DESCRIPTION
We need at least `aiohttp` v3.11.2

See https://docs.aiohttp.org/en/stable/changes.html

Also using new `ClientWSTimeout` method for websockets timeout to remove deprecated message.