### PR TITLE
introspection now requests deprecated input fields by default

### DIFF
--- a/docs/gql-cli/intro.rst
+++ b/docs/gql-cli/intro.rst
@@ -81,10 +81,12 @@ Print the GraphQL schema in a file
 
 .. note::
 
-    By default, deprecated input fields are not requested from the backend.
-    You can add :code:`--schema-download input_value_deprecation:true` to request them.
-
-.. note::
-
     You can add :code:`--schema-download descriptions:false` to request a compact schema
     without comments.
+
+.. warning::
+
+    By default, from gql version 4.0, deprecated input fields are requested from the backend.
+    It is possible that some old backends do not support this feature. In that case
+    you can add :code:`--schema-download input_value_deprecation:false` to go back
+    to the previous behavior.

--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -24,7 +24,7 @@ The schema can be provided as a String (which is usually stored in a .graphql fi
 .. note::
     You can download a schema from a server by using :ref:`gql-cli <gql_cli>`
 
-    :code:`$ gql-cli https://SERVER_URL/graphql --print-schema --schema-download input_value_deprecation:true > schema.graphql`
+    :code:`$ gql-cli https://SERVER_URL/graphql --print-schema > schema.graphql`
 
 OR can be created using python classes:
 

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -132,12 +132,12 @@ def get_parser(with_examples: bool = False) -> ArgumentParser:
             By default, it will:
 
              - request field descriptions
-             - not request deprecated input fields
+             - request deprecated input fields
 
             Possible options:
 
              - descriptions:false             for a compact schema without comments
-             - input_value_deprecation:true   to download deprecated input fields
+             - input_value_deprecation:false  to omit deprecated input fields
              - specified_by_url:true
              - schema_description:true
              - directive_is_repeatable:true"""

--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -10,7 +10,7 @@ def get_introspection_query_ast(
     specified_by_url: bool = False,
     directive_is_repeatable: bool = False,
     schema_description: bool = False,
-    input_value_deprecation: bool = False,
+    input_value_deprecation: bool = True,
     type_recursion_level: int = 7,
 ) -> DocumentNode:
     """Get a query for introspection as a document using the DSL module.

--- a/tests/starwars/test_introspection.py
+++ b/tests/starwars/test_introspection.py
@@ -19,6 +19,9 @@ async def test_starwars_introspection_args(aiohttp_server):
     async with Client(
         transport=transport,
         fetch_schema_from_transport=True,
+        introspection_args={
+            "input_value_deprecation": False,
+        },
     ) as session:
 
         schema_str = print_schema(session.client.schema)
@@ -35,6 +38,7 @@ async def test_starwars_introspection_args(aiohttp_server):
         fetch_schema_from_transport=True,
         introspection_args={
             "descriptions": False,
+            "input_value_deprecation": False,
         },
     ) as session:
 
@@ -50,9 +54,6 @@ async def test_starwars_introspection_args(aiohttp_server):
     async with Client(
         transport=transport,
         fetch_schema_from_transport=True,
-        introspection_args={
-            "input_value_deprecation": True,
-        },
     ) as session:
 
         schema_str = print_schema(session.client.schema)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -43,6 +43,9 @@ def client():
                 url=URL, cookies={"csrftoken": csrf}, headers={"x-csrftoken": csrf}
             ),
             fetch_schema_from_transport=True,
+            introspection_args={
+                "input_value_deprecation": False,
+            },
         )
 
 

--- a/tests/test_transport_batch.py
+++ b/tests/test_transport_batch.py
@@ -43,6 +43,9 @@ def client():
                 url=URL, cookies={"csrftoken": csrf}, headers={"x-csrftoken": csrf}
             ),
             fetch_schema_from_transport=True,
+            introspection_args={
+                "input_value_deprecation": False,
+            },
         )
 
 


### PR DESCRIPTION
**Breaking change:**

 - changing the default introspection arguments to download all deprecated fields by default

## How to go back to previous behavior:

### Using cli

```python
gql-cli https://SERVER_URL/graphql --print-schema --schema-download input_value_deprecation:false
```

### Using Python code:

```python
Client(
    transport=transport,
    fetch_schema_from_transport=True,
    introspection_args={
        "input_value_deprecation": False,
    },
)
```