### PR TITLE
Using GraphQLRequest instead of DocumentNode for gql, execute, subscribe methods

### DIFF
--- a/docs/advanced/batching_requests.rst
+++ b/docs/advanced/batching_requests.rst
@@ -24,7 +24,7 @@ To execute a batch of requests manually:
 
 .. code-block:: python
 
-    request1 = GraphQLRequest("""
+    request1 = gql("""
         query getContinents {
           continents {
             code

--- a/docs/code_examples/appsync/mutation_api_key.py
+++ b/docs/code_examples/appsync/mutation_api_key.py
@@ -46,9 +46,9 @@ mutation createMessage($message: String!) {
 }"""
         )
 
-        variable_values = {"message": "Hello world!"}
+        query.variable_values = {"message": "Hello world!"}
 
-        result = await session.execute(query, variable_values=variable_values)
+        result = await session.execute(query)
         print(result)
 
 

--- a/docs/code_examples/appsync/mutation_iam.py
+++ b/docs/code_examples/appsync/mutation_iam.py
@@ -45,9 +45,9 @@ mutation createMessage($message: String!) {
 }"""
         )
 
-        variable_values = {"message": "Hello world!"}
+        query.variable_values = {"message": "Hello world!"}
 
-        result = await session.execute(query, variable_values=variable_values)
+        result = await session.execute(query)
         print(result)
 
 

--- a/docs/code_examples/console_async.py
+++ b/docs/code_examples/console_async.py
@@ -39,9 +39,7 @@ class GraphQLContinentClient:
 
         assert self._session is not None
 
-        answer = await self._session.execute(
-            self.get_continent_name_query
-        )
+        answer = await self._session.execute(self.get_continent_name_query)
 
         return answer.get("continent").get("name")  # type: ignore
 

--- a/docs/code_examples/console_async.py
+++ b/docs/code_examples/console_async.py
@@ -35,12 +35,12 @@ class GraphQLContinentClient:
         await self._client.close_async()
 
     async def get_continent_name(self, code):
-        params = {"code": code}
+        self.get_continent_name_query.variable_values = {"code": code}
 
         assert self._session is not None
 
         answer = await self._session.execute(
-            self.get_continent_name_query, variable_values=params
+            self.get_continent_name_query
         )
 
         return answer.get("continent").get("name")  # type: ignore

--- a/docs/code_examples/fastapi_async.py
+++ b/docs/code_examples/fastapi_async.py
@@ -93,7 +93,7 @@ async def get_continent(continent_code):
 
     try:
         assert isinstance(client.session, ReconnectingAsyncClientSession)
-        query.variable_values={"code": continent_code}
+        query.variable_values = {"code": continent_code}
         result = await client.session.execute(query)
     except Exception as e:
         log.debug(f"get_continent Error: {e}")

--- a/docs/code_examples/fastapi_async.py
+++ b/docs/code_examples/fastapi_async.py
@@ -93,9 +93,8 @@ async def get_continent(continent_code):
 
     try:
         assert isinstance(client.session, ReconnectingAsyncClientSession)
-        result = await client.session.execute(
-            query, variable_values={"code": continent_code}
-        )
+        query.variable_values={"code": continent_code}
+        result = await client.session.execute(query)
     except Exception as e:
         log.debug(f"get_continent Error: {e}")
         raise HTTPException(status_code=503, detail="GraphQL backend unavailable")

--- a/docs/code_examples/reconnecting_mutation_http.py
+++ b/docs/code_examples/reconnecting_mutation_http.py
@@ -33,10 +33,10 @@ async def main():
         # Execute single query
         query = gql("mutation ($message: String!) {sendMessage(message: $message)}")
 
-        params = {"message": f"test {num}"}
+        query.variable_values = {"message": f"test {num}"}
 
         try:
-            result = await session.execute(query, variable_values=params)
+            result = await session.execute(query)
             print(result)
         except Exception as e:
             print(f"Received exception {e}")

--- a/docs/code_examples/reconnecting_mutation_ws.py
+++ b/docs/code_examples/reconnecting_mutation_ws.py
@@ -33,10 +33,10 @@ async def main():
         # Execute single query
         query = gql("mutation ($message: String!) {sendMessage(message: $message)}")
 
-        params = {"message": f"test {num}"}
+        query.variable_values = {"message": f"test {num}"}
 
         try:
-            result = await session.execute(query, variable_values=params)
+            result = await session.execute(query)
             print(result)
         except Exception as e:
             print(f"Received exception {e}")

--- a/docs/usage/custom_scalars_and_enums.rst
+++ b/docs/usage/custom_scalars_and_enums.rst
@@ -203,11 +203,11 @@ In a variable
 
     query = gql("query shift5days($time: Datetime) {shiftDays(time: $time, days: 5)}")
 
-    variable_values = {
+    query.variable_values = {
         "time": "2021-11-12T11:58:13.461161",
     }
 
-    result = client.execute(query, variable_values=variable_values)
+    result = client.execute(query)
 
 - enum:
 
@@ -220,11 +220,11 @@ In a variable
         }"""
     )
 
-    variable_values = {
+    query.variable_values = {
         "color": 'RED',
     }
 
-    result = client.execute(query, variable_values=variable_values)
+    result = client.execute(query)
 
 Automatically
 ^^^^^^^^^^^^^
@@ -256,12 +256,10 @@ Examples:
         query = gql("query shift5days($time: Datetime) {shiftDays(time: $time, days: 5)}")
 
         # the argument for time is a datetime instance
-        variable_values = {"time": datetime.now()}
+        query.variable_values = {"time": datetime.now()}
 
         # we execute the query with serialize_variables set to True
-        result = await session.execute(
-            query, variable_values=variable_values, serialize_variables=True
-        )
+        result = await session.execute(query, serialize_variables=True)
 
 - enums:
 
@@ -285,14 +283,12 @@ Examples:
         )
 
         # the argument for time is an instance of our Enum type
-        variable_values = {
+        query.variable_values = {
             "color": Color.RED,
         }
 
         # we execute the query with serialize_variables set to True
-        result = client.execute(
-            query, variable_values=variable_values, serialize_variables=True
-        )
+        result = client.execute(query, serialize_variables=True)
 
 Parsing output
 --------------
@@ -319,11 +315,10 @@ Same example as above, with result parsing enabled:
 
         query = gql("query shift5days($time: Datetime) {shiftDays(time: $time, days: 5)}")
 
-        variable_values = {"time": datetime.now()}
+        query.variable_values = {"time": datetime.now()}
 
         result = await session.execute(
             query,
-            variable_values=variable_values,
             serialize_variables=True,
             parse_result=True,
         )

--- a/docs/usage/file_upload.rst
+++ b/docs/usage/file_upload.rst
@@ -15,7 +15,7 @@ In order to upload a single file, you need to:
 
 * set the file as a variable value in the mutation
 * create a :class:`FileVar <gql.FileVar>` object with your file path
-* provide the `FileVar` instance to the `variable_values` argument of `execute`
+* provide the `FileVar` instance to the `variable_values` attribute of your query
 * set the `upload_files` argument to True
 
 .. code-block:: python
@@ -37,11 +37,9 @@ In order to upload a single file, you need to:
       }
     ''')
 
-    params = {"file": FileVar("YOUR_FILE_PATH")}
+    query.variable_values = {"file": FileVar("YOUR_FILE_PATH")}
 
-    result = client.execute(
-        query, variable_values=params, upload_files=True
-    )
+    result = client.execute(query, upload_files=True)
 
 Setting the content-type
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,11 +95,9 @@ It is also possible to upload multiple files using a list.
     f1 = FileVar("YOUR_FILE_PATH_1")
     f2 = FileVar("YOUR_FILE_PATH_2")
 
-    params = {"files": [f1, f2]}
+    query.variable_values = {"files": [f1, f2]}
 
-    result = client.execute(
-        query, variable_values=params, upload_files=True
-    )
+    result = client.execute(query, upload_files=True)
 
 
 Streaming
@@ -150,11 +146,9 @@ setting the `streaming` argument of :class:`FileVar <gql.FileVar>` to `True`
         streaming=True,
     )
 
-    params = {"file": f1}
+    query.variable_values = {"file": f1}
 
-    result = client.execute(
-        query, variable_values=params, upload_files=True
-    )
+    result = client.execute(query, upload_files=True)
 
 Another option is to use an async generator to provide parts of the file.
 
@@ -172,11 +166,9 @@ to read the files in chunks and create this asynchronous generator.
                 yield chunk
 
     f1 = FileVar(file_sender(file_name='YOUR_FILE_PATH'))
-    params = {"file": f1}
+    query.variable_values = {"file": f1}
 
-    result = client.execute(
-        query, variable_values=params, upload_files=True
-    )
+    result = client.execute(query, upload_files=True)
 
 Streaming downloaded files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +185,7 @@ In order to do that, you need to:
 
 * get the response from an aiohttp request and then get the StreamReader instance
   from `resp.content`
-* provide the StreamReader instance to the `variable_values` argument of `execute`
+* provide the StreamReader instance to the `variable_values` attribute of your query
 
 Example:
 
@@ -204,7 +196,7 @@ Example:
         async with http_client.get('YOUR_DOWNLOAD_URL') as resp:
 
             # We now have a StreamReader instance in resp.content
-            # and we provide it to the variable_values argument of execute
+            # and we provide it to the variable_values attribute of the query
 
             transport = AIOHTTPTransport(url='YOUR_GRAPHQL_URL')
 
@@ -218,8 +210,6 @@ Example:
               }
             ''')
 
-            params = {"file": FileVar(resp.content)}
+            query.variable_values = {"file": FileVar(resp.content)}
 
-            result = client.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = client.execute(query, upload_files=True)

--- a/docs/usage/variables.rst
+++ b/docs/usage/variables.rst
@@ -2,7 +2,7 @@ Using variables
 ===============
 
 It is possible to provide variable values with your query by providing a Dict to
-the variable_values argument of the `execute` or the `subscribe` methods.
+the variable_values attribute of your query.
 
 The variable values will be sent alongside the query in the transport message
 (there is no local substitution).
@@ -19,14 +19,14 @@ The variable values will be sent alongside the query in the transport message
     """
     )
 
-    params = {"code": "EU"}
+    query.variable_values = {"code": "EU"}
 
     # Get name of continent with code "EU"
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     print(result)
 
-    params = {"code": "AF"}
+    query.variable_values = {"code": "AF"}
 
     # Get name of continent with code "AF"
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     print(result)

--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -64,6 +64,7 @@ from graphql import (
 )
 from graphql.pyutils import inspect
 
+from .graphql_request import GraphQLRequest
 from .utils import to_camel_case
 
 log = logging.getLogger(__name__)
@@ -214,7 +215,7 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
 
 def dsl_gql(
     *operations: "DSLExecutable", **operations_with_name: "DSLExecutable"
-) -> DocumentNode:
+) -> GraphQLRequest:
     r"""Given arguments instances of :class:`DSLExecutable`
     containing GraphQL operations or fragments,
     generate a Document which can be executed later in a
@@ -231,7 +232,8 @@ def dsl_gql(
     :param \**operations_with_name: the GraphQL operations with an operation name
     :type \**operations_with_name: DSLQuery, DSLMutation, DSLSubscription
 
-    :return: a Document which can be later executed or subscribed by a
+    :return: a :class:`GraphQLRequest <gql.GraphQLRequest>`
+        which can be later executed or subscribed by a
         :class:`Client <gql.client.Client>`, by an
         :class:`async session <gql.client.AsyncClientSession>` or by a
         :class:`sync session <gql.client.SyncClientSession>`
@@ -259,9 +261,11 @@ def dsl_gql(
                 f"Received: {type(operation)}."
             )
 
-    return DocumentNode(
+    document = DocumentNode(
         definitions=[operation.executable_ast for operation in all_operations]
     )
+
+    return GraphQLRequest(document)
 
 
 class DSLSchema:

--- a/gql/gql.py
+++ b/gql/gql.py
@@ -1,24 +1,17 @@
-from __future__ import annotations
-
-from graphql import DocumentNode, Source, parse
+from .graphql_request import GraphQLRequest
 
 
-def gql(request_string: str | Source) -> DocumentNode:
-    """Given a string containing a GraphQL request, parse it into a Document.
+def gql(request_string: str) -> GraphQLRequest:
+    """Given a string containing a GraphQL request,
+       parse it into a Document and put it into a GraphQLRequest object
 
     :param request_string: the GraphQL request as a String
-    :type request_string: str | Source
-    :return: a Document which can be later executed or subscribed by a
+    :return: a :class:`GraphQLRequest <gql.GraphQLRequest>`
+             which can be later executed or subscribed by a
         :class:`Client <gql.client.Client>`, by an
         :class:`async session <gql.client.AsyncClientSession>` or by a
         :class:`sync session <gql.client.SyncClientSession>`
 
     :raises graphql.error.GraphQLError: if a syntax error is encountered.
     """
-    if isinstance(request_string, Source):
-        source = request_string
-    elif isinstance(request_string, str):
-        source = Source(request_string, "GraphQL request")
-    else:
-        raise TypeError("Request must be passed as a string or Source object.")
-    return parse(source)
+    return GraphQLRequest(request_string)

--- a/gql/graphql_request.py
+++ b/gql/graphql_request.py
@@ -1,9 +1,7 @@
+import warnings
 from typing import Any, Dict, Optional, Union
 
-from graphql import DocumentNode, GraphQLSchema, print_ast
-
-from .gql import gql
-from .utilities import serialize_variable_values
+from graphql import DocumentNode, GraphQLSchema, Source, parse, print_ast
 
 
 class GraphQLRequest:
@@ -11,7 +9,7 @@ class GraphQLRequest:
 
     def __init__(
         self,
-        document: Union[DocumentNode, str],
+        request: Union[DocumentNode, "GraphQLRequest", str],
         *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
@@ -19,26 +17,52 @@ class GraphQLRequest:
         """
         Initialize a GraphQL request.
 
-        Args:
-            document: GraphQL query as AST Node object or as a string.
-                     If string, it will be converted to DocumentNode using gql().
-            variable_values: Dictionary of input parameters (Default: None).
-            operation_name: Name of the operation that shall be executed.
-                          Only required in multi-operation documents (Default: None).
-        """
-        if isinstance(document, str):
-            self.document = gql(document)
-        else:
-            self.document = document
+        :param request: GraphQL request as DocumentNode object or as a string.
+             If string, it will be converted to DocumentNode.
+        :param variable_values: Dictionary of input parameters (Default: None).
+        :param operation_name: Name of the operation that shall be executed.
+            Only required in multi-operation documents (Default: None).
 
-        self.variable_values = variable_values
-        self.operation_name = operation_name
+        :return: a :class:`GraphQLRequest <gql.GraphQLRequest>`
+                 which can be later executed or subscribed by a
+            :class:`Client <gql.client.Client>`, by an
+            :class:`async session <gql.client.AsyncClientSession>` or by a
+            :class:`sync session <gql.client.SyncClientSession>`
+        :raises graphql.error.GraphQLError: if a syntax error is encountered.
+
+        """
+        if isinstance(request, str):
+            source = Source(request, "GraphQL request")
+            self.document = parse(source)
+        elif isinstance(request, DocumentNode):
+            self.document = request
+        elif not isinstance(request, GraphQLRequest):
+            raise TypeError(f"Unexpected type for GraphQLRequest: {type(request)}")
+
+        if isinstance(request, GraphQLRequest):
+            self.document = request.document
+            self.variable_values: Optional[Dict[str, Any]] = (
+                request.variable_values
+                if request.variable_values is not None
+                else variable_values
+            )
+            self.operation_name: Optional[str] = (
+                request.operation_name
+                if request.operation_name is not None
+                else operation_name
+            )
+        else:
+            self.variable_values = variable_values
+            self.operation_name = operation_name
 
     def serialize_variable_values(self, schema: GraphQLSchema) -> "GraphQLRequest":
+
+        from .utilities.serialize_variable_values import serialize_variable_values
+
         assert self.variable_values
 
         return GraphQLRequest(
-            document=self.document,
+            self.document,
             variable_values=serialize_variable_values(
                 schema=schema,
                 document=self.document,
@@ -63,3 +87,47 @@ class GraphQLRequest:
 
     def __str__(self):
         return str(self.payload)
+
+
+def support_deprecated_request(
+    request: Union[GraphQLRequest, DocumentNode],
+    kwargs: Dict,
+) -> GraphQLRequest:
+    """This methods is there temporarily to convert the old style of calling
+    execute and subscribe methods with a DocumentNode,
+    variable_values and operation_name arguments.
+    """
+
+    if isinstance(request, DocumentNode):
+        warnings.warn(
+            (
+                "Using a DocumentNode is deprecated. Please use a "
+                "GraphQLRequest instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        request = GraphQLRequest(request)
+
+    if not isinstance(request, GraphQLRequest):
+        raise TypeError("request should be a GraphQLRequest object")
+
+    variable_values = kwargs.pop("variable_values", None)
+    operation_name = kwargs.pop("operation_name", None)
+
+    if variable_values or operation_name:
+        warnings.warn(
+            (
+                "Using variable_values and operation_name arguments of "
+                "execute and subscribe methods is deprecated. Instead, "
+                "please use the variable_values and operation_name properties "
+                "of GraphQLRequest"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        request.variable_values = variable_values
+        request.operation_name = operation_name
+
+    return request

--- a/gql/graphql_request.py
+++ b/gql/graphql_request.py
@@ -41,19 +41,13 @@ class GraphQLRequest:
 
         if isinstance(request, GraphQLRequest):
             self.document = request.document
-            self.variable_values: Optional[Dict[str, Any]] = (
-                request.variable_values
-                if request.variable_values is not None
-                else variable_values
-            )
-            self.operation_name: Optional[str] = (
-                request.operation_name
-                if request.operation_name is not None
-                else operation_name
-            )
-        else:
-            self.variable_values = variable_values
-            self.operation_name = operation_name
+            if variable_values is None:
+                variable_values = request.variable_values
+            if operation_name is None:
+                operation_name = request.operation_name
+
+        self.variable_values: Optional[Dict[str, Any]] = variable_values
+        self.operation_name: Optional[str] = operation_name
 
     def serialize_variable_values(self, schema: GraphQLSchema) -> "GraphQLRequest":
 

--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -139,4 +139,4 @@ def get_introspection_query_ast(
 
     dsl_query = dsl_gql(query, fragment_FullType, fragment_InputValue, fragment_TypeRef)
 
-    return dsl_query
+    return dsl_query.document

--- a/tests/custom_scalars/test_datetime.py
+++ b/tests/custom_scalars/test_datetime.py
@@ -117,11 +117,11 @@ def test_shift_days():
 
     query = gql("query shift5days($time: Datetime) {shiftDays(time: $time, days: 5)}")
 
-    variable_values = {
+    query.variable_values = {
         "time": now,
     }
 
-    result = client.execute(query, variable_values=variable_values)
+    result = client.execute(query)
 
     print(result)
 
@@ -151,11 +151,11 @@ def test_shift_days_serialized_manually_in_variables():
 
     query = gql("query shift5days($time: Datetime) {shiftDays(time: $time, days: 5)}")
 
-    variable_values = {
+    query.variable_values = {
         "time": "2021-11-12T11:58:13.461161",
     }
 
-    result = client.execute(query, variable_values=variable_values)
+    result = client.execute(query)
 
     print(result)
 
@@ -171,13 +171,11 @@ def test_latest():
 
     query = gql("query latest($times: [Datetime!]!) {latest(times: $times)}")
 
-    variable_values = {
+    query.variable_values = {
         "times": [now, in_five_days],
     }
 
-    result = client.execute(
-        query, variable_values=variable_values, serialize_variables=True
-    )
+    result = client.execute(query, serialize_variables=True)
 
     print(result)
 
@@ -194,11 +192,9 @@ def test_seconds():
         "query seconds($interval: IntervalInput) {seconds(interval: $interval)}"
     )
 
-    variable_values = {"interval": {"start": now, "end": in_five_days}}
+    query.variable_values = {"interval": {"start": now, "end": in_five_days}}
 
-    result = client.execute(
-        query, variable_values=variable_values, serialize_variables=True
-    )
+    result = client.execute(query, serialize_variables=True)
 
     print(result)
 
@@ -214,11 +210,9 @@ def test_seconds_omit_optional_start_argument():
         "query seconds($interval: IntervalInput) {seconds(interval: $interval)}"
     )
 
-    variable_values = {"interval": {"end": in_five_days}}
+    query.variable_values = {"interval": {"end": in_five_days}}
 
-    result = client.execute(
-        query, variable_values=variable_values, serialize_variables=True
-    )
+    result = client.execute(query, serialize_variables=True)
 
     print(result)
 

--- a/tests/custom_scalars/test_enum_colors.py
+++ b/tests/custom_scalars/test_enum_colors.py
@@ -165,11 +165,11 @@ def test_opposite_color_variable_serialized_manually():
         }"""
     )
 
-    variable_values = {
+    query.variable_values = {
         "color": "RED",
     }
 
-    result = client.execute(query, variable_values=variable_values)
+    result = client.execute(query)
 
     print(result)
 
@@ -190,13 +190,11 @@ def test_opposite_color_variable_serialized_by_gql():
         }"""
     )
 
-    variable_values = {
+    query.variable_values = {
         "color": RED,
     }
 
-    result = client.execute(
-        query, variable_values=variable_values, serialize_variables=True
-    )
+    result = client.execute(query, serialize_variables=True)
 
     print(result)
 
@@ -328,13 +326,12 @@ def test_parse_results_with_operation_type():
         """
     )
 
-    variable_values = {
+    query.variable_values = {
         "color": "RED",
     }
+    query.operation_name = "GetOppositeColor"
 
-    result = client.execute(
-        query, variable_values=variable_values, operation_name="GetOppositeColor"
-    )
+    result = client.execute(query)
 
     print(result)
 

--- a/tests/custom_scalars/test_json.py
+++ b/tests/custom_scalars/test_json.py
@@ -166,7 +166,7 @@ def test_json_value_input_in_ast_with_variables():
 }"""
     )
 
-    variable_values = {
+    query.variable_values = {
         "name": "Barbara",
         "level": 1,
         "is_connected": False,
@@ -174,9 +174,7 @@ def test_json_value_input_in_ast_with_variables():
         "friends": ["Alex", "John"],
     }
 
-    result = client.execute(
-        query, variable_values=variable_values, root_value=root_value
-    )
+    result = client.execute(query, root_value=root_value)
 
     print(result)
 

--- a/tests/custom_scalars/test_money.py
+++ b/tests/custom_scalars/test_money.py
@@ -765,14 +765,14 @@ async def test_custom_scalar_serialize_variables_sync_transport_2(
     def test_code():
         with Client(schema=schema, transport=transport, parse_results=True) as session:
 
-            query = gql("query myquery($money: Money) {toEuros(money: $money)}")
+            query = "query myquery($money: Money) {toEuros(money: $money)}"
 
             variable_values = {"money": Money(10, "DM")}
 
             results = session.execute_batch(
                 [
-                    GraphQLRequest(document=query, variable_values=variable_values),
-                    GraphQLRequest(document=query, variable_values=variable_values),
+                    GraphQLRequest(query, variable_values=variable_values),
+                    GraphQLRequest(query, variable_values=variable_values),
                 ],
                 serialize_variables=True,
             )
@@ -793,14 +793,14 @@ async def test_custom_scalar_serialize_variables_async_transport(aiohttp_server)
         schema=schema, transport=transport, parse_results=True
     ) as session:
 
-        query = gql("query myquery($money: Money) {toEuros(money: $money)}")
+        query = "query myquery($money: Money) {toEuros(money: $money)}"
 
         variable_values = {"money": Money(10, "DM")}
 
         results = await session.execute_batch(
             [
-                GraphQLRequest(document=query, variable_values=variable_values),
-                GraphQLRequest(document=query, variable_values=variable_values),
+                GraphQLRequest(query, variable_values=variable_values),
+                GraphQLRequest(query, variable_values=variable_values),
             ],
             serialize_variables=True,
         )

--- a/tests/custom_scalars/test_money.py
+++ b/tests/custom_scalars/test_money.py
@@ -20,7 +20,7 @@ from graphql.type import (
 )
 from graphql.utilities import value_from_ast_untyped
 
-from gql import Client, GraphQLRequest, gql
+from gql import Client, gql
 from gql.transport.exceptions import TransportQueryError
 from gql.utilities import serialize_value, update_schema_scalar, update_schema_scalars
 
@@ -275,11 +275,9 @@ def test_custom_scalar_in_input_variable_values():
 
     money_value = {"amount": 10, "currency": "DM"}
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
 
-    result = client.execute(
-        query, variable_values=variable_values, root_value=root_value
-    )
+    result = client.execute(query, root_value=root_value)
 
     assert result["toEuros"] == 5
 
@@ -292,11 +290,10 @@ def test_custom_scalar_in_input_variable_values_serialized():
 
     money_value = Money(10, "DM")
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
 
     result = client.execute(
         query,
-        variable_values=variable_values,
         root_value=root_value,
         serialize_variables=True,
     )
@@ -312,14 +309,13 @@ def test_custom_scalar_in_input_variable_values_serialized_with_operation_name()
 
     money_value = Money(10, "DM")
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
+    query.operation_name = "myquery"
 
     result = client.execute(
         query,
-        variable_values=variable_values,
         root_value=root_value,
         serialize_variables=True,
-        operation_name="myquery",
     )
 
     assert result["toEuros"] == 5
@@ -342,12 +338,11 @@ def test_serialize_variable_values_exception_multiple_ops_without_operation_name
 
     money_value = Money(10, "DM")
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
 
     with pytest.raises(GraphQLError) as exc_info:
         client.execute(
             query,
-            variable_values=variable_values,
             root_value=root_value,
             serialize_variables=True,
         )
@@ -374,15 +369,14 @@ def test_serialize_variable_values_exception_operation_name_not_found():
 
     money_value = Money(10, "DM")
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
+    query.operation_name = "invalid_operation_name"
 
     with pytest.raises(GraphQLError) as exc_info:
         client.execute(
             query,
-            variable_values=variable_values,
             root_value=root_value,
             serialize_variables=True,
-            operation_name="invalid_operation_name",
         )
 
     exception = exc_info.value
@@ -398,13 +392,12 @@ def test_custom_scalar_subscribe_in_input_variable_values_serialized():
 
     money_value = Money(10, "DM")
 
-    variable_values = {"money": money_value}
+    query.variable_values = {"money": money_value}
 
     expected_result = {"spend": Money(10, "DM")}
 
     for result in client.subscribe(
         query,
-        variable_values=variable_values,
         root_value=root_value,
         serialize_variables=True,
         parse_result=True,
@@ -544,9 +537,9 @@ async def test_custom_scalar_in_input_variable_values_with_transport(aiohttp_ser
         money_value = {"amount": 10, "currency": "DM"}
         # money_value = Money(10, "DM")
 
-        variable_values = {"money": money_value}
+        query.variable_values = {"money": money_value}
 
-        result = await session.execute(query, variable_values=variable_values)
+        result = await session.execute(query)
 
         print(f"result = {result!r}")
         assert result["toEuros"] == 5
@@ -570,9 +563,9 @@ query myquery($amount: Float, $currency: String) {
 }"""
         )
 
-        variable_values = {"amount": 10, "currency": "DM"}
+        query.variable_values = {"amount": 10, "currency": "DM"}
 
-        result = await session.execute(query, variable_values=variable_values)
+        result = await session.execute(query)
 
         print(f"result = {result!r}")
         assert result["toEuros"] == 5
@@ -590,11 +583,9 @@ async def test_custom_scalar_serialize_variables(aiohttp_server):
 
         query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-        variable_values = {"money": Money(10, "DM")}
+        query.variable_values = {"money": Money(10, "DM")}
 
-        result = await session.execute(
-            query, variable_values=variable_values, serialize_variables=True
-        )
+        result = await session.execute(query, serialize_variables=True)
 
         print(f"result = {result!r}")
         assert result["toEuros"] == 5
@@ -611,12 +602,10 @@ async def test_custom_scalar_serialize_variables_no_schema(aiohttp_server):
 
         query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-        variable_values = {"money": Money(10, "DM")}
+        query.variable_values = {"money": Money(10, "DM")}
 
         with pytest.raises(TransportQueryError):
-            await session.execute(
-                query, variable_values=variable_values, serialize_variables=True
-            )
+            await session.execute(query, serialize_variables=True)
 
 
 @pytest.mark.asyncio
@@ -643,11 +632,9 @@ async def test_custom_scalar_serialize_variables_schema_from_introspection(
 
         query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-        variable_values = {"money": Money(10, "DM")}
+        query.variable_values = {"money": Money(10, "DM")}
 
-        result = await session.execute(
-            query, variable_values=variable_values, serialize_variables=True
-        )
+        result = await session.execute(query, serialize_variables=True)
 
         print(f"result = {result!r}")
         assert result["toEuros"] == 5
@@ -667,11 +654,9 @@ async def test_update_schema_scalars(aiohttp_server):
 
         query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-        variable_values = {"money": Money(10, "DM")}
+        query.variable_values = {"money": Money(10, "DM")}
 
-        result = await session.execute(
-            query, variable_values=variable_values, serialize_variables=True
-        )
+        result = await session.execute(query, serialize_variables=True)
 
         print(f"result = {result!r}")
         assert result["toEuros"] == 5
@@ -743,11 +728,9 @@ async def test_custom_scalar_serialize_variables_sync_transport(
 
             query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-            variable_values = {"money": Money(10, "DM")}
+            query.variable_values = {"money": Money(10, "DM")}
 
-            result = session.execute(
-                query, variable_values=variable_values, serialize_variables=True
-            )
+            result = session.execute(query, serialize_variables=True)
 
             print(f"result = {result!r}")
             assert result["toEuros"] == 5
@@ -765,14 +748,14 @@ async def test_custom_scalar_serialize_variables_sync_transport_2(
     def test_code():
         with Client(schema=schema, transport=transport, parse_results=True) as session:
 
-            query = "query myquery($money: Money) {toEuros(money: $money)}"
+            query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-            variable_values = {"money": Money(10, "DM")}
+            query.variable_values = {"money": Money(10, "DM")}
 
             results = session.execute_batch(
                 [
-                    GraphQLRequest(query, variable_values=variable_values),
-                    GraphQLRequest(query, variable_values=variable_values),
+                    query,
+                    query,
                 ],
                 serialize_variables=True,
             )
@@ -793,14 +776,14 @@ async def test_custom_scalar_serialize_variables_async_transport(aiohttp_server)
         schema=schema, transport=transport, parse_results=True
     ) as session:
 
-        query = "query myquery($money: Money) {toEuros(money: $money)}"
+        query = gql("query myquery($money: Money) {toEuros(money: $money)}")
 
-        variable_values = {"money": Money(10, "DM")}
+        query.variable_values = {"money": Money(10, "DM")}
 
         results = await session.execute_batch(
             [
-                GraphQLRequest(query, variable_values=variable_values),
-                GraphQLRequest(query, variable_values=variable_values),
+                query,
+                query,
             ],
             serialize_variables=True,
         )

--- a/tests/custom_scalars/test_parse_results.py
+++ b/tests/custom_scalars/test_parse_results.py
@@ -93,6 +93,5 @@ def test_parse_results_null_mapping():
     } }"""
     )
 
-    assert client.execute(query, variable_values={"count": 2}) == {
-        "test": static_result
-    }
+    query.variable_values = {"count": 2}
+    assert client.execute(query) == {"test": static_result}

--- a/tests/regressions/issue_447_dsl_missing_directives/test_dsl_directives.py
+++ b/tests/regressions/issue_447_dsl_missing_directives/test_dsl_directives.py
@@ -65,10 +65,10 @@ def test_issue_447():
     client.validate(q)
 
     # Creating a tree from the DocumentNode created by dsl_gql
-    dsl_tree = node_tree(q)
+    dsl_tree = node_tree(q.document)
 
     # Creating a tree from the DocumentNode created by gql
-    gql_tree = node_tree(gql(print_ast(q)))
+    gql_tree = node_tree(gql(print_ast(q.document)).document)
 
     print("=======")
     print(dsl_tree)

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -143,7 +143,7 @@ def test_use_variable_definition_multiple_times(ds):
     query = dsl_gql(op)
 
     assert (
-        print_ast(query)
+        print_ast(query.document)
         == """mutation \
 ($badReview: ReviewInput, $episode: Episode, $goodReview: ReviewInput) {
   badReview: createReview(review: $badReview, episode: $episode) {
@@ -157,7 +157,9 @@ def test_use_variable_definition_multiple_times(ds):
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_add_variable_definitions(ds):
@@ -171,7 +173,7 @@ def test_add_variable_definitions(ds):
     query = dsl_gql(op)
 
     assert (
-        print_ast(query)
+        print_ast(query.document)
         == """mutation ($review: ReviewInput, $episode: Episode) {
   createReview(review: $review, episode: $episode) {
     stars
@@ -180,7 +182,9 @@ def test_add_variable_definitions(ds):
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_add_variable_definitions_with_default_value_enum(ds):
@@ -194,7 +198,7 @@ def test_add_variable_definitions_with_default_value_enum(ds):
     query = dsl_gql(op)
 
     assert (
-        print_ast(query)
+        print_ast(query.document)
         == """mutation ($review: ReviewInput, $episode: Episode = NEWHOPE) {
   createReview(review: $review, episode: $episode) {
     stars
@@ -216,7 +220,7 @@ def test_add_variable_definitions_with_default_value_input_object(ds):
     query = dsl_gql(op)
 
     assert (
-        strip_braces_spaces(print_ast(query))
+        strip_braces_spaces(print_ast(query.document))
         == """
 mutation ($review: ReviewInput = {stars: 5, commentary: "Wow!"}, $episode: Episode) {
   createReview(review: $review, episode: $episode) {
@@ -226,7 +230,9 @@ mutation ($review: ReviewInput = {stars: 5, commentary: "Wow!"}, $episode: Episo
 }""".strip()
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_add_variable_definitions_in_input_object(ds):
@@ -241,7 +247,7 @@ def test_add_variable_definitions_in_input_object(ds):
     query = dsl_gql(op)
 
     assert (
-        strip_braces_spaces(print_ast(query))
+        strip_braces_spaces(print_ast(query.document))
         == """mutation ($stars: Int, $commentary: String, $episode: Episode) {
   createReview(
     review: {stars: $stars, commentary: $commentary}
@@ -253,7 +259,9 @@ def test_add_variable_definitions_in_input_object(ds):
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_invalid_field_on_type_query(ds):
@@ -416,7 +424,9 @@ def test_hero_name_query_result(ds, client):
     result = client.execute(query)
     expected = {"hero": {"name": "R2-D2"}}
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_arg_serializer_list(ds, client):
@@ -436,7 +446,9 @@ def test_arg_serializer_list(ds, client):
         ]
     }
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_arg_serializer_enum(ds, client):
@@ -444,7 +456,9 @@ def test_arg_serializer_enum(ds, client):
     result = client.execute(query)
     expected = {"hero": {"name": "Luke Skywalker"}}
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_create_review_mutation_result(ds, client):
@@ -459,7 +473,9 @@ def test_create_review_mutation_result(ds, client):
     result = client.execute(query)
     expected = {"createReview": {"stars": 5, "commentary": "This is a great movie!"}}
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_subscription(ds):
@@ -472,7 +488,7 @@ def test_subscription(ds):
         )
     )
     assert (
-        print_ast(query)
+        print_ast(query.document)
         == """subscription {
   reviewAdded(episode: JEDI) {
     stars
@@ -481,7 +497,9 @@ def test_subscription(ds):
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_field_does_not_exit_in_type(ds):
@@ -522,7 +540,9 @@ def test_multiple_root_fields(ds, client):
         "hero_of_episode_5": {"name": "Luke Skywalker"},
     }
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_root_fields_aliased(ds, client):
@@ -538,7 +558,9 @@ def test_root_fields_aliased(ds, client):
         "hero_of_episode_5": {"name": "Luke Skywalker"},
     }
     assert result == expected
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_operation_name(ds):
@@ -549,7 +571,7 @@ def test_operation_name(ds):
     )
 
     assert (
-        print_ast(query)
+        print_ast(query.document)
         == """query GetHeroName {
   hero {
     name
@@ -557,7 +579,9 @@ def test_operation_name(ds):
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_multiple_operations(ds):
@@ -571,7 +595,7 @@ def test_multiple_operations(ds):
     )
 
     assert (
-        strip_braces_spaces(print_ast(query))
+        strip_braces_spaces(print_ast(query.document))
         == """query GetHeroName {
   hero {
     name
@@ -589,7 +613,9 @@ mutation CreateReviewMutation {
 }"""
     )
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_inline_fragments(ds):
@@ -656,12 +682,14 @@ def test_fragments(ds):
 
     query_dsl = DSLQuery(ds.Query.hero.select(name_and_appearances))
 
-    document = dsl_gql(name_and_appearances, query_dsl)
+    request = dsl_gql(name_and_appearances, query_dsl)
+
+    document = request.document
 
     print(print_ast(document))
 
     assert query == print_ast(document)
-    assert node_tree(document) == node_tree(gql(print_ast(document)))
+    assert node_tree(document) == node_tree(gql(print_ast(document)).document)
 
 
 def test_fragment_without_type_condition_error(ds):
@@ -753,12 +781,14 @@ query NestedQueryWithFragment {
         )
     )
 
-    document = dsl_gql(name_and_appearances, NestedQueryWithFragment=query_dsl)
+    request = dsl_gql(name_and_appearances, NestedQueryWithFragment=query_dsl)
+
+    document = request.document
 
     print(print_ast(document))
 
     assert query == print_ast(document)
-    assert node_tree(document) == node_tree(gql(print_ast(document)))
+    assert node_tree(document) == node_tree(gql(print_ast(document)).document)
 
     # Same thing, but incrementaly
 
@@ -779,12 +809,14 @@ query NestedQueryWithFragment {
 
     query_dsl = DSLQuery(hero)
 
-    document = dsl_gql(name_and_appearances, NestedQueryWithFragment=query_dsl)
+    request = dsl_gql(name_and_appearances, NestedQueryWithFragment=query_dsl)
+
+    document = request.document
 
     print(print_ast(document))
 
     assert query == print_ast(document)
-    assert node_tree(document) == node_tree(gql(print_ast(document)))
+    assert node_tree(document) == node_tree(gql(print_ast(document)).document)
 
 
 def test_dsl_query_all_fields_should_be_instances_of_DSLField():
@@ -828,7 +860,7 @@ type QueryNotDefault {
   version
 }
 """
-    assert print_ast(query) == expected_query.strip()
+    assert print_ast(query.document) == expected_query.strip()
 
     with pytest.raises(GraphQLError) as excinfo:
         DSLSubscription(ds.QueryNotDefault.version)
@@ -837,7 +869,9 @@ type QueryNotDefault {
         "Invalid field for <DSLSubscription>: <DSLField QueryNotDefault::version>"
     ) in str(excinfo.value)
 
-    assert node_tree(query) == node_tree(gql(print_ast(query)))
+    assert node_tree(query.document) == node_tree(
+        gql(print_ast(query.document)).document
+    )
 
 
 def test_dsl_gql_all_arguments_should_be_operations_or_fragments():
@@ -925,7 +959,7 @@ def test_type_hero_query(ds):
     )
     query_dsl = DSLQuery(type_hero)
 
-    assert query == str(print_ast(dsl_gql(query_dsl))).strip()
+    assert query == str(print_ast(dsl_gql(query_dsl).document)).strip()
 
 
 def test_invalid_meta_field_selection(ds):
@@ -1000,9 +1034,11 @@ def test_get_introspection_query_ast(option):
     )
 
     try:
-        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert print_ast(gql(introspection_query).document) == print_ast(
+            dsl_introspection_query
+        )
         assert node_tree(dsl_introspection_query) == node_tree(
-            gql(print_ast(dsl_introspection_query))
+            gql(print_ast(dsl_introspection_query)).document
         )
     except AssertionError:
 
@@ -1015,9 +1051,11 @@ def test_get_introspection_query_ast(option):
             input_value_deprecation=option,
             type_recursion_level=9,
         )
-        assert print_ast(gql(introspection_query)) == print_ast(dsl_introspection_query)
+        assert print_ast(gql(introspection_query).document) == print_ast(
+            dsl_introspection_query
+        )
         assert node_tree(dsl_introspection_query) == node_tree(
-            gql(print_ast(dsl_introspection_query))
+            gql(print_ast(dsl_introspection_query)).document
         )
 
 
@@ -1047,7 +1085,7 @@ def test_node_tree_with_loc(ds):
   }
 }""".strip()
 
-    document = gql(query)
+    document = gql(query).document
 
     node_tree_result = """
 DocumentNode
@@ -1232,4 +1270,4 @@ fragment heroFragment($episode: Episode) on Query {
   }
 }
 """.strip()
-    assert print_ast(query) == expected
+    assert print_ast(query.document) == expected

--- a/tests/starwars/test_parse_results.py
+++ b/tests/starwars/test_parse_results.py
@@ -22,6 +22,7 @@ def test_hero_name_and_friends_query():
         }
         """
     )
+
     result = {
         "hero": {
             "id": "2001",
@@ -34,7 +35,7 @@ def test_hero_name_and_friends_query():
         }
     }
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result
 
@@ -58,6 +59,7 @@ def test_hero_name_and_friends_query_with_fragment():
         }
         """
     )
+
     result = {
         "hero": {
             "id": "2001",
@@ -70,7 +72,7 @@ def test_hero_name_and_friends_query_with_fragment():
         }
     }
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result
 
@@ -91,7 +93,7 @@ def test_key_not_found_in_result():
     # Should be impossible. In that case, we ignore the missing key
     result: Dict[str, Any] = {}
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result
 
@@ -112,7 +114,7 @@ def test_invalid_result_raise_error():
 
     with pytest.raises(GraphQLError) as exc_info:
 
-        parse_result(StarWarsSchema, query, result)
+        parse_result(StarWarsSchema, query.document, result)
 
     assert "Invalid result for container of field id: 5" in str(exc_info)
 
@@ -141,7 +143,7 @@ def test_fragment():
         "leia": {"name": "Leia Organa", "homePlanet": "Alderaan"},
     }
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result
 
@@ -164,7 +166,7 @@ def test_fragment_not_found():
 
     with pytest.raises(GraphQLError) as exc_info:
 
-        parse_result(StarWarsSchema, query, result)
+        parse_result(StarWarsSchema, query.document, result)
 
     assert 'Fragment "HumanFragment" not found in document!' in str(exc_info)
 
@@ -183,7 +185,7 @@ def test_return_none_if_result_is_none():
 
     result = None
 
-    assert parse_result(StarWarsSchema, query, result) is None
+    assert parse_result(StarWarsSchema, query.document, result) is None
 
 
 def test_null_result_is_allowed():
@@ -200,7 +202,7 @@ def test_null_result_is_allowed():
 
     result = {"hero": None}
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result
 
@@ -224,6 +226,6 @@ def test_inline_fragment():
         "luke": {"name": "Luke Skywalker", "homePlanet": "Tatooine"},
     }
 
-    parsed_result = parse_result(StarWarsSchema, query, result)
+    parsed_result = parse_result(StarWarsSchema, query.document, result)
 
     assert result == parsed_result

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -1,5 +1,5 @@
 import pytest
-from graphql import GraphQLError, Source
+from graphql import GraphQLError
 
 from gql import Client, gql
 from tests.starwars.schema import StarWarsSchema
@@ -323,17 +323,3 @@ def test_mutation_result(client):
     expected = {"createReview": {"stars": 5, "commentary": "This is a great movie!"}}
     result = client.execute(query, variable_values=params)
     assert result == expected
-
-
-def test_query_from_source(client):
-    source = Source("{ hero { name } }")
-    query = gql(source)
-    expected = {"hero": {"name": "R2-D2"}}
-    result = client.execute(query)
-    assert result == expected
-
-
-def test_already_parsed_query(client):
-    query = gql("{ hero { name } }")
-    with pytest.raises(TypeError, match="must be passed as a string"):
-        gql(query)  # type: ignore

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -136,11 +136,11 @@ def test_fetch_some_id_query(client):
         }
         """
     )
-    params = {
+    query.variable_values = {
         "someId": "1000",
     }
     expected = {"human": {"name": "Luke Skywalker"}}
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     assert result == expected
 
 
@@ -154,11 +154,11 @@ def test_fetch_some_id_query2(client):
         }
         """
     )
-    params = {
+    query.variable_values = {
         "someId": "1002",
     }
     expected = {"human": {"name": "Han Solo"}}
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     assert result == expected
 
 
@@ -172,11 +172,11 @@ def test_invalid_id_query(client):
         }
         """
     )
-    params = {
+    query.variable_values = {
         "id": "not a valid id",
     }
     expected = {"human": None}
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     assert result == expected
 
 
@@ -316,10 +316,10 @@ def test_mutation_result(client):
         }
         """
     )
-    params = {
+    query.variable_values = {
         "ep": "JEDI",
         "review": {"stars": 5, "commentary": "This is a great movie!"},
     }
     expected = {"createReview": {"stars": 5, "commentary": "This is a great movie!"}}
-    result = client.execute(query, variable_values=params)
+    result = client.execute(query)
     assert result == expected

--- a/tests/starwars/test_subscription.py
+++ b/tests/starwars/test_subscription.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from graphql import ExecutionResult, GraphQLError, subscribe
 
-from gql import Client, GraphQLRequest, gql
+from gql import Client, gql
 
 from .fixtures import reviews
 from .schema import StarWarsSchema
@@ -59,14 +59,14 @@ async def test_subscription_support_using_client():
 
     subs = gql(subscription_str)
 
-    params = {"ep": "JEDI"}
+    subs.variable_values = {"ep": "JEDI"}
     expected = [{**review, "episode": "JEDI"} for review in reviews[6]]
 
     async with Client(schema=StarWarsSchema) as session:
         results = [
             result["reviewAdded"]
             async for result in await await_if_coroutine(
-                session.subscribe(subs, variable_values=params, parse_result=False)
+                session.subscribe(subs, parse_result=False)
             )
         ]
 
@@ -83,9 +83,9 @@ subscription_invalid_str = """
 @pytest.mark.asyncio
 async def test_subscription_support_using_client_invalid_field():
 
-    subs = subscription_invalid_str
+    subs = gql(subscription_invalid_str)
 
-    params = {"ep": "JEDI"}
+    subs.variable_values = {"ep": "JEDI"}
 
     async with Client(schema=StarWarsSchema) as session:
 
@@ -93,9 +93,7 @@ async def test_subscription_support_using_client_invalid_field():
         results = [
             result
             async for result in await await_if_coroutine(
-                session.transport.subscribe(
-                    GraphQLRequest(subs, variable_values=params)
-                )
+                session.transport.subscribe(subs)
             )
         ]
 

--- a/tests/starwars/test_subscription.py
+++ b/tests/starwars/test_subscription.py
@@ -41,7 +41,7 @@ async def test_subscription_support():
     expected = [{**review, "episode": "JEDI"} for review in reviews[6]]
 
     ai = await await_if_coroutine(
-        subscribe(StarWarsSchema, subs, variable_values=params)
+        subscribe(StarWarsSchema, subs.document, variable_values=params)
     )
 
     result = [result.data["reviewAdded"] async for result in ai]
@@ -83,7 +83,7 @@ subscription_invalid_str = """
 @pytest.mark.asyncio
 async def test_subscription_support_using_client_invalid_field():
 
-    subs = gql(subscription_invalid_str)
+    subs = subscription_invalid_str
 
     params = {"ep": "JEDI"}
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -491,14 +491,13 @@ async def test_aiohttp_query_variable_values(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        params = {"code": "EU"}
-
         query = gql(query2_str)
 
+        query.variable_values = {"code": "EU"}
+        query.operation_name = "getEurope"
+
         # Execute query asynchronously
-        result = await session.execute(
-            query, variable_values=params, operation_name="getEurope"
-        )
+        result = await session.execute(query)
 
         continent = result["continent"]
 
@@ -528,14 +527,13 @@ async def test_aiohttp_query_variable_values_fix_issue_292(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        params = {"code": "EU"}
-
         query = gql(query2_str)
 
+        query.variable_values = {"code": "EU"}
+        query.operation_name = "getEurope"
+
         # Execute query asynchronously
-        result = await session.execute(
-            query, variable_values=params, operation_name="getEurope"
-        )
+        result = await session.execute(query)
 
         continent = result["continent"]
 
@@ -730,15 +728,13 @@ async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
                 # Setting the content_type
                 f.content_type = "application/pdf"  # type: ignore
 
-                params = {"file": f, "other_var": 42}
+                query.variable_values = {"file": f, "other_var": 42}
 
                 with pytest.warns(
                     DeprecationWarning,
                     match="Not using FileVar for file upload is deprecated",
                 ):
-                    result = await session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -746,7 +742,7 @@ async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
             # Using an opened file inside a FileVar object
             with open(file_path, "rb") as f:
 
-                params = {
+                query.variable_values = {
                     "file": FileVar(
                         f,
                         content_type="application/pdf",
@@ -754,15 +750,13 @@ async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
                     "other_var": 42,
                 }
 
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
 
             # Using an filename string inside a FileVar object
-            params = {
+            query.variable_values = {
                 "file": FileVar(
                     file_path,
                     content_type="application/pdf",
@@ -770,9 +764,7 @@ async def test_aiohttp_file_upload_with_content_type(aiohttp_server):
                 "other_var": 42,
             }
 
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -810,16 +802,14 @@ async def test_aiohttp_file_upload_default_filename_is_basename(aiohttp_server):
 
             query = gql(file_upload_mutation_1)
 
-            params = {
+            query.variable_values = {
                 "file": FileVar(
                     file_path,
                 ),
                 "other_var": 42,
             }
 
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -856,7 +846,7 @@ async def test_aiohttp_file_upload_with_filename(aiohttp_server):
 
             query = gql(file_upload_mutation_1)
 
-            params = {
+            query.variable_values = {
                 "file": FileVar(
                     file_path,
                     filename="filename1.txt",
@@ -864,9 +854,7 @@ async def test_aiohttp_file_upload_with_filename(aiohttp_server):
                 "other_var": 42,
             }
 
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -903,9 +891,9 @@ async def test_aiohttp_file_upload_without_session(aiohttp_server, run_sync_test
 
             file_path = test_file.filename
 
-            params = {"file": FileVar(file_path), "other_var": 42}
+            query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
-            result = client.execute(query, variable_values=params, upload_files=True)
+            result = client.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -947,12 +935,10 @@ async def test_aiohttp_binary_file_upload(aiohttp_server):
 
             file_path = test_file.filename
 
-            params = {"file": FileVar(file_path), "other_var": 42}
+            query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
             # Execute query asynchronously
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
 
@@ -998,15 +984,13 @@ async def test_aiohttp_stream_reader_upload(aiohttp_server):
         query = gql(file_upload_mutation_1)
         async with ClientSession() as client:
             async with client.get(binary_data_url) as resp:
-                params = {"file": resp.content, "other_var": 42}
+                query.variable_values = {"file": resp.content, "other_var": 42}
 
                 with pytest.warns(
                     DeprecationWarning,
                     match="Not using FileVar for file upload is deprecated",
                 ):
-                    result = await session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    result = await session.execute(query, upload_files=True)
 
     success = result["success"]
     assert success
@@ -1016,11 +1000,9 @@ async def test_aiohttp_stream_reader_upload(aiohttp_server):
         query = gql(file_upload_mutation_1)
         async with ClientSession() as client:
             async with client.get(binary_data_url) as resp:
-                params = {"file": FileVar(resp.content), "other_var": 42}
+                query.variable_values = {"file": FileVar(resp.content), "other_var": 42}
 
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
     success = result["success"]
     assert success
@@ -1069,15 +1051,13 @@ async def test_aiohttp_async_generator_upload(aiohttp_server):
         # Not using FileVar
         async with Client(transport=transport) as session:
 
-            params = {"file": file_sender(file_path), "other_var": 42}
+            query.variable_values = {"file": file_sender(file_path), "other_var": 42}
 
             with pytest.warns(
                 DeprecationWarning,
                 match="Not using FileVar for file upload is deprecated",
             ):
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -1085,12 +1065,13 @@ async def test_aiohttp_async_generator_upload(aiohttp_server):
         # Using FileVar
         async with Client(transport=transport) as session:
 
-            params = {"file": FileVar(file_sender(file_path)), "other_var": 42}
+            query.variable_values = {
+                "file": FileVar(file_sender(file_path)),
+                "other_var": 42,
+            }
 
             # Execute query asynchronously
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -1098,15 +1079,13 @@ async def test_aiohttp_async_generator_upload(aiohttp_server):
         # Using FileVar with new streaming support
         async with Client(transport=transport) as session:
 
-            params = {
+            query.variable_values = {
                 "file": FileVar(file_path, streaming=True),
                 "other_var": 42,
             }
 
             # Execute query asynchronously
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -1166,14 +1145,12 @@ async def test_aiohttp_file_upload_two_files(aiohttp_server):
                 file_path_1 = test_file_1.filename
                 file_path_2 = test_file_2.filename
 
-                params = {
+                query.variable_values = {
                     "file1": FileVar(file_path_1),
                     "file2": FileVar(file_path_2),
                 }
 
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
                 success = result["success"]
 
@@ -1236,7 +1213,7 @@ async def test_aiohttp_file_upload_list_of_two_files(aiohttp_server):
                 file_path_1 = test_file_1.filename
                 file_path_2 = test_file_2.filename
 
-                params = {
+                query.variable_values = {
                     "files": [
                         FileVar(file_path_1),
                         FileVar(file_path_2),
@@ -1244,9 +1221,7 @@ async def test_aiohttp_file_upload_list_of_two_files(aiohttp_server):
                 }
 
                 # Execute query asynchronously
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
                 success = result["success"]
 
@@ -1882,8 +1857,6 @@ async def test_aiohttp_deprecation_warning_execute_variable_values(aiohttp_serve
 
     async with Client(transport=transport) as session:
 
-        params = {"code": "EU"}
-
         query = gql(query2_str)
 
         with pytest.warns(
@@ -1894,7 +1867,9 @@ async def test_aiohttp_deprecation_warning_execute_variable_values(aiohttp_serve
             ),
         ):
             result = await session.execute(
-                query, variable_values=params, operation_name="getEurope"
+                query,
+                variable_values={"code": "EU"},
+                operation_name="getEurope",
             )
 
         continent = result["continent"]
@@ -1920,10 +1895,6 @@ async def test_aiohttp_type_error_execute(aiohttp_server):
     transport = AIOHTTPTransport(url=url, timeout=10)
 
     async with Client(transport=transport) as session:
-
-        params = {"code": "EU"}
-
-        query = gql(query2_str)
 
         with pytest.raises(TypeError) as exc_info:
             await session.execute("qmlsdkfj")

--- a/tests/test_aiohttp_batch.py
+++ b/tests/test_aiohttp_batch.py
@@ -70,7 +70,7 @@ async def test_aiohttp_batch_query(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         # Execute query asynchronously
         results = await session.execute_batch(query)
@@ -286,7 +286,7 @@ async def test_aiohttp_batch_query_without_session(aiohttp_server, run_sync_test
 
         client = Client(transport=transport)
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         results = client.execute_batch(query)
 
@@ -330,7 +330,7 @@ async def test_aiohttp_batch_error_code(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         with pytest.raises(TransportQueryError):
             await session.execute_batch(query)
@@ -368,7 +368,7 @@ async def test_aiohttp_batch_invalid_protocol(aiohttp_server, response):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         with pytest.raises(TransportProtocolError):
             await session.execute_batch(query)
@@ -398,7 +398,7 @@ async def test_aiohttp_batch_cannot_execute_if_not_connected(
 
     transport = AIOHTTPTransport(url=url, timeout=10)
 
-    query = [GraphQLRequest(document=gql(query1_str))]
+    query = [GraphQLRequest(query1_str)]
 
     with pytest.raises(TransportClosed):
         await transport.execute_batch(query)
@@ -433,7 +433,7 @@ async def test_aiohttp_batch_extra_args(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         # Passing extra arguments to the post method of aiohttp
         results = await session.execute_batch(
@@ -480,7 +480,7 @@ async def test_aiohttp_batch_query_with_extensions(aiohttp_server):
 
     transport = AIOHTTPTransport(url=url)
 
-    query = [GraphQLRequest(document=gql(query1_str))]
+    query = [GraphQLRequest(query1_str)]
 
     async with Client(transport=transport) as session:
 
@@ -504,15 +504,13 @@ async def test_aiohttp_batch_online_manual():
         transport=AIOHTTPTransport(url=ONLINE_URL, timeout=10),
     )
 
-    query = gql(
-        """
+    query = """
         query getContinentName($continent_code: ID!) {
           continent(code: $continent_code) {
             name
           }
         }
-        """
-    )
+    """
 
     async with client as session:
 

--- a/tests/test_aiohttp_websocket_graphqlws_subscription.py
+++ b/tests/test_aiohttp_websocket_graphqlws_subscription.py
@@ -425,10 +425,9 @@ async def test_aiohttp_websocket_graphqlws_subscription_with_operation_name(
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
+    subscription.operation_name = "CountdownSubscription"
 
-    async for result in session.subscribe(
-        subscription, operation_name="CountdownSubscription"
-    ):
+    async for result in session.subscribe(subscription):
 
         number = result["number"]
         print(f"Number received: {number}")

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -444,10 +444,9 @@ async def test_aiohttp_websocket_subscription_with_operation_name(
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
+    subscription.operation_name = "CountdownSubscription"
 
-    async for result in session.subscribe(
-        subscription, operation_name="CountdownSubscription"
-    ):
+    async for result in session.subscribe(subscription):
 
         number = result["number"]
         print(f"Number received: {number}")
@@ -751,15 +750,13 @@ async def test_async_aiohttp_client_validation(server, subscription_str, client_
 
     async with client as session:
 
-        variable_values = {"ep": "JEDI"}
-
         subscription = gql(subscription_str)
+
+        subscription.variable_values = {"ep": "JEDI"}
 
         expected = []
 
-        async for result in session.subscribe(
-            subscription, variable_values=variable_values, parse_result=False
-        ):
+        async for result in session.subscribe(subscription, parse_result=False):
 
             review = result["reviewAdded"]
             expected.append(review)

--- a/tests/test_appsync_websockets.py
+++ b/tests/test_appsync_websockets.py
@@ -514,10 +514,10 @@ mutation createMessage($message: String!) {
 }"""
         )
 
-        variable_values = {"message": "Hello world!"}
+        query.variable_values = {"message": "Hello world!"}
 
         with pytest.raises(AssertionError) as exc_info:
-            await session.execute(query, variable_values=variable_values)
+            await session.execute(query)
 
         assert (
             "execute method is not allowed for AppSyncWebsocketsTransport "
@@ -693,10 +693,11 @@ async def test_appsync_subscription_variable_values_and_operation_name(server):
     async with client as session:
         subscription = gql(on_create_message_subscription_str)
 
+        subscription.variable_values = {"key1": "val1"}
+        subscription.operation_name = "onCreateMessage"
+
         async for execution_result in session.subscribe(
             subscription,
-            operation_name="onCreateMessage",
-            variable_values={"key1": "val1"},
             get_execution_result=True,
         ):
 

--- a/tests/test_async_client_validation.py
+++ b/tests/test_async_client_validation.py
@@ -97,15 +97,13 @@ async def test_async_client_validation(server, subscription_str, client_params):
 
     async with client as session:
 
-        variable_values = {"ep": "JEDI"}
-
         subscription = gql(subscription_str)
+
+        subscription.variable_values = {"ep": "JEDI"}
 
         expected = []
 
-        async for result in session.subscribe(
-            subscription, variable_values=variable_values, parse_result=False
-        ):
+        async for result in session.subscribe(subscription, parse_result=False):
 
             review = result["reviewAdded"]
             expected.append(review)
@@ -144,14 +142,12 @@ async def test_async_client_validation_invalid_query(
 
     async with client as session:
 
-        variable_values = {"ep": "JEDI"}
-
         subscription = gql(subscription_str)
 
+        subscription.variable_values = {"ep": "JEDI"}
+
         with pytest.raises(graphql.error.GraphQLError):
-            async for _result in session.subscribe(
-                subscription, variable_values=variable_values
-            ):
+            async for _result in session.subscribe(subscription):
                 pass
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,7 +94,7 @@ def test_retries_on_transport(execute_mock):
     assert execute_mock.call_count == expected_retries + 1
 
     execute_mock.reset_mock()
-    queries = map(lambda d: GraphQLRequest(document=d), [query, query, query])
+    queries = [query, query, query]
 
     with client as session:  # We're using the client as context manager
         with pytest.raises(Exception):
@@ -143,7 +143,7 @@ def test_execute_result_error():
     Batching is not supported anymore on countries backend
 
     with pytest.raises(TransportQueryError) as exc_info:
-        client.execute_batch([GraphQLRequest(document=failing_query)])
+        client.execute_batch([GraphQLRequest(failing_query)])
     assert 'Cannot query field "id" on type "Continent".' in str(exc_info.value)
     """
 
@@ -171,7 +171,7 @@ def test_http_transport_verify_error(http_transport_query):
         Batching is not supported anymore on countries backend
 
         with pytest.warns(Warning) as record:
-            client.execute_batch([GraphQLRequest(document=http_transport_query)])
+            client.execute_batch([GraphQLRequest(http_transport_query)])
 
         assert len(record) == 1
         assert "Unverified HTTPS request is being made to host" in str(
@@ -197,7 +197,7 @@ def test_http_transport_specify_method_valid(http_transport_query):
         """
         Batching is not supported anymore on countries backend
 
-        result = client.execute_batch([GraphQLRequest(document=http_transport_query)])
+        result = client.execute_batch([GraphQLRequest(http_transport_query)])
         assert result is not None
         """
 

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -230,6 +230,9 @@ def test_graphql_request_init_with_graphql_request():
 
     assert request_1.document == request_2.document
     assert request_2.document == request_3.document
+    assert isinstance(request_1.variable_values, Dict)
+    assert isinstance(request_2.variable_values, Dict)
+    assert isinstance(request_3.variable_values, Dict)
     assert request_1.variable_values["money"] == money_value_1
     assert request_2.variable_values["money"] == money_value_1
     assert request_3.variable_values["money"] == money_value_2

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -210,3 +210,26 @@ def test_graphql_request_using_string_instead_of_document():
     print(request)
 
     assert str(request) == strip_braces_spaces(expected_payload)
+
+
+def test_graphql_request_init_with_graphql_request():
+    money_value_1 = Money(10, "DM")
+    money_value_2 = Money(20, "DM")
+
+    request_1 = GraphQLRequest(
+        "query myquery($money: Money) {toEuros(money: $money)}",
+        variable_values={"money": money_value_1},
+    )
+    request_2 = GraphQLRequest(
+        request_1,
+    )
+    request_3 = GraphQLRequest(
+        request_1,
+        variable_values={"money": money_value_2},
+    )
+
+    assert request_1.document == request_2.document
+    assert request_2.document == request_3.document
+    assert request_1.variable_values["money"] == money_value_1
+    assert request_2.variable_values["money"] == money_value_1
+    assert request_3.variable_values["money"] == money_value_2

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -18,7 +18,7 @@ from graphql.type import (
 )
 from graphql.utilities import value_from_ast_untyped
 
-from gql import GraphQLRequest, gql
+from gql import GraphQLRequest
 
 from .conftest import MS, strip_braces_spaces
 
@@ -188,12 +188,12 @@ schema = GraphQLSchema(
 
 
 def test_serialize_variables_using_money_example():
-    req = GraphQLRequest(document=gql("{balance}"))
+    req = GraphQLRequest("{balance}")
 
     money_value = Money(10, "DM")
 
     req = GraphQLRequest(
-        document=gql("query myquery($money: Money) {toEuros(money: $money)}"),
+        "query myquery($money: Money) {toEuros(money: $money)}",
         variable_values={"money": money_value},
     )
 

--- a/tests/test_graphqlws_subscription.py
+++ b/tests/test_graphqlws_subscription.py
@@ -425,10 +425,9 @@ async def test_graphqlws_subscription_with_operation_name(
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
+    subscription.operation_name = "CountdownSubscription"
 
-    async for result in session.subscribe(
-        subscription, operation_name="CountdownSubscription"
-    ):
+    async for result in session.subscribe(subscription):
 
         number = result["number"]
         print(f"Number received: {number}")

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -573,35 +573,29 @@ async def test_httpx_file_upload(aiohttp_server, run_sync_test):
                 # Using an opened file
                 with open(file_path, "rb") as f:
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
 
-                    params = {"file": FileVar(f), "other_var": 42}
-                    execution_result = session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    query.variable_values = {"file": FileVar(f), "other_var": 42}
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using an filename string inside a FileVar object
-                params = {
+                query.variable_values = {
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -645,25 +639,21 @@ async def test_httpx_file_upload_with_content_type(aiohttp_server, run_sync_test
                     # Setting the content_type
                     f.content_type = "application/pdf"  # type: ignore
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using FileVar
-                params = {
+                query.variable_values = {
                     "file": FileVar(file_path, content_type="application/pdf"),
                     "other_var": 42,
                 }
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -706,13 +696,11 @@ async def test_httpx_file_upload_default_filename_is_basename(
                 query = gql(file_upload_mutation_1)
 
                 # Using FileVar
-                params = {
+                query.variable_values = {
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -750,10 +738,8 @@ async def test_httpx_file_upload_additional_headers(aiohttp_server, run_sync_tes
 
                 file_path = test_file.filename
 
-                params = {"file": FileVar(file_path), "other_var": 42}
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                query.variable_values = {"file": FileVar(file_path), "other_var": 42}
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -795,11 +781,9 @@ async def test_httpx_binary_file_upload(aiohttp_server, run_sync_test):
 
                 file_path = test_file.filename
 
-                params = {"file": FileVar(file_path), "other_var": 42}
+                query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -862,14 +846,12 @@ async def test_httpx_file_upload_two_files(aiohttp_server, run_sync_test):
                     file_path_1 = test_file_1.filename
                     file_path_2 = test_file_2.filename
 
-                    params = {
+                    query.variable_values = {
                         "file1": FileVar(file_path_1),
                         "file2": FileVar(file_path_2),
                     }
 
-                    execution_result = session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -933,16 +915,14 @@ async def test_httpx_file_upload_list_of_two_files(aiohttp_server, run_sync_test
                     file_path_1 = test_file_1.filename
                     file_path_2 = test_file_2.filename
 
-                    params = {
+                    query.variable_values = {
                         "files": [
                             FileVar(file_path_1),
                             FileVar(file_path_2),
                         ],
                     }
 
-                    execution_result = session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, GraphQLRequest, gql
+from gql import Client, FileVar, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -470,7 +470,7 @@ async def test_httpx_cannot_execute_if_not_connected(aiohttp_server, run_sync_te
         query = gql(query1_str)
 
         with pytest.raises(TransportClosed):
-            transport.execute(GraphQLRequest(query))
+            transport.execute(query)
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -498,14 +498,13 @@ async def test_httpx_query_variable_values(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        params = {"code": "EU"}
-
         query = gql(query2_str)
 
+        query.variable_values = {"code": "EU"}
+        query.operation_name = "getEurope"
+
         # Execute query asynchronously
-        result = await session.execute(
-            query, variable_values=params, operation_name="getEurope"
-        )
+        result = await session.execute(query)
 
         continent = result["continent"]
 
@@ -536,14 +535,13 @@ async def test_httpx_query_variable_values_fix_issue_292(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        params = {"code": "EU"}
-
         query = gql(query2_str)
 
+        query.variable_values = {"code": "EU"}
+        query.operation_name = "getEurope"
+
         # Execute query asynchronously
-        result = await session.execute(
-            query, variable_values=params, operation_name="getEurope"
-        )
+        result = await session.execute(query)
 
         continent = result["continent"]
 
@@ -671,16 +669,14 @@ async def test_httpx_file_upload(aiohttp_server):
             # Using an opened file
             with open(file_path, "rb") as f:
 
-                params = {"file": f, "other_var": 42}
+                query.variable_values = {"file": f, "other_var": 42}
 
                 # Execute query asynchronously
                 with pytest.warns(
                     DeprecationWarning,
                     match="Not using FileVar for file upload is deprecated",
                 ):
-                    result = await session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -688,23 +684,19 @@ async def test_httpx_file_upload(aiohttp_server):
             # Using an opened file inside a FileVar object
             with open(file_path, "rb") as f:
 
-                params = {"file": FileVar(f), "other_var": 42}
+                query.variable_values = {"file": FileVar(f), "other_var": 42}
 
                 # Execute query asynchronously
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
 
             # Using an filename string inside a FileVar object
-            params = {"file": FileVar(file_path), "other_var": 42}
+            query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
             # Execute query asynchronously
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
             assert success
@@ -742,9 +734,9 @@ async def test_httpx_file_upload_without_session(aiohttp_server, run_sync_test):
 
             file_path = test_file.filename
 
-            params = {"file": FileVar(file_path), "other_var": 42}
+            query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
-            result = client.execute(query, variable_values=params, upload_files=True)
+            result = client.execute(query, upload_files=True)
 
             success = result["success"]
 
@@ -788,12 +780,10 @@ async def test_httpx_binary_file_upload(aiohttp_server):
 
             file_path = test_file.filename
 
-            params = {"file": FileVar(file_path), "other_var": 42}
+            query.variable_values = {"file": FileVar(file_path), "other_var": 42}
 
             # Execute query asynchronously
-            result = await session.execute(
-                query, variable_values=params, upload_files=True
-            )
+            result = await session.execute(query, upload_files=True)
 
             success = result["success"]
 
@@ -855,14 +845,12 @@ async def test_httpx_file_upload_two_files(aiohttp_server):
                 file_path_1 = test_file_1.filename
                 file_path_2 = test_file_2.filename
 
-                params = {
+                query.variable_values = {
                     "file1": FileVar(file_path_1),
                     "file2": FileVar(file_path_2),
                 }
 
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
                 success = result["success"]
                 assert success
@@ -925,7 +913,7 @@ async def test_httpx_file_upload_list_of_two_files(aiohttp_server):
                 file_path_1 = test_file_1.filename
                 file_path_2 = test_file_2.filename
 
-                params = {
+                query.variable_values = {
                     "files": [
                         FileVar(file_path_1),
                         FileVar(file_path_2),
@@ -933,9 +921,7 @@ async def test_httpx_file_upload_list_of_two_files(aiohttp_server):
                 }
 
                 # Execute query asynchronously
-                result = await session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                result = await session.execute(query, upload_files=True)
 
                 success = result["success"]
                 assert success

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, GraphQLRequest, gql
+from gql import Client, FileVar, gql
 from gql.cli import get_parser, main
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
@@ -429,7 +429,7 @@ async def test_httpx_cannot_execute_if_not_connected(aiohttp_server):
     query = gql(query1_str)
 
     with pytest.raises(TransportClosed):
-        await transport.execute(GraphQLRequest(query))
+        await transport.execute(query)
 
 
 @pytest.mark.aiohttp

--- a/tests/test_httpx_batch.py
+++ b/tests/test_httpx_batch.py
@@ -2,7 +2,7 @@ from typing import Mapping
 
 import pytest
 
-from gql import Client, GraphQLRequest, gql
+from gql import Client, GraphQLRequest
 from gql.transport.exceptions import (
     TransportClosed,
     TransportProtocolError,
@@ -54,7 +54,7 @@ async def test_httpx_async_batch_query(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         # Execute query asynchronously
         results = await session.execute_batch(query)
@@ -98,7 +98,7 @@ async def test_httpx_sync_batch_query(aiohttp_server, run_sync_test):
     def test_code():
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             results = session.execute_batch(query)
 
@@ -143,7 +143,7 @@ async def test_httpx_async_batch_query_without_session(aiohttp_server, run_sync_
 
         client = Client(transport=transport)
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         results = client.execute_batch(query)
 
@@ -188,7 +188,7 @@ async def test_httpx_async_batch_error_code(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         with pytest.raises(TransportQueryError):
             await session.execute_batch(query)
@@ -227,7 +227,7 @@ async def test_httpx_async_batch_invalid_protocol(aiohttp_server, response):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         with pytest.raises(TransportProtocolError):
             await session.execute_batch(query)
@@ -255,7 +255,7 @@ async def test_httpx_async_batch_cannot_execute_if_not_connected(aiohttp_server)
 
     transport = HTTPXAsyncTransport(url=url, timeout=10)
 
-    query = [GraphQLRequest(document=gql(query1_str))]
+    query = [GraphQLRequest(query1_str)]
 
     with pytest.raises(TransportClosed):
         await transport.execute_batch(query)
@@ -283,7 +283,7 @@ async def test_httpx_sync_batch_cannot_execute_if_not_connected(aiohttp_server):
 
     transport = HTTPXTransport(url=url, timeout=10)
 
-    query = [GraphQLRequest(document=gql(query1_str))]
+    query = [GraphQLRequest(query1_str)]
 
     with pytest.raises(TransportClosed):
         transport.execute_batch(query)
@@ -316,7 +316,7 @@ async def test_httpx_async_batch_extra_args(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         # Passing extra arguments to the post method
         results = await session.execute_batch(
@@ -364,7 +364,7 @@ async def test_httpx_async_batch_query_with_extensions(aiohttp_server):
 
     transport = HTTPXAsyncTransport(url=url)
 
-    query = [GraphQLRequest(document=gql(query1_str))]
+    query = [GraphQLRequest(query1_str)]
 
     async with Client(transport=transport) as session:
 
@@ -388,15 +388,13 @@ async def test_httpx_batch_online_async_manual():
         transport=HTTPXAsyncTransport(url=ONLINE_URL),
     )
 
-    query = gql(
-        """
+    query = """
         query getContinentName($continent_code: ID!) {
           continent(code: $continent_code) {
             name
           }
         }
-        """
-    )
+    """
 
     async with client as session:
 
@@ -419,15 +417,13 @@ async def test_httpx_batch_online_sync_manual():
         transport=HTTPXTransport(url=ONLINE_URL),
     )
 
-    query = gql(
-        """
+    query = """
         query getContinentName($continent_code: ID!) {
           continent(code: $continent_code) {
             name
           }
         }
-        """
-    )
+    """
 
     with client as session:
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, GraphQLRequest, gql
+from gql import Client, FileVar, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -471,7 +471,7 @@ async def test_requests_cannot_execute_if_not_connected(aiohttp_server, run_sync
         query = gql(query1_str)
 
         with pytest.raises(TransportClosed):
-            transport.execute(GraphQLRequest(query))
+            transport.execute(query)
 
     await run_sync_test(server, test_code)
 
@@ -574,35 +574,29 @@ async def test_requests_file_upload(aiohttp_server, run_sync_test):
                 # Using an opened file
                 with open(file_path, "rb") as f:
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
 
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
 
-                    params = {"file": FileVar(f), "other_var": 42}
+                    query.variable_values = {"file": FileVar(f), "other_var": 42}
                     with warnings.catch_warnings():
                         warnings.simplefilter("error")  # Turn warnings into errors
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using an filename string inside a FileVar object
-                params = {"file": FileVar(file_path), "other_var": 42}
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                query.variable_values = {"file": FileVar(file_path), "other_var": 42}
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -640,27 +640,23 @@ async def test_requests_file_upload_with_content_type(aiohttp_server, run_sync_t
                     # Setting the content_type
                     f.content_type = "application/pdf"  # type: ignore
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
                 # Using an opened file inside a FileVar object
                 with open(file_path, "rb") as f:
 
-                    params = {
+                    query.variable_values = {
                         "file": FileVar(f, content_type="application/pdf"),
                         "other_var": 42,
                     }
-                    execution_result = session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -703,13 +699,11 @@ async def test_requests_file_upload_default_filename_is_basename(
             with Client(transport=transport) as session:
                 query = gql(file_upload_mutation_1)
 
-                params = {
+                query.variable_values = {
                     "file": FileVar(file_path),
                     "other_var": 42,
                 }
-                execution_result = session.execute(
-                    query, variable_values=params, upload_files=True
-                )
+                execution_result = session.execute(query, upload_files=True)
 
                 assert execution_result["success"]
 
@@ -750,13 +744,11 @@ async def test_requests_file_upload_with_filename(aiohttp_server, run_sync_test)
 
                 with open(file_path, "rb") as f:
 
-                    params = {
+                    query.variable_values = {
                         "file": FileVar(f, filename="filename1.txt"),
                         "other_var": 42,
                     }
-                    execution_result = session.execute(
-                        query, variable_values=params, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -796,14 +788,12 @@ async def test_requests_file_upload_additional_headers(aiohttp_server, run_sync_
 
                 with open(file_path, "rb") as f:
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -847,15 +837,13 @@ async def test_requests_binary_file_upload(aiohttp_server, run_sync_test):
 
                 with open(file_path, "rb") as f:
 
-                    params = {"file": f, "other_var": 42}
+                    query.variable_values = {"file": f, "other_var": 42}
 
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -922,7 +910,7 @@ async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
                     f1 = open(file_path_1, "rb")
                     f2 = open(file_path_2, "rb")
 
-                    params_1 = {
+                    query.variable_values = {
                         "file1": f1,
                         "file2": f2,
                     }
@@ -931,9 +919,7 @@ async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params_1, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -947,14 +933,12 @@ async def test_requests_file_upload_two_files(aiohttp_server, run_sync_test):
                     f1 = open(file_path_1, "rb")
                     f2 = open(file_path_2, "rb")
 
-                    params_2 = {
+                    query.variable_values = {
                         "file1": FileVar(f1),
                         "file2": FileVar(f2),
                     }
 
-                    execution_result = session.execute(
-                        query, variable_values=params_2, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -1025,15 +1009,13 @@ async def test_requests_file_upload_list_of_two_files(aiohttp_server, run_sync_t
                     f1 = open(file_path_1, "rb")
                     f2 = open(file_path_2, "rb")
 
-                    params = {"files": [f1, f2]}
+                    query.variable_values = {"files": [f1, f2]}
 
                     with pytest.warns(
                         DeprecationWarning,
                         match="Not using FileVar for file upload is deprecated",
                     ):
-                        execution_result = session.execute(
-                            query, variable_values=params, upload_files=True
-                        )
+                        execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 
@@ -1047,11 +1029,9 @@ async def test_requests_file_upload_list_of_two_files(aiohttp_server, run_sync_t
                     f1 = open(file_path_1, "rb")
                     f2 = open(file_path_2, "rb")
 
-                    params_2 = {"files": [FileVar(f1), FileVar(f2)]}
+                    query.variable_values = {"files": [FileVar(f1), FileVar(f2)]}
 
-                    execution_result = session.execute(
-                        query, variable_values=params_2, upload_files=True
-                    )
+                    execution_result = session.execute(query, upload_files=True)
 
                     assert execution_result["success"]
 

--- a/tests/test_requests_batch.py
+++ b/tests/test_requests_batch.py
@@ -71,7 +71,7 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             # Execute query synchronously
             results = session.execute_batch(query)
@@ -225,7 +225,7 @@ async def test_requests_cookies(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             # Execute query synchronously
             results = session.execute_batch(query)
@@ -265,7 +265,7 @@ async def test_requests_error_code_401(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             with pytest.raises(TransportServerError) as exc_info:
                 session.execute_batch(query)
@@ -353,7 +353,7 @@ async def test_requests_error_code_429(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             with pytest.raises(TransportServerError) as exc_info:
                 session.execute_batch(query)
@@ -388,7 +388,7 @@ async def test_requests_error_code_500(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             with pytest.raises(TransportServerError):
                 session.execute_batch(query)
@@ -422,7 +422,7 @@ async def test_requests_error_code(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             with pytest.raises(TransportQueryError):
                 session.execute_batch(query)
@@ -464,7 +464,7 @@ async def test_requests_invalid_protocol(aiohttp_server, response, run_sync_test
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             with pytest.raises(TransportProtocolError):
                 session.execute_batch(query)
@@ -493,7 +493,7 @@ async def test_requests_cannot_execute_if_not_connected(aiohttp_server, run_sync
     def test_code():
         transport = RequestsHTTPTransport(url=url)
 
-        query = [GraphQLRequest(document=gql(query1_str))]
+        query = [GraphQLRequest(query1_str)]
 
         with pytest.raises(TransportClosed):
             transport.execute_batch(query)
@@ -536,7 +536,7 @@ async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
 
         with Client(transport=transport) as session:
 
-            query = [GraphQLRequest(document=gql(query1_str))]
+            query = [GraphQLRequest(query1_str)]
 
             execution_results = session.execute_batch(query, get_execution_result=True)
 
@@ -626,15 +626,13 @@ def test_requests_sync_batch_auto_execute_future():
         batch_max=3,
     )
 
-    query = gql(
-        """
+    query = """
         query getContinentName($continent_code: ID!) {
           continent(code: $continent_code) {
             name
           }
         }
-        """
-    )
+    """
 
     with client as session:
 
@@ -661,15 +659,13 @@ def test_requests_sync_batch_manual():
         transport=RequestsHTTPTransport(url=ONLINE_URL),
     )
 
-    query = gql(
-        """
+    query = """
         query getContinentName($continent_code: ID!) {
           continent(code: $continent_code) {
             name
           }
         }
-        """
-    )
+    """
 
     with client as session:
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -100,9 +100,10 @@ def test_query_with_variable(client):
         }
         """
     )
+    query.variable_values = {"id": "UGxhbmV0OjEw"}
     expected = {"planet": {"id": "UGxhbmV0OjEw", "name": "Kamino"}}
     with use_cassette("queries"):
-        result = client.execute(query, variable_values={"id": "UGxhbmV0OjEw"})
+        result = client.execute(query)
     assert result == expected
 
 
@@ -123,9 +124,10 @@ def test_named_query(client):
         }
         """
     )
+    query.operation_name = "Planet2"
     expected = {"planet": {"id": "UGxhbmV0OjEx", "name": "Geonosis"}}
     with use_cassette("queries"):
-        result = client.execute(query, operation_name="Planet2")
+        result = client.execute(query)
     assert result == expected
 
 

--- a/tests/test_transport_batch.py
+++ b/tests/test_transport_batch.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from gql import Client, GraphQLRequest, gql
+from gql import Client, gql
 
 # We serve https://github.com/graphql-python/swapi-graphene locally:
 URL = "http://127.0.0.1:8000/graphql"
@@ -87,7 +87,7 @@ def test_hero_name_query(client):
         }
     ]
     with use_cassette("queries_batch"):
-        results = client.execute_batch([GraphQLRequest(document=query)])
+        results = client.execute_batch([query])
     assert results == expected
 
 
@@ -102,11 +102,10 @@ def test_query_with_variable(client):
         }
         """
     )
+    query.variable_values = {"id": "UGxhbmV0OjEw"}
     expected = [{"planet": {"id": "UGxhbmV0OjEw", "name": "Kamino"}}]
     with use_cassette("queries_batch"):
-        results = client.execute_batch(
-            [GraphQLRequest(document=query, variable_values={"id": "UGxhbmV0OjEw"})]
-        )
+        results = client.execute_batch([query])
     assert results == expected
 
 
@@ -127,11 +126,10 @@ def test_named_query(client):
         }
         """
     )
+    query.operation_name = "Planet2"
     expected = [{"planet": {"id": "UGxhbmV0OjEx", "name": "Geonosis"}}]
     with use_cassette("queries_batch"):
-        results = client.execute_batch(
-            [GraphQLRequest(document=query, operation_name="Planet2")]
-        )
+        results = client.execute_batch([query])
     assert results == expected
 
 
@@ -149,7 +147,7 @@ def test_header_query(client):
     expected = [{"planet": {"id": "UGxhbmV0OjEx", "name": "Geonosis"}}]
     with use_cassette("queries_batch"):
         results = client.execute_batch(
-            [GraphQLRequest(document=query)],
+            [query],
             extra_args={"headers": {"authorization": "xxx-123"}},
         )
     assert results == expected

--- a/tests/test_websocket_subscription.py
+++ b/tests/test_websocket_subscription.py
@@ -370,10 +370,9 @@ async def test_websocket_subscription_with_operation_name(
 
     count = 10
     subscription = gql(subscription_str.format(count=count))
+    subscription.operation_name = "CountdownSubscription"
 
-    async for result in session.subscribe(
-        subscription, operation_name="CountdownSubscription"
-    ):
+    async for result in session.subscribe(subscription):
 
         number = result["number"]
         print(f"Number received: {number}")

--- a/tests/test_websockets_adapter.py
+++ b/tests/test_websockets_adapter.py
@@ -39,7 +39,7 @@ async def test_websockets_adapter_simple_query(server):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    query = print_ast(gql(query1_str))
+    query = print_ast(gql(query1_str).document)
     print("query=", query)
 
     adapter = WebSocketsAdapter(url)
@@ -71,7 +71,7 @@ async def test_websockets_adapter_edge_cases(server):
 
     url = f"ws://{server.hostname}:{server.port}/graphql"
 
-    query = print_ast(gql(query1_str))
+    query = print_ast(gql(query1_str).document)
     print("query=", query)
 
     adapter = WebSocketsAdapter(url, headers={"a": "r1"}, ssl=False, connect_args={})


### PR DESCRIPTION
### Breaking change:

- `gql` and `dsl_gql` methods now returns a `GraphQLRequest` instead of a `DocumentNode`
- all `execute` and `subscribe` methods of `Client` and sessions now expects a `GraphQLRequest` instead of a `DocumentNode`

A `GraphQLRequest` is an object which contains optional `variable_values` and `operation_name` in addition to the document.

Because of that double change, the simple code examples do not need to be changed, but if you're using external methods on the result from the gql method, like `print_ast` which expects a DocumentNode, then you will need to use the `document` attribute of the request.

**Before:**

```python
query = gql("{balance}")
print_ast(query)
```

**After:**

```python
query = gql("{balance}")
print_ast(query.document)
```

### Deprecated variable_values and operation_name in execute and subscribe methods

The new way to add `variable_values` is to set it as a property of the `GraphQLRequest`, and not as an argument of `execute` or `subscribe` methods:

```python
    query = gql(
        """
        query getContinentName ($code: ID!) {
          continent (code: $code) {
            name
          }
        }
    """
    )

    query.variable_values = {"code": "EU"}

    # Get name of continent with code "EU"
    result = client.execute(query)
```


