### PR TITLE
Refactor transports

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -176,7 +176,7 @@ class AIOHTTPTransport(AsyncTransport):
 
         # Log the payload
         if log.isEnabledFor(logging.DEBUG):
-            log.debug(">>> %s", self.json_serialize(post_args["json"]))
+            log.debug(">>> %s", self.json_serialize(payload))
 
         # Pass post_args to aiohttp post method
         if extra_args:
@@ -379,14 +379,14 @@ class AIOHTTPTransport(AsyncTransport):
         :returns: an ExecutionResult object.
         """
 
+        if self.session is None:
+            raise TransportClosed("Transport is not connected")
+
         post_args = self._prepare_request(
             request,
             extra_args,
             upload_files,
         )
-
-        if self.session is None:
-            raise TransportClosed("Transport is not connected")
 
         try:
             async with self.session.post(self.url, ssl=self.ssl, **post_args) as resp:
@@ -413,13 +413,13 @@ class AIOHTTPTransport(AsyncTransport):
             if an error occurred.
         """
 
+        if self.session is None:
+            raise TransportClosed("Transport is not connected")
+
         post_args = self._prepare_batch_request(
             reqs,
             extra_args,
         )
-
-        if self.session is None:
-            raise TransportClosed("Transport is not connected")
 
         async with self.session.post(self.url, ssl=self.ssl, **post_args) as resp:
             return await self._prepare_batch_result(reqs, resp)

--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -127,7 +127,7 @@ class AIOHTTPTransport(AsyncTransport):
 
             # Adding custom parameters passed from init
             if self.client_session_args:
-                client_session_args.update(self.client_session_args)  # type: ignore
+                client_session_args.update(self.client_session_args)
 
             log.debug("Connecting transport")
 
@@ -164,36 +164,22 @@ class AIOHTTPTransport(AsyncTransport):
 
         self.session = None
 
-    def _prepare_batch_request(
-        self,
-        reqs: List[GraphQLRequest],
-        extra_args: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-
-        payload = [req.payload for req in reqs]
-
-        post_args = {"json": payload}
-
-        # Log the payload
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(">>> %s", self.json_serialize(payload))
-
-        # Pass post_args to aiohttp post method
-        if extra_args:
-            post_args.update(extra_args)
-
-        return post_args
-
     def _prepare_request(
         self,
-        request: GraphQLRequest,
+        request: Union[GraphQLRequest, List[GraphQLRequest]],
         extra_args: Optional[Dict[str, Any]] = None,
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload = request.payload
+        payload: Dict | List
+        if isinstance(request, GraphQLRequest):
+            payload = request.payload
+        else:
+            payload = [req.payload for req in request]
 
         if upload_files:
+            assert isinstance(payload, Dict)
+            assert isinstance(request, GraphQLRequest)
             post_args = self._prepare_file_uploads(request, payload)
         else:
             post_args = {"json": payload}
@@ -416,7 +402,7 @@ class AIOHTTPTransport(AsyncTransport):
         if self.session is None:
             raise TransportClosed("Transport is not connected")
 
-        post_args = self._prepare_batch_request(
+        post_args = self._prepare_request(
             reqs,
             extra_args,
         )

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -95,7 +95,7 @@ class _HTTPXTransport:
         if log.isEnabledFor(logging.DEBUG):
             log.debug(">>> %s", self.json_serialize(payload))
 
-        # Pass post_args to aiohttp post method
+        # Pass post_args to httpx post method
         if extra_args:
             post_args.update(extra_args)
 
@@ -292,7 +292,7 @@ class HTTPXTransport(Transport, _HTTPXTransport):
         :code:`execute_batch` on a client or a session.
 
         :param reqs: GraphQL requests as a list of GraphQLRequest objects.
-        :param extra_args: additional arguments to send to the aiohttp post method
+        :param extra_args: additional arguments to send to the httpx post method
         :return: A list of results of execution.
             For every result `data` is the result of executing the query,
             `errors` is null if no errors occurred, and is a non-empty array
@@ -384,7 +384,7 @@ class HTTPXAsyncTransport(AsyncTransport, _HTTPXTransport):
         :code:`execute_batch` on a client or a session.
 
         :param reqs: GraphQL requests as a list of GraphQLRequest objects.
-        :param extra_args: additional arguments to send to the aiohttp post method
+        :param extra_args: additional arguments to send to the httpx post method
         :return: A list of results of execution.
             For every result `data` is the result of executing the query,
             `errors` is null if no errors occurred, and is a non-empty array

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -59,37 +59,24 @@ class _HTTPXTransport:
 
     def _prepare_request(
         self,
-        req: GraphQLRequest,
+        request: Union[GraphQLRequest, List[GraphQLRequest]],
+        *,
         extra_args: Optional[Dict[str, Any]] = None,
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload = req.payload
+        payload: Dict | List
+        if isinstance(request, GraphQLRequest):
+            payload = request.payload
+        else:
+            payload = [req.payload for req in request]
 
         if upload_files:
-            post_args = self._prepare_file_uploads(req, payload)
+            assert isinstance(payload, Dict)
+            assert isinstance(request, GraphQLRequest)
+            post_args = self._prepare_file_uploads(request, payload)
         else:
             post_args = {"json": payload}
-
-        # Log the payload
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(">>> %s", self.json_serialize(payload))
-
-        # Pass post_args to httpx post method
-        if extra_args:
-            post_args.update(extra_args)
-
-        return post_args
-
-    def _prepare_batch_request(
-        self,
-        reqs: List[GraphQLRequest],
-        extra_args: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-
-        payload = [req.payload for req in reqs]
-
-        post_args = {"json": payload}
 
         # Log the payload
         if log.isEnabledFor(logging.DEBUG):
@@ -244,7 +231,7 @@ class HTTPXTransport(Transport, _HTTPXTransport):
 
         self.client = httpx.Client(**self.kwargs)
 
-    def execute(  # type: ignore
+    def execute(
         self,
         request: GraphQLRequest,
         *,
@@ -269,8 +256,8 @@ class HTTPXTransport(Transport, _HTTPXTransport):
 
         post_args = self._prepare_request(
             request,
-            extra_args,
-            upload_files,
+            extra_args=extra_args,
+            upload_files=upload_files,
         )
 
         try:
@@ -302,9 +289,9 @@ class HTTPXTransport(Transport, _HTTPXTransport):
         if not self.client:
             raise TransportClosed("Transport is not connected")
 
-        post_args = self._prepare_batch_request(
+        post_args = self._prepare_request(
             reqs,
-            extra_args,
+            extra_args=extra_args,
         )
 
         response = self.client.post(self.url, **post_args)
@@ -361,8 +348,8 @@ class HTTPXAsyncTransport(AsyncTransport, _HTTPXTransport):
 
         post_args = self._prepare_request(
             request,
-            extra_args,
-            upload_files,
+            extra_args=extra_args,
+            upload_files=upload_files,
         )
 
         try:
@@ -394,9 +381,9 @@ class HTTPXAsyncTransport(AsyncTransport, _HTTPXTransport):
         if not self.client:
             raise TransportClosed("Transport is not connected")
 
-        post_args = self._prepare_batch_request(
+        post_args = self._prepare_request(
             reqs,
-            extra_args,
+            extra_args=extra_args,
         )
 
         response = await self.client.post(self.url, **post_args)


### PR DESCRIPTION
- split requests transport in private methods similarly than the aiohttp and httpx transport
- remove the `_prepare_batch_request` method and use `_prepare_request` instead for batch requests to avoid code duplication