### PR TITLE
Fix python 3.9 dev dependencies

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -173,7 +173,7 @@ class AIOHTTPTransport(AsyncTransport):
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload: Dict | List
+        payload: Union[Dict, List]
         if isinstance(request, GraphQLRequest):
             payload = request.payload
         else:

--- a/gql/transport/httpx.py
+++ b/gql/transport/httpx.py
@@ -66,7 +66,7 @@ class _HTTPXTransport:
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload: Dict | List
+        payload: Union[Dict, List]
         if isinstance(request, GraphQLRequest):
             payload = request.payload
         else:

--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -147,7 +147,7 @@ class RequestsHTTPTransport(Transport):
         upload_files: bool = False,
     ) -> Dict[str, Any]:
 
-        payload: Dict | List
+        payload: Union[Dict, List]
         if isinstance(request, GraphQLRequest):
             payload = request.payload
         else:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ dev_requires = [
     "sphinx>=7.0.0,<8;python_version<='3.9'",
     "sphinx>=8.1.0,<9;python_version>'3.9'",
     "sphinx_rtd_theme>=3.0.2,<4",
-    "sphinx-argparse==0.5.2",
+    "sphinx-argparse==0.5.2; python_version>='3.10'",
+    "sphinx-argparse==0.4.0; python_version<'3.10'",
     "types-aiofiles",
     "types-requests",
 ] + tests_requires


### PR DESCRIPTION
Fixing two problems on Python 3.9:

- The | syntax for typing Union is not yet supported on Python 3.9
- `sphinx-argparse==0.5.2` dev dependency does not exist for Python 3.9