### PR TITLE
change transports prototype using GraphQLRequest

### DIFF
--- a/gql/client.py
+++ b/gql/client.py
@@ -40,7 +40,6 @@ from .transport.local_schema import LocalSchemaTransport
 from .transport.transport import Transport
 from .utilities import build_client_schema, get_introspection_query_ast
 from .utilities import parse_result as parse_result_fn
-from .utilities import serialize_variable_values
 from .utils import str_first_element
 
 log = logging.getLogger(__name__)
@@ -68,6 +67,7 @@ class Client:
 
     def __init__(
         self,
+        *,
         schema: Optional[Union[str, GraphQLSchema]] = None,
         introspection: Optional[IntrospectionQuery] = None,
         transport: Optional[Union[Transport, AsyncTransport]] = None,
@@ -206,11 +206,11 @@ class Client:
     def execute_sync(
         self,
         document: DocumentNode,
+        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Dict[str, Any]: ...  # pragma: no cover
@@ -219,11 +219,11 @@ class Client:
     def execute_sync(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> ExecutionResult: ...  # pragma: no cover
@@ -232,11 +232,11 @@ class Client:
     def execute_sync(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], ExecutionResult]: ...  # pragma: no cover
@@ -244,6 +244,7 @@ class Client:
     def execute_sync(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -319,11 +320,11 @@ class Client:
     async def execute_async(
         self,
         document: DocumentNode,
+        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Dict[str, Any]: ...  # pragma: no cover
@@ -332,11 +333,11 @@ class Client:
     async def execute_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> ExecutionResult: ...  # pragma: no cover
@@ -345,11 +346,11 @@ class Client:
     async def execute_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], ExecutionResult]: ...  # pragma: no cover
@@ -357,6 +358,7 @@ class Client:
     async def execute_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -432,11 +434,11 @@ class Client:
     def execute(
         self,
         document: DocumentNode,
+        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,  # https://github.com/python/mypy/issues/7333#issuecomment-788255229
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Dict[str, Any]: ...  # pragma: no cover
@@ -445,11 +447,11 @@ class Client:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> ExecutionResult: ...  # pragma: no cover
@@ -458,11 +460,11 @@ class Client:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], ExecutionResult]: ...  # pragma: no cover
@@ -470,6 +472,7 @@ class Client:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -629,11 +632,11 @@ class Client:
     def subscribe_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> AsyncGenerator[Dict[str, Any], None]: ...  # pragma: no cover
@@ -642,11 +645,11 @@ class Client:
     def subscribe_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> AsyncGenerator[ExecutionResult, None]: ...  # pragma: no cover
@@ -655,11 +658,11 @@ class Client:
     def subscribe_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[
@@ -669,6 +672,7 @@ class Client:
     async def subscribe_async(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -697,11 +701,11 @@ class Client:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Generator[Dict[str, Any], None, None]: ...  # pragma: no cover
@@ -710,11 +714,11 @@ class Client:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> Generator[ExecutionResult, None, None]: ...  # pragma: no cover
@@ -723,11 +727,11 @@ class Client:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[
@@ -737,11 +741,11 @@ class Client:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
-        *,
         get_execution_result: bool = False,
         **kwargs: Any,
     ) -> Union[
@@ -925,19 +929,17 @@ class SyncClientSession:
 
     def _execute(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
     ) -> ExecutionResult:
-        """Execute the provided document AST synchronously using
+        """Execute the provided request synchronously using
         the sync transport, returning an ExecutionResult object.
 
-        :param document: GraphQL query as AST Node object.
-        :param variable_values: Dictionary of input parameters.
-        :param operation_name: Name of the operation that shall be executed.
+        :param request: GraphQL request as a
+                        :class:`GraphQLRequest <gql.GraphQLRequest>` object.
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
@@ -948,34 +950,22 @@ class SyncClientSession:
 
         # Validate document
         if self.client.schema:
-            self.client.validate(document)
+            self.client.validate(request.document)
 
             # Parse variable values for custom scalars if requested
-            if variable_values is not None:
+            if request.variable_values is not None:
                 if serialize_variables or (
                     serialize_variables is None and self.client.serialize_variables
                 ):
-                    variable_values = serialize_variable_values(
-                        self.client.schema,
-                        document,
-                        variable_values,
-                        operation_name=operation_name,
-                    )
+                    request = request.serialize_variable_values(self.client.schema)
 
         if self.client.batching_enabled:
-            request = GraphQLRequest(
-                document,
-                variable_values=variable_values,
-                operation_name=operation_name,
-            )
             future_result = self._execute_future(request)
             result = future_result.result()
 
         else:
             result = self.transport.execute(
-                document,
-                variable_values=variable_values,
-                operation_name=operation_name,
+                request,
                 **kwargs,
             )
 
@@ -984,9 +974,9 @@ class SyncClientSession:
             if parse_result or (parse_result is None and self.client.parse_results):
                 result.data = parse_result_fn(
                     self.client.schema,
-                    document,
+                    request.document,
                     result.data,
-                    operation_name=operation_name,
+                    operation_name=request.operation_name,
                 )
 
         return result
@@ -995,11 +985,11 @@ class SyncClientSession:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Dict[str, Any]: ...  # pragma: no cover
@@ -1008,11 +998,11 @@ class SyncClientSession:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> ExecutionResult: ...  # pragma: no cover
@@ -1021,11 +1011,11 @@ class SyncClientSession:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], ExecutionResult]: ...  # pragma: no cover
@@ -1033,6 +1023,7 @@ class SyncClientSession:
     def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -1059,11 +1050,16 @@ class SyncClientSession:
 
         The extra arguments are passed to the transport execute method."""
 
-        # Validate and execute on the transport
-        result = self._execute(
-            document,
+        # Make GraphQLRequest object
+        request = GraphQLRequest(
+            document=document,
             variable_values=variable_values,
             operation_name=operation_name,
+        )
+
+        # Validate and execute on the transport
+        result = self._execute(
+            request,
             serialize_variables=serialize_variables,
             parse_result=parse_result,
             **kwargs,
@@ -1337,7 +1333,9 @@ class SyncClientSession:
         introspection_query = get_introspection_query_ast(
             **self.client.introspection_args
         )
-        execution_result = self.transport.execute(introspection_query)
+        execution_result = self.transport.execute(
+            GraphQLRequest(document=introspection_query)
+        )
 
         self.client._build_schema_from_introspection(execution_result)
 
@@ -1360,23 +1358,21 @@ class AsyncClientSession:
 
     async def _subscribe(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
     ) -> AsyncGenerator[ExecutionResult, None]:
-        """Coroutine to subscribe asynchronously to the provided document AST
+        """Coroutine to subscribe asynchronously to the provided request
         asynchronously using the async transport,
         returning an async generator producing ExecutionResult objects.
 
         * Validate the query with the schema if provided.
         * Serialize the variable_values if requested.
 
-        :param document: GraphQL query as AST Node object.
-        :param variable_values: Dictionary of input parameters.
-        :param operation_name: Name of the operation that shall be executed.
+        :param request: GraphQL request as a
+                        :class:`GraphQLRequest <gql.GraphQLRequest>` object.
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
@@ -1387,26 +1383,19 @@ class AsyncClientSession:
 
         # Validate document
         if self.client.schema:
-            self.client.validate(document)
+            self.client.validate(request.document)
 
             # Parse variable values for custom scalars if requested
-            if variable_values is not None:
+            if request.variable_values is not None:
                 if serialize_variables or (
                     serialize_variables is None and self.client.serialize_variables
                 ):
-                    variable_values = serialize_variable_values(
-                        self.client.schema,
-                        document,
-                        variable_values,
-                        operation_name=operation_name,
-                    )
+                    request = request.serialize_variable_values(self.client.schema)
 
         # Subscribe to the transport
         inner_generator: AsyncGenerator[ExecutionResult, None] = (
             self.transport.subscribe(
-                document,
-                variable_values=variable_values,
-                operation_name=operation_name,
+                request,
                 **kwargs,
             )
         )
@@ -1423,9 +1412,9 @@ class AsyncClientSession:
                     ):
                         result.data = parse_result_fn(
                             self.client.schema,
-                            document,
+                            request.document,
                             result.data,
-                            operation_name=operation_name,
+                            operation_name=request.operation_name,
                         )
 
                 yield result
@@ -1437,11 +1426,11 @@ class AsyncClientSession:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> AsyncGenerator[Dict[str, Any], None]: ...  # pragma: no cover
@@ -1450,11 +1439,11 @@ class AsyncClientSession:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> AsyncGenerator[ExecutionResult, None]: ...  # pragma: no cover
@@ -1463,11 +1452,11 @@ class AsyncClientSession:
     def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[
@@ -1477,6 +1466,7 @@ class AsyncClientSession:
     async def subscribe(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -1505,10 +1495,15 @@ class AsyncClientSession:
 
         The extra arguments are passed to the transport subscribe method."""
 
-        inner_generator: AsyncGenerator[ExecutionResult, None] = self._subscribe(
-            document,
+        # Make GraphQLRequest object
+        request = GraphQLRequest(
+            document=document,
             variable_values=variable_values,
             operation_name=operation_name,
+        )
+
+        inner_generator: AsyncGenerator[ExecutionResult, None] = self._subscribe(
+            request,
             serialize_variables=serialize_variables,
             parse_result=parse_result,
             **kwargs,
@@ -1536,22 +1531,20 @@ class AsyncClientSession:
 
     async def _execute(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
     ) -> ExecutionResult:
-        """Coroutine to execute the provided document AST asynchronously using
+        """Coroutine to execute the provided request asynchronously using
         the async transport, returning an ExecutionResult object.
 
         * Validate the query with the schema if provided.
         * Serialize the variable_values if requested.
 
-        :param document: GraphQL query as AST Node object.
-        :param variable_values: Dictionary of input parameters.
-        :param operation_name: Name of the operation that shall be executed.
+        :param request: graphql request as a
+                        :class:`graphqlrequest <gql.graphqlrequest>` object.
         :param serialize_variables: whether the variable values should be
             serialized. Used for custom scalars and/or enums.
             By default use the serialize_variables argument of the client.
@@ -1562,26 +1555,19 @@ class AsyncClientSession:
 
         # Validate document
         if self.client.schema:
-            self.client.validate(document)
+            self.client.validate(request.document)
 
             # Parse variable values for custom scalars if requested
-            if variable_values is not None:
+            if request.variable_values is not None:
                 if serialize_variables or (
                     serialize_variables is None and self.client.serialize_variables
                 ):
-                    variable_values = serialize_variable_values(
-                        self.client.schema,
-                        document,
-                        variable_values,
-                        operation_name=operation_name,
-                    )
+                    request = request.serialize_variable_values(self.client.schema)
 
         # Execute the query with the transport with a timeout
         with fail_after(self.client.execute_timeout):
             result = await self.transport.execute(
-                document,
-                variable_values=variable_values,
-                operation_name=operation_name,
+                request,
                 **kwargs,
             )
 
@@ -1590,9 +1576,9 @@ class AsyncClientSession:
             if parse_result or (parse_result is None and self.client.parse_results):
                 result.data = parse_result_fn(
                     self.client.schema,
-                    document,
+                    request.document,
                     result.data,
-                    operation_name=operation_name,
+                    operation_name=request.operation_name,
                 )
 
         return result
@@ -1601,11 +1587,11 @@ class AsyncClientSession:
     async def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[False] = ...,
         **kwargs: Any,
     ) -> Dict[str, Any]: ...  # pragma: no cover
@@ -1614,11 +1600,11 @@ class AsyncClientSession:
     async def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: Literal[True],
         **kwargs: Any,
     ) -> ExecutionResult: ...  # pragma: no cover
@@ -1627,11 +1613,11 @@ class AsyncClientSession:
     async def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = ...,
         operation_name: Optional[str] = ...,
         serialize_variables: Optional[bool] = ...,
         parse_result: Optional[bool] = ...,
-        *,
         get_execution_result: bool,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], ExecutionResult]: ...  # pragma: no cover
@@ -1639,6 +1625,7 @@ class AsyncClientSession:
     async def execute(
         self,
         document: DocumentNode,
+        *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         serialize_variables: Optional[bool] = None,
@@ -1665,11 +1652,16 @@ class AsyncClientSession:
 
         The extra arguments are passed to the transport execute method."""
 
-        # Validate and execute on the transport
-        result = await self._execute(
-            document,
+        # Make GraphQLRequest object
+        request = GraphQLRequest(
+            document=document,
             variable_values=variable_values,
             operation_name=operation_name,
+        )
+
+        # Validate and execute on the transport
+        result = await self._execute(
+            request,
             serialize_variables=serialize_variables,
             parse_result=parse_result,
             **kwargs,
@@ -1844,7 +1836,9 @@ class AsyncClientSession:
         introspection_query = get_introspection_query_ast(
             **self.client.introspection_args
         )
-        execution_result = await self.transport.execute(introspection_query)
+        execution_result = await self.transport.execute(
+            GraphQLRequest(introspection_query)
+        )
 
         self.client._build_schema_from_introspection(execution_result)
 
@@ -1869,6 +1863,7 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
     def __init__(
         self,
         client: Client,
+        *,
         retry_connect: Union[bool, _Decorator] = True,
         retry_execute: Union[bool, _Decorator] = True,
     ):
@@ -1961,9 +1956,8 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
 
     async def _execute_once(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
@@ -1974,9 +1968,7 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
 
         try:
             answer = await super()._execute(
-                document,
-                variable_values=variable_values,
-                operation_name=operation_name,
+                request,
                 serialize_variables=serialize_variables,
                 parse_result=parse_result,
                 **kwargs,
@@ -1989,9 +1981,8 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
 
     async def _execute(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
@@ -2002,9 +1993,7 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
         """
 
         return await self._execute_with_retries(
-            document,
-            variable_values=variable_values,
-            operation_name=operation_name,
+            request,
             serialize_variables=serialize_variables,
             parse_result=parse_result,
             **kwargs,
@@ -2012,9 +2001,8 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
 
     async def _subscribe(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
+        *,
         serialize_variables: Optional[bool] = None,
         parse_result: Optional[bool] = None,
         **kwargs: Any,
@@ -2024,9 +2012,7 @@ class ReconnectingAsyncClientSession(AsyncClientSession):
         """
 
         inner_generator: AsyncGenerator[ExecutionResult, None] = super()._subscribe(
-            document,
-            variable_values=variable_values,
-            operation_name=operation_name,
+            request,
             serialize_variables=serialize_variables,
             parse_result=parse_result,
             **kwargs,

--- a/gql/graphql_request.py
+++ b/gql/graphql_request.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from graphql import DocumentNode, GraphQLSchema
+from graphql import DocumentNode, GraphQLSchema, print_ast
 
 from .utilities import serialize_variable_values
 
@@ -35,3 +35,16 @@ class GraphQLRequest:
             ),
             operation_name=self.operation_name,
         )
+
+    @property
+    def payload(self) -> Dict[str, Any]:
+        query_str = print_ast(self.document)
+        payload: Dict[str, Any] = {"query": query_str}
+
+        if self.operation_name:
+            payload["operationName"] = self.operation_name
+
+        if self.variable_values:
+            payload["variables"] = self.variable_values
+
+        return payload

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -170,7 +170,7 @@ class AIOHTTPTransport(AsyncTransport):
         extra_args: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
 
-        payload = [self._build_payload(req) for req in reqs]
+        payload = [req.payload for req in reqs]
 
         post_args = {"json": payload}
 
@@ -186,15 +186,15 @@ class AIOHTTPTransport(AsyncTransport):
 
     def _prepare_request(
         self,
-        req: GraphQLRequest,
+        request: GraphQLRequest,
         extra_args: Optional[Dict[str, Any]] = None,
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload = self._build_payload(req)
+        payload = request.payload
 
         if upload_files:
-            post_args = self._prepare_file_uploads(req, payload)
+            post_args = self._prepare_file_uploads(request, payload)
         else:
             post_args = {"json": payload}
 
@@ -216,11 +216,11 @@ class AIOHTTPTransport(AsyncTransport):
         return post_args
 
     def _prepare_file_uploads(
-        self, req: GraphQLRequest, payload: Dict[str, Any]
+        self, request: GraphQLRequest, payload: Dict[str, Any]
     ) -> Dict[str, Any]:
 
         # If the upload_files flag is set, then we need variable_values
-        variable_values = req.variable_values
+        variable_values = request.variable_values
         assert variable_values is not None
 
         # If we upload files, we will extract the files present in the

--- a/gql/transport/appsync_websockets.py
+++ b/gql/transport/appsync_websockets.py
@@ -4,8 +4,9 @@ from ssl import SSLContext
 from typing import Any, Dict, Optional, Tuple, Union, cast
 from urllib.parse import urlparse
 
-from graphql import DocumentNode, ExecutionResult, print_ast
+from graphql import ExecutionResult
 
+from ..graphql_request import GraphQLRequest
 from .appsync_auth import AppSyncAuthentication, AppSyncIAMAuthentication
 from .common.adapters.websockets import WebSocketsAdapter
 from .common.base import SubscriptionTransportBase
@@ -150,22 +151,14 @@ class AppSyncWebsocketsTransport(SubscriptionTransportBase):
 
     async def _send_query(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> int:
 
         query_id = self.next_query_id
 
         self.next_query_id += 1
 
-        data: Dict = {"query": print_ast(document)}
-
-        if variable_values:
-            data["variables"] = variable_values
-
-        if operation_name:
-            data["operationName"] = operation_name
+        data: Dict[str, Any] = self._build_payload(request)
 
         serialized_data = json.dumps(data, separators=(",", ":"))
 
@@ -203,9 +196,7 @@ class AppSyncWebsocketsTransport(SubscriptionTransportBase):
 
     async def execute(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> ExecutionResult:
         """This method is not available.
 

--- a/gql/transport/appsync_websockets.py
+++ b/gql/transport/appsync_websockets.py
@@ -158,7 +158,7 @@ class AppSyncWebsocketsTransport(SubscriptionTransportBase):
 
         self.next_query_id += 1
 
-        data: Dict[str, Any] = self._build_payload(request)
+        data: Dict[str, Any] = request.payload
 
         serialized_data = json.dumps(data, separators=(",", ":"))
 

--- a/gql/transport/async_transport.py
+++ b/gql/transport/async_transport.py
@@ -1,7 +1,7 @@
 import abc
-from typing import Any, AsyncGenerator, Dict, List
+from typing import Any, AsyncGenerator, List
 
-from graphql import ExecutionResult, print_ast
+from graphql import ExecutionResult
 
 from ..graphql_request import GraphQLRequest
 
@@ -63,15 +63,3 @@ class AsyncTransport(abc.ABC):
         raise NotImplementedError(
             "Any AsyncTransport subclass must implement subscribe method"
         )  # pragma: no cover
-
-    def _build_payload(self, req: GraphQLRequest) -> Dict[str, Any]:
-        query_str = print_ast(req.document)
-        payload: Dict[str, Any] = {"query": query_str}
-
-        if req.operation_name:
-            payload["operationName"] = req.operation_name
-
-        if req.variable_values:
-            payload["variables"] = req.variable_values
-
-        return payload

--- a/gql/transport/async_transport.py
+++ b/gql/transport/async_transport.py
@@ -1,7 +1,7 @@
 import abc
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List
 
-from graphql import DocumentNode, ExecutionResult
+from graphql import ExecutionResult, print_ast
 
 from ..graphql_request import GraphQLRequest
 
@@ -24,11 +24,9 @@ class AsyncTransport(abc.ABC):
     @abc.abstractmethod
     async def execute(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> ExecutionResult:
-        """Execute the provided document AST for either a remote or local GraphQL
+        """Execute the provided request for either a remote or local GraphQL
         Schema."""
         raise NotImplementedError(
             "Any AsyncTransport subclass must implement execute method"
@@ -54,9 +52,7 @@ class AsyncTransport(abc.ABC):
     @abc.abstractmethod
     def subscribe(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> AsyncGenerator[ExecutionResult, None]:
         """Send a query and receive the results using an async generator
 
@@ -67,3 +63,15 @@ class AsyncTransport(abc.ABC):
         raise NotImplementedError(
             "Any AsyncTransport subclass must implement subscribe method"
         )  # pragma: no cover
+
+    def _build_payload(self, req: GraphQLRequest) -> Dict[str, Any]:
+        query_str = print_ast(req.document)
+        payload: Dict[str, Any] = {"query": query_str}
+
+        if req.operation_name:
+            payload["operationName"] = req.operation_name
+
+        if req.variable_values:
+            payload["variables"] = req.variable_values
+
+        return payload

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -1,4 +1,3 @@
-import abc
 import io
 import json
 import logging
@@ -58,11 +57,6 @@ class _HTTPXTransport:
         self.json_deserialize = json_deserialize
         self.kwargs = kwargs
 
-    @abc.abstractmethod
-    def _build_payload(self, req: GraphQLRequest) -> Dict[str, Any]:
-        """This is Implemented in Transport and AsyncTransport"""
-        raise NotImplementedError()  # pragma: no cover
-
     def _prepare_request(
         self,
         req: GraphQLRequest,
@@ -70,7 +64,7 @@ class _HTTPXTransport:
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload = self._build_payload(req)
+        payload = req.payload
 
         if upload_files:
             post_args = self._prepare_file_uploads(req, payload)
@@ -93,7 +87,7 @@ class _HTTPXTransport:
         extra_args: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
 
-        payload = [self._build_payload(req) for req in reqs]
+        payload = [req.payload for req in reqs]
 
         post_args = {"json": payload}
 

--- a/gql/transport/phoenix_channel_websockets.py
+++ b/gql/transport/phoenix_channel_websockets.py
@@ -3,8 +3,9 @@ import json
 import logging
 from typing import Any, Dict, Optional, Tuple, Union
 
-from graphql import DocumentNode, ExecutionResult, print_ast
+from graphql import ExecutionResult, print_ast
 
+from ..graphql_request import GraphQLRequest
 from .common.adapters.websockets import WebSocketsAdapter
 from .common.base import SubscriptionTransportBase
 from .exceptions import (
@@ -182,9 +183,7 @@ class PhoenixChannelWebsocketsTransport(SubscriptionTransportBase):
 
     async def _send_query(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> int:
         """Send a query to the provided websocket connection.
 
@@ -201,8 +200,8 @@ class PhoenixChannelWebsocketsTransport(SubscriptionTransportBase):
                 "topic": self.channel_name,
                 "event": "doc",
                 "payload": {
-                    "query": print_ast(document),
-                    "variables": variable_values or {},
+                    "query": print_ast(request.document),
+                    "variables": request.variable_values or {},
                 },
                 "ref": query_id,
             }

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -162,7 +162,7 @@ class RequestsHTTPTransport(Transport):
         if not self.session:
             raise TransportClosed("Transport is not connected")
 
-        payload = self._build_payload(request)
+        payload = request.payload
 
         post_args: Dict[str, Any] = {
             "headers": self.headers,
@@ -372,7 +372,7 @@ class RequestsHTTPTransport(Transport):
         }
 
         data_key = "json" if self.use_json else "data"
-        post_args[data_key] = [self._build_payload(req) for req in reqs]
+        post_args[data_key] = [req.payload for req in reqs]
 
         # Log the payload
         if log.isEnabledFor(logging.INFO):

--- a/gql/transport/transport.py
+++ b/gql/transport/transport.py
@@ -1,7 +1,7 @@
 import abc
-from typing import Any, Dict, List
+from typing import Any, List
 
-from graphql import ExecutionResult, print_ast
+from graphql import ExecutionResult
 
 from ..graphql_request import GraphQLRequest
 
@@ -54,15 +54,3 @@ class Transport(abc.ABC):
         the session's connection pool.
         """
         pass  # pragma: no cover
-
-    def _build_payload(self, req: GraphQLRequest) -> Dict[str, Any]:
-        query_str = print_ast(req.document)
-        payload: Dict[str, Any] = {"query": query_str}
-
-        if req.operation_name:
-            payload["operationName"] = req.operation_name
-
-        if req.variable_values:
-            payload["variables"] = req.variable_values
-
-        return payload

--- a/gql/transport/websockets_protocol.py
+++ b/gql/transport/websockets_protocol.py
@@ -237,7 +237,7 @@ class WebsocketsProtocolTransportBase(SubscriptionTransportBase):
         query_id = self.next_query_id
         self.next_query_id += 1
 
-        payload: Dict[str, Any] = self._build_payload(request)
+        payload: Dict[str, Any] = request.payload
 
         query_type = "start"
 

--- a/gql/transport/websockets_protocol.py
+++ b/gql/transport/websockets_protocol.py
@@ -4,8 +4,9 @@ import logging
 from contextlib import suppress
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from graphql import DocumentNode, ExecutionResult, print_ast
+from graphql import ExecutionResult
 
+from ..graphql_request import GraphQLRequest
 from .common.adapters.connection import AdapterConnection
 from .common.base import SubscriptionTransportBase
 from .exceptions import (
@@ -224,9 +225,7 @@ class WebsocketsProtocolTransportBase(SubscriptionTransportBase):
 
     async def _send_query(
         self,
-        document: DocumentNode,
-        variable_values: Optional[Dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
+        request: GraphQLRequest,
     ) -> int:
         """Send a query to the provided websocket connection.
 
@@ -238,11 +237,7 @@ class WebsocketsProtocolTransportBase(SubscriptionTransportBase):
         query_id = self.next_query_id
         self.next_query_id += 1
 
-        payload: Dict[str, Any] = {"query": print_ast(document)}
-        if variable_values:
-            payload["variables"] = variable_values
-        if operation_name:
-            payload["operationName"] = operation_name
+        payload: Dict[str, Any] = self._build_payload(request)
 
         query_type = "start"
 

--- a/tests/starwars/test_subscription.py
+++ b/tests/starwars/test_subscription.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from graphql import ExecutionResult, GraphQLError, subscribe
 
-from gql import Client, gql
+from gql import Client, GraphQLRequest, gql
 
 from .fixtures import reviews
 from .schema import StarWarsSchema
@@ -93,7 +93,9 @@ async def test_subscription_support_using_client_invalid_field():
         results = [
             result
             async for result in await await_if_coroutine(
-                session.transport.subscribe(subs, variable_values=params)
+                session.transport.subscribe(
+                    GraphQLRequest(subs, variable_values=params)
+                )
             )
         ]
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -6,7 +6,7 @@ from typing import Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.cli import get_parser, main
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
@@ -421,7 +421,7 @@ async def test_aiohttp_cannot_execute_if_not_connected(aiohttp_server):
     query = gql(query1_str)
 
     with pytest.raises(TransportClosed):
-        await transport.execute(query)
+        await transport.execute(GraphQLRequest(query))
 
 
 @pytest.mark.asyncio
@@ -533,7 +533,9 @@ async def test_aiohttp_query_variable_values_fix_issue_292(aiohttp_server):
         query = gql(query2_str)
 
         # Execute query asynchronously
-        result = await session.execute(query, params, operation_name="getEurope")
+        result = await session.execute(
+            query, variable_values=params, operation_name="getEurope"
+        )
 
         continent = result["continent"]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
-from graphql import DocumentNode, ExecutionResult, build_ast_schema, parse
+from graphql import ExecutionResult, build_ast_schema, parse
 
 from gql import Client, GraphQLRequest, gql
 from gql.transport import Transport
@@ -40,7 +40,7 @@ def test_request_transport_not_implemented(http_transport_query):
     class RandomTransport2(Transport):
         def execute(
             self,
-            document: DocumentNode,
+            request: GraphQLRequest,
             *args: Any,
             **kwargs: Any,
         ) -> ExecutionResult:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -470,7 +470,7 @@ async def test_httpx_cannot_execute_if_not_connected(aiohttp_server, run_sync_te
         query = gql(query1_str)
 
         with pytest.raises(TransportClosed):
-            transport.execute(query)
+            transport.execute(GraphQLRequest(query))
 
     await run_sync_test(server, test_code)
 
@@ -578,32 +578,32 @@ async def test_httpx_file_upload(aiohttp_server, run_sync_test):
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
 
                     params = {"file": FileVar(f), "other_var": 42}
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using an filename string inside a FileVar object
                 params = {
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -650,22 +650,22 @@ async def test_httpx_file_upload_with_content_type(aiohttp_server, run_sync_test
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using FileVar
                 params = {
                     "file": FileVar(file_path, content_type="application/pdf"),
                     "other_var": 42,
                 }
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -710,11 +710,11 @@ async def test_httpx_file_upload_default_filename_is_basename(
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
         await run_sync_test(server, test_code)
 
@@ -751,11 +751,11 @@ async def test_httpx_file_upload_additional_headers(aiohttp_server, run_sync_tes
                 file_path = test_file.filename
 
                 params = {"file": FileVar(file_path), "other_var": 42}
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -797,11 +797,11 @@ async def test_httpx_binary_file_upload(aiohttp_server, run_sync_test):
 
                 params = {"file": FileVar(file_path), "other_var": 42}
 
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -867,11 +867,11 @@ async def test_httpx_file_upload_two_files(aiohttp_server, run_sync_test):
                         "file2": FileVar(file_path_2),
                     }
 
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -940,11 +940,11 @@ async def test_httpx_file_upload_list_of_two_files(aiohttp_server, run_sync_test
                         ],
                     }
 
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.cli import get_parser, main
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
@@ -429,7 +429,7 @@ async def test_httpx_cannot_execute_if_not_connected(aiohttp_server):
     query = gql(query1_str)
 
     with pytest.raises(TransportClosed):
-        await transport.execute(query)
+        await transport.execute(GraphQLRequest(query))
 
 
 @pytest.mark.aiohttp
@@ -541,7 +541,9 @@ async def test_httpx_query_variable_values_fix_issue_292(aiohttp_server):
         query = gql(query2_str)
 
         # Execute query asynchronously
-        result = await session.execute(query, params, operation_name="getEurope")
+        result = await session.execute(
+            query, variable_values=params, operation_name="getEurope"
+        )
 
         continent = result["continent"]
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -471,7 +471,7 @@ async def test_requests_cannot_execute_if_not_connected(aiohttp_server, run_sync
         query = gql(query1_str)
 
         with pytest.raises(TransportClosed):
-            transport.execute(query)
+            transport.execute(GraphQLRequest(query))
 
     await run_sync_test(server, test_code)
 
@@ -580,11 +580,11 @@ async def test_requests_file_upload(aiohttp_server, run_sync_test):
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
@@ -592,19 +592,19 @@ async def test_requests_file_upload(aiohttp_server, run_sync_test):
                     params = {"file": FileVar(f), "other_var": 42}
                     with warnings.catch_warnings():
                         warnings.simplefilter("error")  # Turn warnings into errors
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using an filename string inside a FileVar object
                 params = {"file": FileVar(file_path), "other_var": 42}
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -651,11 +651,11 @@ async def test_requests_file_upload_with_content_type(aiohttp_server, run_sync_t
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
@@ -664,11 +664,11 @@ async def test_requests_file_upload_with_content_type(aiohttp_server, run_sync_t
                         "file": FileVar(f, content_type="application/pdf"),
                         "other_var": 42,
                     }
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -713,11 +713,11 @@ async def test_requests_file_upload_default_filename_is_basename(
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session._execute(
+                execution_result = session.execute(
                     query, variable_values=params, upload_files=True
                 )
 
-                assert execution_result.data["success"]
+                assert execution_result["success"]
 
         await run_sync_test(server, test_code)
 
@@ -760,11 +760,11 @@ async def test_requests_file_upload_with_filename(aiohttp_server, run_sync_test)
                         "file": FileVar(f, filename="filename1.txt"),
                         "other_var": 42,
                     }
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -807,11 +807,11 @@ async def test_requests_file_upload_additional_headers(aiohttp_server, run_sync_
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -859,11 +859,11 @@ async def test_requests_binary_file_upload(aiohttp_server, run_sync_test):
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
     await run_sync_test(server, test_code)
 
@@ -937,11 +937,11 @@ async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params_1, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                     f1.close()
                     f2.close()
@@ -958,11 +958,11 @@ async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
                         "file2": FileVar(f2),
                     }
 
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params_2, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                     f1.close()
                     f2.close()
@@ -1037,11 +1037,11 @@ async def test_requests_file_upload_list_of_two_files(aiohttp_server, run_sync_t
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session._execute(
+                        execution_result = session.execute(
                             query, variable_values=params, upload_files=True
                         )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                     f1.close()
                     f2.close()
@@ -1055,11 +1055,11 @@ async def test_requests_file_upload_list_of_two_files(aiohttp_server, run_sync_t
 
                     params_2 = {"files": [FileVar(f1), FileVar(f2)]}
 
-                    execution_result = session._execute(
+                    execution_result = session.execute(
                         query, variable_values=params_2, upload_files=True
                     )
 
-                    assert execution_result.data["success"]
+                    assert execution_result["success"]
 
                     f1.close()
                     f2.close()


### PR DESCRIPTION
Everywhere in the code we are sending the `document`, `variable_values` and `operation_name` as arguments of the methods.
Now that we have a `GraphQLRequest` class which encapsulate those properties, it makes sense to use it instead.

Simplifying transport `execute` and `subscribe` methods prototypes by using a `GraphQLRequest` object intead of `document`, `variable_values` and `operation_name`

**Potential breaking changes**:

- `variable_values` and `operation_name` are now keyword arguments only in `client.py`:
   you cannot do `client.execute(query, params)` anymore and need to do `client.execute(query, variable_values=params)` instead
- if a custom transport is used, it would need to change its `execute` and `subscribe` prototype to conform to the new methods.