### PR TITLE
Feature dsl schema shortcuts

### DIFF
--- a/docs/advanced/dsl_module.rst
+++ b/docs/advanced/dsl_module.rst
@@ -328,16 +328,6 @@ The above example will generate the following request::
         }
     }
 
-Alternatively, you can use the DSL shortcut syntax to create a fragment by
-passing the string ``"fragment"`` directly to the :meth:`__call__ <gql.dsl.DSLSchema.__call__>` method.
-When using the shortcut, you must also provide the fragment name via the ``name`` parameter::
-
-    name_and_appearances = (
-        ds("fragment", "NameAndAppearances")
-        .on(ds.Character)
-        .select(ds.Character.name, ds.Character.appearsIn)
-    )
-
 Inline Fragments
 ^^^^^^^^^^^^^^^^
 

--- a/docs/advanced/dsl_module.rst
+++ b/docs/advanced/dsl_module.rst
@@ -328,6 +328,16 @@ The above example will generate the following request::
         }
     }
 
+Alternatively, you can use the DSL shortcut syntax to create a fragment by
+passing the string ``"fragment"`` directly to the :meth:`__call__ <gql.dsl.DSLSchema.__call__>` method.
+When using the shortcut, you must also provide the fragment name via the ``name`` parameter::
+
+    name_and_appearances = (
+        ds("fragment", "NameAndAppearances")
+        .on(ds.Character)
+        .select(ds.Character.name, ds.Character.appearsIn)
+    )
+
 Inline Fragments
 ^^^^^^^^^^^^^^^^
 
@@ -373,6 +383,14 @@ this can be written in a concise manner::
         DSLInlineFragment().on(ds.Human).select(ds.Human.homePlanet)
     )
 
+Alternatively, you can use the DSL shortcut syntax to create an inline fragment by
+passing the string ``"..."`` directly to the :meth:`__call__ <gql.dsl.DSLSchema.__call__>` method::
+
+    query_with_inline_fragment = ds.Query.hero.args(episode=6).select(
+        ds.Character.name,
+        ds("...").on(ds.Human).select(ds.Human.homePlanet)
+    )
+
 Meta-fields
 ^^^^^^^^^^^
 
@@ -383,6 +401,15 @@ you can use the :class:`DSLMetaField <gql.dsl.DSLMetaField>` class::
         ds.Character.name,
         DSLMetaField("__typename")
     )
+
+Alternatively, you can use the DSL shortcut syntax to create the same meta-field by
+passing the ``"__typename"`` string directly to the :meth:`__call__ <gql.dsl.DSLSchema.__call__>` method::
+
+    query = ds.Query.hero.select(
+        ds.Character.name,
+        ds("__typename")
+    )
+
 
 Directives
 ^^^^^^^^^^

--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -324,46 +324,32 @@ class DSLSchema:
     ) -> "DSLInlineFragment": ...  # pragma: no cover
 
     @overload
-    def __call__(
-        self, shortcut: Literal["fragment"], name: str
-    ) -> "DSLFragment": ...  # pragma: no cover
-
-    @overload
     def __call__(self, shortcut: Any) -> "DSLDirective": ...  # pragma: no cover
 
     def __call__(
-        self, shortcut: str, name: Optional[str] = None
-    ) -> Union["DSLMetaField", "DSLInlineFragment", "DSLFragment", "DSLDirective"]:
+        self, shortcut: str
+    ) -> Union["DSLMetaField", "DSLInlineFragment", "DSLDirective"]:
         """Factory method for creating DSL objects from a shortcut string.
 
         The shortcut determines which DSL object is created:
 
           * "__typename", "__schema", "__type" -> :class:`DSLMetaField`
           * "..." -> :class:`DSLInlineFragment`
-          * "fragment" -> :class:`DSLFragment` (requires ``name`` to be a string)
           * "@<name>" -> :class:`DSLDirective`
 
         :param shortcut: The shortcut string identifying the DSL object.
         :type shortcut: str
 
-        :param name: The fragment name, required when ``shortcut == "fragment"``.
-        :type name: Optional[str]
-
         :return: A DSL object corresponding to the given shortcut.
-        :rtype: DSLMetaField | DSLInlineFragment | DSLFragment | DSLDirective
+        :rtype: DSLMetaField | DSLInlineFragment | DSLDirective
 
-        :raises ValueError: If the shortcut is not recognized,
-            or if ``name`` is missing for a fragment shortcut.
+        :raises ValueError: If the shortcut is not recognized.
         """
 
         if shortcut in ("__typename", "__schema", "__type"):
             return DSLMetaField(name=shortcut)
         if shortcut == "...":
             return DSLInlineFragment()
-        if shortcut == "fragment":
-            if not isinstance(name, str):
-                raise ValueError(f"Missing name: {name} for fragment shortcut")
-            return DSLFragment(name=name)
         if shortcut.startswith("@"):
             return DSLDirective(name=shortcut[1:], dsl_schema=self)
 

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -1314,19 +1314,9 @@ def test_dsl_schema_call_shortcuts(ds, shortcut, expected):
     assert isinstance(actual, type(expected))
 
 
-def test_dsl_schema_call_fragment(ds):
-    fragment = ds("fragment", "foo")
-    assert fragment.name == "foo"
-    assert isinstance(fragment, DSLFragment)
-
-
-@pytest.mark.parametrize(
-    "shortcut,match",
-    [("foo", "(?i)unsupported shortcut"), ("fragment", "(?i)missing name")],
-)
-def test_dsl_schema_call_validation(ds, shortcut, match):
-    with pytest.raises(ValueError, match=match):
-        ds(shortcut)
+def test_dsl_schema_call_validation(ds):
+    with pytest.raises(ValueError, match="(?i)unsupported shortcut"):
+        ds("foo")
 
 
 def test_executable_directives(ds, var):


### PR DESCRIPTION
This PR adds shortcuts for the remaining overloads for `DSLSchema.__call__`, including

- `"__typename"`, `"__schema"`, `"__type"` → `DSLMetaField`
- `"..."` → `DSLInlineFragment`
- `"fragment"` → `DSLFragment` (requires `name` to be a string)