### PR TITLE
Set log level to DEBUG for all transports

### DIFF
--- a/docs/advanced/logging.rst
+++ b/docs/advanced/logging.rst
@@ -4,14 +4,7 @@ Logging
 GQL uses the python `logging`_ module.
 
 In order to debug a problem, you can enable logging to see the messages exchanged between the client and the server.
-To do that, set the loglevel at **INFO** at the beginning of your code:
-
-.. code-block:: python
-
-    import logging
-    logging.basicConfig(level=logging.INFO)
-
-For even more logs, you can set the loglevel at **DEBUG**:
+To do that, set the loglevel at **DEBUG** at the beginning of your code:
 
 .. code-block:: python
 
@@ -21,10 +14,7 @@ For even more logs, you can set the loglevel at **DEBUG**:
 Disabling logs
 --------------
 
-By default, the logs for the transports are quite verbose.
-
-On the **INFO** level, all the messages between the frontend and the backend are logged which can
-be difficult to read especially when it fetches the schema from the transport.
+On the **DEBUG** log level, the logs for the transports are quite verbose.
 
 It is possible to disable the logs only for a specific gql transport by setting a higher
 log level for this transport (**WARNING** for example) so that the other logs of your program are not affected.

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -175,8 +175,8 @@ class AIOHTTPTransport(AsyncTransport):
         post_args = {"json": payload}
 
         # Log the payload
-        if log.isEnabledFor(logging.INFO):
-            log.info(">>> %s", self.json_serialize(post_args["json"]))
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(">>> %s", self.json_serialize(post_args["json"]))
 
         # Pass post_args to aiohttp post method
         if extra_args:
@@ -199,8 +199,8 @@ class AIOHTTPTransport(AsyncTransport):
             post_args = {"json": payload}
 
         # Log the payload
-        if log.isEnabledFor(logging.INFO):
-            log.info(">>> %s", self.json_serialize(payload))
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(">>> %s", self.json_serialize(payload))
 
         # Pass post_args to aiohttp post method
         if extra_args:
@@ -299,9 +299,9 @@ class AIOHTTPTransport(AsyncTransport):
         try:
             result = await response.json(loads=self.json_deserialize, content_type=None)
 
-            if log.isEnabledFor(logging.INFO):
+            if log.isEnabledFor(logging.DEBUG):
                 result_text = await response.text()
-                log.info("<<< %s", result_text)
+                log.debug("<<< %s", result_text)
 
         except Exception:
             await self.raise_response_error(response, "Not a JSON answer")

--- a/gql/transport/common/base.py
+++ b/gql/transport/common/base.py
@@ -136,7 +136,7 @@ class SubscriptionTransportBase(AsyncTransport):
         try:
             # Can raise TransportConnectionFailed
             await self.adapter.send(message)
-            log.info(">>> %s", message)
+            log.debug(">>> %s", message)
         except TransportConnectionFailed as e:
             await self._fail(e, clean_close=False)
             raise e
@@ -152,7 +152,7 @@ class SubscriptionTransportBase(AsyncTransport):
         # Can raise TransportConnectionFailed or TransportProtocolError
         answer: str = await self.adapter.receive()
 
-        log.info("<<< %s", answer)
+        log.debug("<<< %s", answer)
 
         return answer
 

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -92,7 +92,7 @@ class _HTTPXTransport:
         post_args = {"json": payload}
 
         # Log the payload
-        if log.isEnabledFor(logging.INFO):
+        if log.isEnabledFor(logging.DEBUG):
             log.debug(">>> %s", self.json_serialize(payload))
 
         # Pass post_args to aiohttp post method

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -237,8 +237,8 @@ class RequestsHTTPTransport(Transport):
             post_args[data_key] = payload
 
         # Log the payload
-        if log.isEnabledFor(logging.INFO):
-            log.info(">>> %s", self.json_serialize(payload))
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(">>> %s", self.json_serialize(payload))
 
         # Pass kwargs to requests post method
         post_args.update(self.kwargs)
@@ -282,8 +282,8 @@ class RequestsHTTPTransport(Transport):
             else:
                 result = self.json_deserialize(response.text)
 
-            if log.isEnabledFor(logging.INFO):
-                log.info("<<< %s", response.text)
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug("<<< %s", response.text)
 
         except Exception:
             raise_response_error(response, "Not a JSON answer")
@@ -344,8 +344,8 @@ class RequestsHTTPTransport(Transport):
             response.raise_for_status()
             result = response.json()
 
-            if log.isEnabledFor(logging.INFO):
-                log.info("<<< %s", response.text)
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug("<<< %s", response.text)
 
         except requests.HTTPError as e:
             raise TransportServerError(
@@ -375,8 +375,8 @@ class RequestsHTTPTransport(Transport):
         post_args[data_key] = [req.payload for req in reqs]
 
         # Log the payload
-        if log.isEnabledFor(logging.INFO):
-            log.info(">>> %s", self.json_serialize(post_args[data_key]))
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(">>> %s", self.json_serialize(post_args[data_key]))
 
         # Pass kwargs to requests post method
         post_args.update(self.kwargs)


### PR DESCRIPTION
By popular request (#178, #400, #453), setting log level to `DEBUG` instead of `INFO` for all transports.