### PR TITLE
Remove MIT license classifier in favor of SPDX license expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Running `python -m build` to build the package generates the following warning:

```
        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```

This PR removes the obsolete classifier. We already have the "MIT" license expression defined.

