### PR TITLE
chore: Replace archived backoff with tenacity

### DIFF
--- a/docs/advanced/async_permanent_session.rst
+++ b/docs/advanced/async_permanent_session.rst
@@ -36,19 +36,22 @@ Retries
 Connection retries
 ^^^^^^^^^^^^^^^^^^
 
-With :code:`reconnecting=True`, gql will use the `backoff`_ module to repeatedly try to connect with
-exponential backoff and jitter with a maximum delay of 60 seconds by default.
+With :code:`reconnecting=True`, gql will use the `tenacity`_ module to repeatedly
+try to connect with exponential backoff and jitter with a maximum delay of
+60 seconds by default.
 
 You can change the default reconnecting profile by providing your own
-backoff decorator to the :code:`retry_connect` argument.
+retry decorator (from tenacity) to the :code:`retry_connect` argument.
 
 .. code-block:: python
 
+    from tenacity import retry, retry_if_exception_type, wait_exponential
+
     # Here wait maximum 5 minutes between connection retries
-    retry_connect = backoff.on_exception(
-        backoff.expo,  # wait generator (here: exponential backoff)
-        Exception,     # which exceptions should cause a retry (here: everything)
-        max_value=300, # max wait time in seconds
+    retry_connect = retry(
+        # which exceptions should cause a retry (here: everything)
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(max=300),  # max wait time in seconds
     )
     session = await client.connect_async(
         reconnecting=True,
@@ -66,32 +69,49 @@ There is no retry in case of a :code:`TransportQueryError` exception as it indic
 the connection to the backend is working correctly.
 
 You can change the default execute retry profile by providing your own
-backoff decorator to the :code:`retry_execute` argument.
+retry decorator (from tenacity) to the :code:`retry_execute` argument.
 
 .. code-block:: python
 
+    from tenacity import (
+        retry,
+        retry_if_exception_type,
+        stop_after_attempt,
+        wait_exponential,
+    )
+
     # Here Only 3 tries for execute calls
-    retry_execute = backoff.on_exception(
-        backoff.expo,
-        Exception,
-        max_tries=3,
+    retry_execute = retry(
+        retry=retry_if_exception_type(Exception),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(),
     )
     session = await client.connect_async(
         reconnecting=True,
         retry_execute=retry_execute,
     )
 
-If you don't want any retry on the execute calls, you can disable the retries with :code:`retry_execute=False`
+If you don't want any retry on the execute calls, you can disable the retries
+with :code:`retry_execute=False`
 
 .. note::
     If you want to retry even with :code:`TransportQueryError` exceptions,
-    then you need to make your own backoff decorator on your own method:
+    then you need to make your own retry decorator (from tenacity) on your own method:
 
     .. code-block:: python
 
-        @backoff.on_exception(backoff.expo,
-                              Exception,
-                              max_tries=3)
+        from tenacity import (
+            retry,
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_exponential,
+        )
+
+        @retry(
+            retry=retry_if_exception_type(Exception),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(),
+        )
         async def execute_with_retry(session, query):
             return await session.execute(query)
 
@@ -100,14 +120,25 @@ Subscription retries
 
 There is no :code:`retry_subscribe` as it is not feasible with async generators.
 If you want retries for your subscriptions, then you can do it yourself
-with backoff decorators on your methods.
+with retry decorators (from tenacity) on your methods.
 
 .. code-block:: python
 
-    @backoff.on_exception(backoff.expo,
-                          Exception,
-                          max_tries=3,
-                          giveup=lambda e: isinstance(e, TransportQueryError))
+    from tenacity import (
+        retry,
+        retry_if_exception_type,
+        retry_unless_exception_type,
+        stop_after_attempt,
+        wait_exponential,
+    )
+    from gql.transport.exceptions import TransportQueryError
+
+    @retry(
+        retry=retry_if_exception_type(Exception)
+        & retry_unless_exception_type(TransportQueryError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(),
+    )
     async def execute_subscription1(session):
         async for result in session.subscribe(subscription1):
             print(result)
@@ -123,4 +154,4 @@ Console example
 .. literalinclude:: ../code_examples/console_async.py
 
 .. _difficult to manage: https://github.com/graphql-python/gql/issues/179
-.. _backoff: https://github.com/litl/backoff
+.. _tenacity: https://github.com/jd/tenacity

--- a/docs/code_examples/reconnecting_mutation_http.py
+++ b/docs/code_examples/reconnecting_mutation_http.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-import backoff
+from tenacity import retry, retry_if_exception_type, wait_exponential
 
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
@@ -17,11 +17,9 @@ async def main():
 
     client = Client(transport=transport)
 
-    retry_connect = backoff.on_exception(
-        backoff.expo,
-        Exception,
-        max_value=10,
-        jitter=None,
+    retry_connect = retry(
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(max=10),
     )
     session = await client.connect_async(reconnecting=True, retry_connect=retry_connect)
 

--- a/docs/code_examples/reconnecting_mutation_ws.py
+++ b/docs/code_examples/reconnecting_mutation_ws.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-import backoff
+from tenacity import retry, retry_if_exception_type, wait_exponential
 
 from gql import Client, gql
 from gql.transport.websockets import WebsocketsTransport
@@ -17,11 +17,9 @@ async def main():
 
     client = Client(transport=transport)
 
-    retry_connect = backoff.on_exception(
-        backoff.expo,
-        Exception,
-        max_value=10,
-        jitter=None,
+    retry_connect = retry(
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(max=10),
     )
     session = await client.connect_async(reconnecting=True, retry_connect=retry_connect)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 install_requires = [
     "graphql-core>=3.3.0a3,<3.4",
     "yarl>=1.6,<2.0",
-    "backoff>=1.11.1,<3.0",
+    "tenacity>=9.1.2,<10.0",
     "anyio>=3.0,<5",
     "typing_extensions>=4.0.0; python_version<'3.11'",
 ]


### PR DESCRIPTION
The backoff library is no longer maintained. This commit replaces it with tenacity, which provides equivalent functionality for retry logic.

Changes:
- Replace backoff dependency with tenacity>=9.1.2 in setup.py
- Update retry decorators in gql/client.py to use tenacity API
- Update all documentation examples to use tenacity instead of backoff
- Update code examples to use tenacity retry decorators

The functionality remains the same:
- retry_connect: exponential backoff with max 60 seconds (infinite retries)
- retry_execute: exponential backoff, 5 attempts, excluding TransportQueryError