### PR TITLE
Upgrade lastest websockets and Exceptions overhaul

### DIFF
--- a/gql/transport/common/adapters/aiohttp.py
+++ b/gql/transport/common/adapters/aiohttp.py
@@ -178,12 +178,14 @@ class AIOHTTPWebSocketsAdapter(AdapterConnection):
             TransportConnectionFailed: If connection closed
         """
         if self.websocket is None:
-            raise TransportConnectionFailed("Connection is already closed")
+            raise TransportConnectionFailed("WebSocket connection is already closed")
 
         try:
             await self.websocket.send_str(message)
-        except ConnectionResetError as e:
-            raise TransportConnectionFailed("Connection was closed") from e
+        except Exception as e:
+            raise TransportConnectionFailed(
+                f"Error trying to send data: {type(e).__name__}"
+            ) from e
 
     async def receive(self) -> str:
         """Receive message from the WebSocket server.
@@ -200,6 +202,9 @@ class AIOHTTPWebSocketsAdapter(AdapterConnection):
             raise TransportConnectionFailed("Connection is already closed")
 
         while True:
+            # Should not raise any exception:
+            # https://docs.aiohttp.org/en/stable/_modules/aiohttp/client_ws.html
+            #                                           #ClientWebSocketResponse.receive
             ws_message = await self.websocket.receive()
 
             # Ignore low-level ping and pong received

--- a/gql/transport/common/adapters/websockets.py
+++ b/gql/transport/common/adapters/websockets.py
@@ -86,12 +86,14 @@ class WebSocketsAdapter(AdapterConnection):
             TransportConnectionFailed: If connection closed
         """
         if self.websocket is None:
-            raise TransportConnectionFailed("Connection is already closed")
+            raise TransportConnectionFailed("WebSocket connection is already closed")
 
         try:
             await self.websocket.send(message)
         except Exception as e:
-            raise TransportConnectionFailed("Connection was closed") from e
+            raise TransportConnectionFailed(
+                f"Error trying to send data: {type(e).__name__}"
+            ) from e
 
     async def receive(self) -> str:
         """Receive message from the WebSocket server.
@@ -111,7 +113,9 @@ class WebSocketsAdapter(AdapterConnection):
         try:
             data = await self.websocket.recv()
         except Exception as e:
-            raise TransportConnectionFailed("Connection was closed") from e
+            raise TransportConnectionFailed(
+                f"Error trying to receive data: {type(e).__name__}"
+            ) from e
 
         # websocket.recv() can return either str or bytes
         # In our case, we should receive only str here

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_httpx_requires = [
 ]
 
 install_websockets_requires = [
-    "websockets>=10.1,<14",
+    "websockets>=14.2,<16",
 ]
 
 install_botocore_requires = [

--- a/tests/test_aiohttp_online.py
+++ b/tests/test_aiohttp_online.py
@@ -19,10 +19,10 @@ async def test_aiohttp_simple_query():
     url = "https://countries.trevorblades.com/graphql"
 
     # Get transport
-    sample_transport = AIOHTTPTransport(url=url)
+    transport = AIOHTTPTransport(url=url)
 
     # Instanciate client
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query = gql(
             """
@@ -60,11 +60,9 @@ async def test_aiohttp_invalid_query():
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
-    sample_transport = AIOHTTPTransport(
-        url="https://countries.trevorblades.com/graphql"
-    )
+    transport = AIOHTTPTransport(url="https://countries.trevorblades.com/graphql")
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query = gql(
             """
@@ -89,12 +87,12 @@ async def test_aiohttp_two_queries_in_parallel_using_two_tasks():
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
-    sample_transport = AIOHTTPTransport(
+    transport = AIOHTTPTransport(
         url="https://countries.trevorblades.com/graphql",
     )
 
     # Instanciate client
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query1 = gql(
             """

--- a/tests/test_aiohttp_websocket_exceptions.py
+++ b/tests/test_aiohttp_websocket_exceptions.py
@@ -118,7 +118,7 @@ async def test_aiohttp_websocket_server_does_not_send_ack(server, query_str):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=1)
+    transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=0.1)
 
     with pytest.raises(asyncio.TimeoutError):
         async with Client(transport=transport):

--- a/tests/test_aiohttp_websocket_exceptions.py
+++ b/tests/test_aiohttp_websocket_exceptions.py
@@ -118,10 +118,10 @@ async def test_aiohttp_websocket_server_does_not_send_ack(server, query_str):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=1)
+    transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=1)
 
     with pytest.raises(asyncio.TimeoutError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -261,10 +261,10 @@ async def test_aiohttp_websocket_server_does_not_ack(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -281,10 +281,10 @@ async def test_aiohttp_websocket_server_closing_directly(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
     with pytest.raises(TransportConnectionFailed):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -323,10 +323,10 @@ async def test_aiohttp_websocket_server_sending_invalid_query_errors(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
     # Invalid server message is ignored
-    async with Client(transport=sample_transport):
+    async with Client(transport=transport):
         await asyncio.sleep(2 * MS)
 
 
@@ -342,9 +342,9 @@ async def test_aiohttp_websocket_non_regression_bug_105(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = AIOHTTPWebsocketsTransport(url=url)
+    transport = AIOHTTPWebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     # Create a coroutine which start the connection with the transport but does nothing
     async def client_connect(client):

--- a/tests/test_aiohttp_websocket_exceptions.py
+++ b/tests/test_aiohttp_websocket_exceptions.py
@@ -301,6 +301,15 @@ async def test_aiohttp_websocket_server_closing_after_ack(aiohttp_client_and_ser
 
     query = gql("query { hello }")
 
+    print("\n Trying to execute first query.\n")
+
+    with pytest.raises(TransportConnectionFailed):
+        await session.execute(query)
+
+    await session.transport.wait_closed()
+
+    print("\n Trying to execute second query.\n")
+
     with pytest.raises(TransportConnectionFailed):
         await session.execute(query)
 

--- a/tests/test_aiohttp_websocket_graphqlws_exceptions.py
+++ b/tests/test_aiohttp_websocket_graphqlws_exceptions.py
@@ -5,7 +5,6 @@ import pytest
 
 from gql import Client, gql
 from gql.transport.exceptions import (
-    TransportClosed,
     TransportConnectionFailed,
     TransportProtocolError,
     TransportQueryError,
@@ -264,10 +263,14 @@ async def test_aiohttp_websocket_graphqlws_server_closing_after_ack(
 
     query = gql("query { hello }")
 
+    print("\n Trying to execute first query.\n")
+
     with pytest.raises(TransportConnectionFailed):
         await session.execute(query)
 
     await session.transport.wait_closed()
 
-    with pytest.raises(TransportClosed):
+    print("\n Trying to execute second query.\n")
+
+    with pytest.raises(TransportConnectionFailed):
         await session.execute(query)

--- a/tests/test_aiohttp_websocket_graphqlws_exceptions.py
+++ b/tests/test_aiohttp_websocket_graphqlws_exceptions.py
@@ -117,7 +117,7 @@ async def test_aiohttp_websocket_graphqlws_server_does_not_send_ack(
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
 
-    transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=1)
+    transport = AIOHTTPWebsocketsTransport(url=url, ack_timeout=0.1)
 
     with pytest.raises(asyncio.TimeoutError):
         async with Client(transport=transport):

--- a/tests/test_aiohttp_websocket_graphqlws_subscription.py
+++ b/tests/test_aiohttp_websocket_graphqlws_subscription.py
@@ -11,7 +11,7 @@ from gql import Client, gql
 from gql.client import AsyncClientSession
 from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
 
-from .conftest import MS, PyPy, WebSocketServerHelper
+from .conftest import MS, WebSocketServerHelper
 
 # Marking all tests in this file with the aiohttp AND websockets marker
 pytestmark = [pytest.mark.aiohttp, pytest.mark.websockets]
@@ -821,7 +821,6 @@ async def test_aiohttp_websocket_graphqlws_subscription_reconnecting_session(
 ):
 
     from gql.transport.aiohttp_websockets import AIOHTTPWebsocketsTransport
-    from gql.transport.exceptions import TransportClosed
 
     path = "/graphql"
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}{path}"
@@ -839,56 +838,64 @@ async def test_aiohttp_websocket_graphqlws_subscription_reconnecting_session(
         reconnecting=True, retry_connect=False, retry_execute=False
     )
 
-    # First we make a subscription which will cause a disconnect in the backend
-    # (count=8)
+    # First we make a query or subscription which will cause a disconnect
+    # in the backend (count=8)
     try:
-        print("\nSUBSCRIPTION_1_WITH_DISCONNECT\n")
-        async for result in session.subscribe(subscription_with_disconnect):
-            pass
+        if execute_instead_of_subscribe:
+            print("\nEXECUTION_1\n")
+            await session.execute(subscription_with_disconnect)
+        else:
+            print("\nSUBSCRIPTION_1_WITH_DISCONNECT\n")
+            async for result in session.subscribe(subscription_with_disconnect):
+                pass
     except TransportConnectionFailed:
         pass
 
-    await asyncio.sleep(50 * MS)
+    # Wait for disconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if not transport._connected:
+            print(f"\nDisconnected in {i+1} MS")
+            break
 
-    # Then with the same session handle, we make a subscription or an execute
-    # which will detect that the transport is closed so that the client could
-    # try to reconnect
-    generator = None
-    try:
-        if execute_instead_of_subscribe:
-            print("\nEXECUTION_2\n")
-            await session.execute(subscription)
-        else:
-            print("\nSUBSCRIPTION_2\n")
-            generator = session.subscribe(subscription)
-            async for result in generator:
-                pass
-    except (TransportClosed, TransportConnectionFailed):
-        if generator:
-            await generator.aclose()
-        pass
+    assert transport._connected is False
 
-    timeout = 50
+    # Wait for reconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if transport._connected:
+            print(f"\nConnected again in {i+1} MS")
+            break
 
-    if PyPy:
-        timeout = 500
+    assert transport._connected is True
 
-    await asyncio.sleep(timeout * MS)
+    # Then after the reconnection, we make a query or a subscription
+    if execute_instead_of_subscribe:
+        print("\nEXECUTION_2\n")
+        result = await session.execute(subscription)
+        assert result["number"] == 10
+    else:
+        print("\nSUBSCRIPTION_2\n")
+        generator = session.subscribe(subscription)
+        async for result in generator:
+            number = result["number"]
+            print(f"Number received: {number}")
 
-    # And finally with the same session handle, we make a subscription
-    # which works correctly
-    print("\nSUBSCRIPTION_3\n")
-    generator = session.subscribe(subscription)
-    async for result in generator:
+            assert number == count
+            count -= 1
 
-        number = result["number"]
-        print(f"Number received: {number}")
+        await generator.aclose()
 
-        assert number == count
-        count -= 1
+        assert count == -1
 
-    await generator.aclose()
-
-    assert count == -1
-
+    # Close the reconnecting session
     await client.close_async()
+
+    # Wait for disconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if not transport._connected:
+            print(f"\nDisconnected in {i+1} MS")
+            break
+
+    assert transport._connected is False

--- a/tests/test_aiohttp_websocket_graphqlws_subscription.py
+++ b/tests/test_aiohttp_websocket_graphqlws_subscription.py
@@ -858,8 +858,6 @@ async def test_aiohttp_websocket_graphqlws_subscription_reconnecting_session(
             print(f"\nDisconnected in {i+1} MS")
             break
 
-    assert transport._connected is False
-
     # Wait for reconnect
     for i in range(200):
         await asyncio.sleep(1 * MS)

--- a/tests/test_aiohttp_websocket_query.py
+++ b/tests/test_aiohttp_websocket_query.py
@@ -8,7 +8,6 @@ import pytest
 from gql import Client, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
-    TransportClosed,
     TransportConnectionFailed,
     TransportQueryError,
     TransportServerError,
@@ -323,7 +322,7 @@ async def test_aiohttp_websocket_server_closing_after_first_query(
 
     # Now the server is closed but we don't know it yet, we have to send a query
     # to notice it and to receive the exception
-    with pytest.raises(TransportClosed):
+    with pytest.raises(TransportConnectionFailed):
         await session.execute(query)
 
 

--- a/tests/test_aiohttp_websocket_query.py
+++ b/tests/test_aiohttp_websocket_query.py
@@ -319,7 +319,7 @@ async def test_aiohttp_websocket_server_closing_after_first_query(
     await session.execute(query)
 
     # Then we do other things
-    await asyncio.sleep(1000 * MS)
+    await asyncio.sleep(10 * MS)
 
     # Now the server is closed but we don't know it yet, we have to send a query
     # to notice it and to receive the exception

--- a/tests/test_appsync_auth.py
+++ b/tests/test_appsync_auth.py
@@ -9,15 +9,15 @@ def test_appsync_init_with_minimal_args(fake_session_factory):
     from gql.transport.appsync_auth import AppSyncIAMAuthentication
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
 
-    sample_transport = AppSyncWebsocketsTransport(
+    transport = AppSyncWebsocketsTransport(
         url=mock_transport_url, session=fake_session_factory()
     )
-    assert isinstance(sample_transport.auth, AppSyncIAMAuthentication)
-    assert sample_transport.connect_timeout == 10
-    assert sample_transport.close_timeout == 10
-    assert sample_transport.ack_timeout == 10
-    assert sample_transport.ssl is False
-    assert sample_transport.connect_args == {}
+    assert isinstance(transport.auth, AppSyncIAMAuthentication)
+    assert transport.connect_timeout == 10
+    assert transport.close_timeout == 10
+    assert transport.ack_timeout == 10
+    assert transport.ssl is False
+    assert transport.connect_args == {}
 
 
 @pytest.mark.botocore
@@ -27,11 +27,11 @@ def test_appsync_init_with_no_credentials(caplog, fake_session_factory):
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
 
     with pytest.raises(botocore.exceptions.NoCredentialsError):
-        sample_transport = AppSyncWebsocketsTransport(
+        transport = AppSyncWebsocketsTransport(
             url=mock_transport_url,
             session=fake_session_factory(credentials=None),
         )
-        assert sample_transport.auth is None
+        assert transport.auth is None
 
     expected_error = "Credentials not found"
 
@@ -46,8 +46,8 @@ def test_appsync_init_with_jwt_auth():
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
 
     auth = AppSyncJWTAuthentication(host=mock_transport_host, jwt="some-jwt")
-    sample_transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
-    assert sample_transport.auth is auth
+    transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
+    assert transport.auth is auth
 
     assert auth.get_headers() == {
         "host": mock_transport_host,
@@ -61,8 +61,8 @@ def test_appsync_init_with_apikey_auth():
     from gql.transport.appsync_websockets import AppSyncWebsocketsTransport
 
     auth = AppSyncApiKeyAuthentication(host=mock_transport_host, api_key="some-api-key")
-    sample_transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
-    assert sample_transport.auth is auth
+    transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
+    assert transport.auth is auth
 
     assert auth.get_headers() == {
         "host": mock_transport_host,
@@ -95,8 +95,8 @@ def test_appsync_init_with_iam_auth_with_creds(fake_credentials_factory):
         credentials=fake_credentials_factory(),
         region_name="us-east-1",
     )
-    sample_transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
-    assert sample_transport.auth is auth
+    transport = AppSyncWebsocketsTransport(url=mock_transport_url, auth=auth)
+    assert transport.auth is auth
 
 
 @pytest.mark.botocore
@@ -153,7 +153,7 @@ def test_munge_url(fake_signer_factory, fake_request_factory):
         signer=fake_signer_factory(),
         request_creator=fake_request_factory,
     )
-    sample_transport = AppSyncWebsocketsTransport(url=test_url, auth=auth)
+    transport = AppSyncWebsocketsTransport(url=test_url, auth=auth)
 
     header_string = (
         "eyJGYWtlQXV0aG9yaXphdGlvbiI6ImEiLCJGYWtlVGltZSI6InRvZGF5"
@@ -164,7 +164,7 @@ def test_munge_url(fake_signer_factory, fake_request_factory):
         "wss://appsync-realtime-api.aws.example.org/"
         f"some-other-params?header={header_string}&payload=e30="
     )
-    assert sample_transport.url == expected_url
+    assert transport.url == expected_url
 
 
 @pytest.mark.botocore

--- a/tests/test_appsync_http.py
+++ b/tests/test_appsync_http.py
@@ -49,9 +49,9 @@ async def test_appsync_iam_mutation(aiohttp_server, fake_credentials_factory):
         region_name="us-east-1",
     )
 
-    sample_transport = AIOHTTPTransport(url=url, auth=auth)
+    transport = AIOHTTPTransport(url=url, auth=auth)
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query = gql(
             """

--- a/tests/test_appsync_websockets.py
+++ b/tests/test_appsync_websockets.py
@@ -139,7 +139,7 @@ def realtime_appsync_server_factory(
                 )
                 return
 
-            path = ws.path
+            path = ws.request.path
 
             print(f"path = {path}")
 

--- a/tests/test_async_client_validation.py
+++ b/tests/test_async_client_validation.py
@@ -91,9 +91,9 @@ async def test_async_client_validation(server, subscription_str, client_params):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport, **client_params)
+    client = Client(transport=transport, **client_params)
 
     async with client as session:
 
@@ -138,9 +138,9 @@ async def test_async_client_validation_invalid_query(
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport, **client_params)
+    client = Client(transport=transport, **client_params)
 
     async with client as session:
 
@@ -171,10 +171,10 @@ async def test_async_client_validation_different_schemas_parameters_forbidden(
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     with pytest.raises(AssertionError):
-        async with Client(transport=sample_transport, **client_params):
+        async with Client(transport=transport, **client_params):
             pass
 
 
@@ -261,10 +261,10 @@ async def test_async_client_validation_fetch_schema_from_server_with_client_argu
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     async with Client(
-        transport=sample_transport,
+        transport=transport,
         fetch_schema_from_transport=True,
     ) as session:
 

--- a/tests/test_graphqlws_exceptions.py
+++ b/tests/test_graphqlws_exceptions.py
@@ -5,7 +5,6 @@ import pytest
 
 from gql import Client, gql
 from gql.transport.exceptions import (
-    TransportClosed,
     TransportConnectionFailed,
     TransportProtocolError,
     TransportQueryError,
@@ -251,10 +250,32 @@ async def test_graphqlws_server_closing_after_ack(client_and_graphqlws_server):
 
     query = gql("query { hello }")
 
-    with pytest.raises(TransportClosed):
+    print("\n Trying to execute first query.\n")
+
+    with pytest.raises(TransportConnectionFailed) as exc1:
         await session.execute(query)
+
+    exc1_cause = exc1.value.__cause__
+    exc1_cause_str = f"{type(exc1_cause).__name__}:{exc1_cause!s}"
+
+    print(f"\n First query Exception cause: {exc1_cause_str}\n")
+
+    assert (
+        exc1_cause_str == "ConnectionClosedOK:received 1000 (OK); then sent 1000 (OK)"
+    )
 
     await session.transport.wait_closed()
 
-    with pytest.raises(TransportClosed):
+    print("\n Trying to execute second query.\n")
+
+    with pytest.raises(TransportConnectionFailed) as exc2:
         await session.execute(query)
+
+    exc2_cause = exc2.value.__cause__
+    exc2_cause_str = f"{type(exc2_cause).__name__}:{exc2_cause!s}"
+
+    print(f" Second query Exception cause: {exc2_cause_str}\n")
+
+    assert (
+        exc2_cause_str == "ConnectionClosedOK:received 1000 (OK); then sent 1000 (OK)"
+    )

--- a/tests/test_graphqlws_exceptions.py
+++ b/tests/test_graphqlws_exceptions.py
@@ -111,7 +111,7 @@ async def test_graphqlws_server_does_not_send_ack(graphqlws_server, query_str):
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
 
-    transport = WebsocketsTransport(url=url, ack_timeout=1)
+    transport = WebsocketsTransport(url=url, ack_timeout=0.1)
 
     with pytest.raises(asyncio.TimeoutError):
         async with Client(transport=transport):

--- a/tests/test_graphqlws_exceptions.py
+++ b/tests/test_graphqlws_exceptions.py
@@ -111,10 +111,10 @@ async def test_graphqlws_server_does_not_send_ack(graphqlws_server, query_str):
 
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url, ack_timeout=1)
+    transport = WebsocketsTransport(url=url, ack_timeout=1)
 
     with pytest.raises(asyncio.TimeoutError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -212,10 +212,10 @@ async def test_graphqlws_server_does_not_ack(graphqlws_server):
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -231,10 +231,10 @@ async def test_graphqlws_server_closing_directly(graphqlws_server):
     url = f"ws://{graphqlws_server.hostname}:{graphqlws_server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     with pytest.raises(TransportConnectionFailed):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -251,7 +251,7 @@ async def test_graphqlws_server_closing_after_ack(client_and_graphqlws_server):
 
     query = gql("query { hello }")
 
-    with pytest.raises(TransportConnectionFailed):
+    with pytest.raises(TransportClosed):
         await session.execute(query)
 
     await session.transport.wait_closed()

--- a/tests/test_graphqlws_subscription.py
+++ b/tests/test_graphqlws_subscription.py
@@ -852,8 +852,6 @@ async def test_graphqlws_subscription_reconnecting_session(
             print(f"\nDisconnected in {i+1} MS")
             break
 
-    assert transport._connected is False
-
     # Wait for reconnect
     for i in range(200):
         await asyncio.sleep(1 * MS)

--- a/tests/test_graphqlws_subscription.py
+++ b/tests/test_graphqlws_subscription.py
@@ -11,7 +11,7 @@ from gql import Client, gql
 from gql.client import AsyncClientSession
 from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
 
-from .conftest import MS, PyPy, WebSocketServerHelper
+from .conftest import MS, WebSocketServerHelper
 
 # Marking all tests in this file with the websockets marker
 pytestmark = pytest.mark.websockets
@@ -814,7 +814,6 @@ async def test_graphqlws_subscription_reconnecting_session(
     graphqlws_server, subscription_str, execute_instead_of_subscribe
 ):
 
-    from gql.transport.exceptions import TransportClosed
     from gql.transport.websockets import WebsocketsTransport
 
     path = "/graphql"
@@ -833,56 +832,64 @@ async def test_graphqlws_subscription_reconnecting_session(
         reconnecting=True, retry_connect=False, retry_execute=False
     )
 
-    # First we make a subscription which will cause a disconnect in the backend
-    # (count=8)
+    # First we make a query or subscription which will cause a disconnect
+    # in the backend (count=8)
     try:
-        print("\nSUBSCRIPTION_1_WITH_DISCONNECT\n")
-        async for result in session.subscribe(subscription_with_disconnect):
-            pass
+        if execute_instead_of_subscribe:
+            print("\nEXECUTION_1\n")
+            await session.execute(subscription_with_disconnect)
+        else:
+            print("\nSUBSCRIPTION_1_WITH_DISCONNECT\n")
+            async for result in session.subscribe(subscription_with_disconnect):
+                pass
     except TransportConnectionFailed:
         pass
 
-    await asyncio.sleep(50 * MS)
+    # Wait for disconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if not transport._connected:
+            print(f"\nDisconnected in {i+1} MS")
+            break
 
-    # Then with the same session handle, we make a subscription or an execute
-    # which will detect that the transport is closed so that the client could
-    # try to reconnect
-    generator = None
-    try:
-        if execute_instead_of_subscribe:
-            print("\nEXECUTION_2\n")
-            await session.execute(subscription)
-        else:
-            print("\nSUBSCRIPTION_2\n")
-            generator = session.subscribe(subscription)
-            async for result in generator:
-                pass
-    except (TransportClosed, TransportConnectionFailed):
-        if generator:
-            await generator.aclose()
-        pass
+    assert transport._connected is False
 
-    timeout = 50
+    # Wait for reconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if transport._connected:
+            print(f"\nConnected again in {i+1} MS")
+            break
 
-    if PyPy:
-        timeout = 500
+    assert transport._connected is True
 
-    await asyncio.sleep(timeout * MS)
+    # Then after the reconnection, we make a query or a subscription
+    if execute_instead_of_subscribe:
+        print("\nEXECUTION_2\n")
+        result = await session.execute(subscription)
+        assert result["number"] == 10
+    else:
+        print("\nSUBSCRIPTION_2\n")
+        generator = session.subscribe(subscription)
+        async for result in generator:
+            number = result["number"]
+            print(f"Number received: {number}")
 
-    # And finally with the same session handle, we make a subscription
-    # which works correctly
-    print("\nSUBSCRIPTION_3\n")
-    generator = session.subscribe(subscription)
-    async for result in generator:
+            assert number == count
+            count -= 1
 
-        number = result["number"]
-        print(f"Number received: {number}")
+        await generator.aclose()
 
-        assert number == count
-        count -= 1
+        assert count == -1
 
-    await generator.aclose()
-
-    assert count == -1
-
+    # Close the reconnecting session
     await client.close_async()
+
+    # Wait for disconnect
+    for i in range(200):
+        await asyncio.sleep(1 * MS)
+        if not transport._connected:
+            print(f"\nDisconnected in {i+1} MS")
+            break
+
+    assert transport._connected is False

--- a/tests/test_http_async_sync.py
+++ b/tests/test_http_async_sync.py
@@ -15,11 +15,11 @@ async def test_async_client_async_transport(fetch_schema_from_transport):
     url = "https://countries.trevorblades.com/graphql"
 
     # Get async transport
-    sample_transport = AIOHTTPTransport(url=url)
+    transport = AIOHTTPTransport(url=url)
 
     # Instantiate client
     async with Client(
-        transport=sample_transport,
+        transport=transport,
         fetch_schema_from_transport=fetch_schema_from_transport,
     ) as session:
 
@@ -58,17 +58,17 @@ async def test_async_client_sync_transport(fetch_schema_from_transport):
     url = "http://countries.trevorblades.com/graphql"
 
     # Get sync transport
-    sample_transport = RequestsHTTPTransport(url=url, use_json=True)
+    transport = RequestsHTTPTransport(url=url, use_json=True)
 
     # Impossible to use a sync transport asynchronously
     with pytest.raises(AssertionError):
         async with Client(
-            transport=sample_transport,
+            transport=transport,
             fetch_schema_from_transport=fetch_schema_from_transport,
         ):
             pass
 
-    sample_transport.close()
+    transport.close()
 
 
 @pytest.mark.aiohttp
@@ -82,11 +82,11 @@ def test_sync_client_async_transport(fetch_schema_from_transport):
     url = "https://countries.trevorblades.com/graphql"
 
     # Get async transport
-    sample_transport = AIOHTTPTransport(url=url)
+    transport = AIOHTTPTransport(url=url)
 
     # Instanciate client
     client = Client(
-        transport=sample_transport,
+        transport=transport,
         fetch_schema_from_transport=fetch_schema_from_transport,
     )
 
@@ -125,11 +125,11 @@ def test_sync_client_sync_transport(fetch_schema_from_transport):
     url = "https://countries.trevorblades.com/graphql"
 
     # Get sync transport
-    sample_transport = RequestsHTTPTransport(url=url, use_json=True)
+    transport = RequestsHTTPTransport(url=url, use_json=True)
 
     # Instanciate client
     client = Client(
-        transport=sample_transport,
+        transport=transport,
         fetch_schema_from_transport=fetch_schema_from_transport,
     )
 

--- a/tests/test_httpx_online.py
+++ b/tests/test_httpx_online.py
@@ -19,10 +19,10 @@ async def test_httpx_simple_query():
     url = "https://countries.trevorblades.com/graphql"
 
     # Get transport
-    sample_transport = HTTPXAsyncTransport(url=url)
+    transport = HTTPXAsyncTransport(url=url)
 
     # Instanciate client
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query = gql(
             """
@@ -60,11 +60,9 @@ async def test_httpx_invalid_query():
 
     from gql.transport.httpx import HTTPXAsyncTransport
 
-    sample_transport = HTTPXAsyncTransport(
-        url="https://countries.trevorblades.com/graphql"
-    )
+    transport = HTTPXAsyncTransport(url="https://countries.trevorblades.com/graphql")
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query = gql(
             """
@@ -89,12 +87,12 @@ async def test_httpx_two_queries_in_parallel_using_two_tasks():
 
     from gql.transport.httpx import HTTPXAsyncTransport
 
-    sample_transport = HTTPXAsyncTransport(
+    transport = HTTPXAsyncTransport(
         url="https://countries.trevorblades.com/graphql",
     )
 
     # Instanciate client
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         query1 = gql(
             """

--- a/tests/test_phoenix_channel_exceptions.py
+++ b/tests/test_phoenix_channel_exceptions.py
@@ -167,13 +167,11 @@ async def test_phoenix_channel_query_protocol_error(server, query_str):
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
-        channel_name="test_channel", url=url
-    )
+    transport = PhoenixChannelWebsocketsTransport(channel_name="test_channel", url=url)
 
     query = gql(query_str)
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             await session.execute(query)
 
 
@@ -197,13 +195,11 @@ async def test_phoenix_channel_query_error(server, query_str):
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
-        channel_name="test_channel", url=url
-    )
+    transport = PhoenixChannelWebsocketsTransport(channel_name="test_channel", url=url)
 
     query = gql(query_str)
     with pytest.raises(TransportQueryError):
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             await session.execute(query)
 
 
@@ -414,13 +410,11 @@ async def test_phoenix_channel_subscription_protocol_error(server, query_str):
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
-        channel_name="test_channel", url=url
-    )
+    transport = PhoenixChannelWebsocketsTransport(channel_name="test_channel", url=url)
 
     query = gql(query_str)
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             async for _result in session.subscribe(query):
                 await asyncio.sleep(10 * MS)
                 break
@@ -444,13 +438,11 @@ async def test_phoenix_channel_server_error(server, query_str):
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
-        channel_name="test_channel", url=url
-    )
+    transport = PhoenixChannelWebsocketsTransport(channel_name="test_channel", url=url)
 
     query = gql(query_str)
     with pytest.raises(TransportServerError):
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             await session.execute(query)
 
 
@@ -476,12 +468,12 @@ async def test_phoenix_channel_unsubscribe_error(server, query_str):
 
     # Reduce close_timeout. These tests will wait for an unsubscribe
     # reply that will never come...
-    sample_transport = PhoenixChannelWebsocketsTransport(
+    transport = PhoenixChannelWebsocketsTransport(
         channel_name="test_channel", url=url, close_timeout=1
     )
 
     query = gql(query_str)
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
         async for _result in session.subscribe(query):
             break
 
@@ -504,13 +496,13 @@ async def test_phoenix_channel_unsubscribe_error_forcing(server, query_str):
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
 
-    sample_transport = PhoenixChannelWebsocketsTransport(
+    transport = PhoenixChannelWebsocketsTransport(
         channel_name="test_channel", url=url, close_timeout=1
     )
 
     query = gql(query_str)
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             async for _result in session.subscribe(query):
                 await session.transport._send_stop_message(2)
                 await asyncio.sleep(10 * MS)

--- a/tests/test_phoenix_channel_subscription.py
+++ b/tests/test_phoenix_channel_subscription.py
@@ -191,14 +191,14 @@ async def test_phoenix_channel_subscription(server, subscription_str, end_count)
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
+    transport = PhoenixChannelWebsocketsTransport(
         channel_name=test_channel, url=url, close_timeout=5
     )
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
 
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
 
         generator = session.subscribe(subscription)
         async for result in generator:
@@ -240,14 +240,14 @@ async def test_phoenix_channel_subscription_no_break(server, subscription_str):
 
     async def testing_stopping_without_break():
 
-        sample_transport = PhoenixChannelWebsocketsTransport(
+        transport = PhoenixChannelWebsocketsTransport(
             channel_name=test_channel, url=url, close_timeout=(5000 * MS)
         )
 
         count = 10
         subscription = gql(subscription_str.format(count=count))
 
-        async with Client(transport=sample_transport) as session:
+        async with Client(transport=transport) as session:
             async for result in session.subscribe(subscription):
                 number = result["countdown"]["number"]
                 print(f"Number received: {number}")
@@ -372,12 +372,12 @@ async def test_phoenix_channel_heartbeat(server, subscription_str):
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = PhoenixChannelWebsocketsTransport(
+    transport = PhoenixChannelWebsocketsTransport(
         channel_name=test_channel, url=url, heartbeat_interval=0.1
     )
 
     subscription = gql(heartbeat_subscription_str)
-    async with Client(transport=sample_transport) as session:
+    async with Client(transport=transport) as session:
         i = 0
         generator = session.subscribe(subscription)
         async for result in generator:

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -118,7 +118,7 @@ async def test_websocket_server_does_not_send_ack(server, query_str):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    transport = WebsocketsTransport(url=url, ack_timeout=1)
+    transport = WebsocketsTransport(url=url, ack_timeout=0.1)
 
     with pytest.raises(asyncio.TimeoutError):
         async with Client(transport=transport):

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -296,7 +296,7 @@ async def test_websocket_server_closing_after_ack(client_and_server):
 
     query = gql("query { hello }")
 
-    with pytest.raises(TransportConnectionFailed):
+    with pytest.raises(TransportClosed):
         await session.execute(query)
 
     await session.transport.wait_closed()

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -8,7 +8,6 @@ import pytest
 from gql import Client, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
-    TransportClosed,
     TransportConnectionFailed,
     TransportProtocolError,
     TransportQueryError,
@@ -296,13 +295,35 @@ async def test_websocket_server_closing_after_ack(client_and_server):
 
     query = gql("query { hello }")
 
-    with pytest.raises(TransportClosed):
+    print("\n Trying to execute first query.\n")
+
+    with pytest.raises(TransportConnectionFailed) as exc1:
         await session.execute(query)
+
+    exc1_cause = exc1.value.__cause__
+    exc1_cause_str = f"{type(exc1_cause).__name__}:{exc1_cause!s}"
+
+    print(f"\n First query Exception cause: {exc1_cause_str}\n")
+
+    assert (
+        exc1_cause_str == "ConnectionClosedOK:received 1000 (OK); then sent 1000 (OK)"
+    )
 
     await session.transport.wait_closed()
 
-    with pytest.raises(TransportClosed):
+    print("\n Trying to execute second query.\n")
+
+    with pytest.raises(TransportConnectionFailed) as exc2:
         await session.execute(query)
+
+    exc2_cause = exc2.value.__cause__
+    exc2_cause_str = f"{type(exc2_cause).__name__}:{exc2_cause!s}"
+
+    print(f" Second query Exception cause: {exc2_cause_str}\n")
+
+    assert (
+        exc2_cause_str == "ConnectionClosedOK:received 1000 (OK); then sent 1000 (OK)"
+    )
 
 
 async def server_sending_invalid_query_errors(ws):

--- a/tests/test_websocket_exceptions.py
+++ b/tests/test_websocket_exceptions.py
@@ -118,10 +118,10 @@ async def test_websocket_server_does_not_send_ack(server, query_str):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    sample_transport = WebsocketsTransport(url=url, ack_timeout=1)
+    transport = WebsocketsTransport(url=url, ack_timeout=1)
 
     with pytest.raises(asyncio.TimeoutError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -257,10 +257,10 @@ async def test_websocket_server_does_not_ack(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     with pytest.raises(TransportProtocolError):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -276,10 +276,10 @@ async def test_websocket_server_closing_directly(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     with pytest.raises(TransportConnectionFailed):
-        async with Client(transport=sample_transport):
+        async with Client(transport=transport):
             pass
 
 
@@ -323,10 +323,10 @@ async def test_websocket_server_sending_invalid_query_errors(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
     # Invalid server message is ignored
-    async with Client(transport=sample_transport):
+    async with Client(transport=transport):
         await asyncio.sleep(2 * MS)
 
 
@@ -342,9 +342,9 @@ async def test_websocket_non_regression_bug_105(server):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     # Create a coroutine which start the connection with the transport but does nothing
     async def client_connect(client):

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -288,7 +288,7 @@ async def test_websocket_server_closing_after_first_query(client_and_server, que
     await session.execute(query)
 
     # Then we do other things
-    await asyncio.sleep(100 * MS)
+    await asyncio.sleep(10 * MS)
 
     # Now the server is closed but we don't know it yet, we have to send a query
     # to notice it and to receive the exception

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -8,7 +8,6 @@ import pytest
 from gql import Client, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
-    TransportClosed,
     TransportConnectionFailed,
     TransportQueryError,
     TransportServerError,
@@ -292,7 +291,7 @@ async def test_websocket_server_closing_after_first_query(client_and_server, que
 
     # Now the server is closed but we don't know it yet, we have to send a query
     # to notice it and to receive the exception
-    with pytest.raises(TransportClosed):
+    with pytest.raises(TransportConnectionFailed):
         await session.execute(query)
 
 
@@ -661,7 +660,7 @@ async def test_websocket_adapter_connection_closed(server):
         # Close adapter connection manually (should not be done)
         await transport.adapter.close()
 
-        with pytest.raises(TransportClosed):
+        with pytest.raises(TransportConnectionFailed):
             await session.execute(query1)
 
     # Check client is disconnect here
@@ -689,5 +688,5 @@ async def test_websocket_transport_closed_in_receive(server):
         # await transport.adapter.close()
         transport._connected = False
 
-        with pytest.raises(TransportClosed):
+        with pytest.raises(TransportConnectionFailed):
             await session.execute(query1)

--- a/tests/test_websocket_query.py
+++ b/tests/test_websocket_query.py
@@ -112,9 +112,7 @@ async def test_websocket_using_ssl_connection(ws_ssl_server):
 
     async with Client(transport=transport) as session:
 
-        assert isinstance(
-            transport.adapter.websocket, websockets.client.WebSocketClientProtocol
-        )
+        assert isinstance(transport.adapter.websocket, websockets.ClientConnection)
 
         query1 = gql(query1_str)
 

--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -420,11 +420,9 @@ async def test_websocket_subscription_with_keepalive_with_timeout_ok(
     if PyPy:
         keep_alive_timeout = 200 * MS
 
-    sample_transport = WebsocketsTransport(
-        url=url, keep_alive_timeout=keep_alive_timeout
-    )
+    transport = WebsocketsTransport(url=url, keep_alive_timeout=keep_alive_timeout)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -452,9 +450,9 @@ async def test_websocket_subscription_with_keepalive_with_timeout_nok(
 
     path = "/graphql"
     url = f"ws://{server.hostname}:{server.port}{path}"
-    sample_transport = WebsocketsTransport(url=url, keep_alive_timeout=(1 * MS))
+    transport = WebsocketsTransport(url=url, keep_alive_timeout=(1 * MS))
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -480,9 +478,9 @@ def test_websocket_subscription_sync(server, subscription_str):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -506,9 +504,9 @@ def test_websocket_subscription_sync_user_exception(server, subscription_str):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -537,9 +535,9 @@ def test_websocket_subscription_sync_break(server, subscription_str):
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -578,9 +576,9 @@ def test_websocket_subscription_sync_graceful_shutdown(server, subscription_str)
     url = f"ws://{server.hostname}:{server.port}/graphql"
     print(f"url = {url}")
 
-    sample_transport = WebsocketsTransport(url=url)
+    transport = WebsocketsTransport(url=url)
 
-    client = Client(transport=sample_transport)
+    client = Client(transport=transport)
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
@@ -630,9 +628,9 @@ async def test_websocket_subscription_running_in_thread(
     def test_code():
         path = "/graphql"
         url = f"ws://{server.hostname}:{server.port}{path}"
-        sample_transport = WebsocketsTransport(url=url)
+        transport = WebsocketsTransport(url=url)
 
-        client = Client(transport=sample_transport)
+        client = Client(transport=transport)
 
         count = 10
         subscription = gql(subscription_str.format(count=count))


### PR DESCRIPTION
- Using new asyncio implementation of the `websockets` dependency.
- Bump `websockets` to >=14.2
- Reduced some timers to make tests faster.
- Now the reconnecting session will reconnect as soon as it detects that the connection failed.
- Better log messages
- using `TransportConnectionFailed` instead of `TransportClosed` for exceptions which were due to the connection failing or closing. Using `TransportClosed` only for a closing of the transport initiated by the user.