### PR TITLE
show @oneOf in introspection query

### DIFF
--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -75,7 +75,7 @@ def get_introspection_query_ast(
             fragment_FullType.select(ds.__Type.isOneOf)
         except AttributeError:
             raise NotImplementedError(
-                "IsOneOf is only supported from graphql-core version 3.3.0a7"
+                "isOneOf is only supported from graphql-core version 3.3.0a7"
             )
     if specified_by_url:
         fragment_FullType.select(ds.__Type.specifiedByURL)

--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -11,6 +11,8 @@ def get_introspection_query_ast(
     directive_is_repeatable: bool = False,
     schema_description: bool = False,
     input_value_deprecation: bool = True,
+    input_object_one_of: bool = False,
+    *,
     type_recursion_level: int = 7,
 ) -> DocumentNode:
     """Get a query for introspection as a document using the DSL module.
@@ -68,6 +70,13 @@ def get_introspection_query_ast(
     )
     if descriptions:
         fragment_FullType.select(ds.__Type.description)
+    if input_object_one_of:
+        try:
+            fragment_FullType.select(ds.__Type.isOneOf)
+        except AttributeError:
+            raise NotImplementedError(
+                "IsOneOf is only supported from graphql-core version 3.3.0a7"
+            )
     if specified_by_url:
         fragment_FullType.select(ds.__Type.specifiedByURL)
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ console_scripts = [
 
 tests_requires = [
     "parse==1.20.2",
+    "packaging>=21.0",
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
     "pytest-console-scripts==1.4.1",


### PR DESCRIPTION
Allow to add `isOneOf` in the introspection query.

Needs `graphql-core >= 3.3.0a7`

Correspond to [graphql-core PR #241](https://github.com/graphql-python/graphql-core/pull/241)