### PR TITLE
Fix warning in make docs: target not found: graphql.execution.incremental_publisher.ExecutionResult

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ intersphinx_mapping = {
 nitpick_ignore = [
     # graphql-core: should be fixed
     ('py:class', 'graphql.execution.execute.ExecutionResult'),
+    ('py:class', 'graphql.execution.incremental_publisher.ExecutionResult'),
     ('py:class', 'Source'),
     ('py:class', 'GraphQLSchema'),
 


### PR DESCRIPTION
Fixing the following warnings which appeared when running `make docs`:

```
gql/client.py:docstring of gql.client.AsyncClientSession.execute:1: WARNING: py:class reference target not found: graphql.execution.incremental_publisher.ExecutionResult [ref.class]
gql/client.py:docstring of gql.client.AsyncClientSession.execute:1: WARNING: py:class reference target not found: graphql.execution.incremental_publisher.ExecutionResult [ref.class]
gql/client.py:docstring of gql.client.AsyncClientSession.execute_batch:1: WARNING: py:class reference target not found: graphql.execution.incremental_publisher.ExecutionResult [ref.class]
...
```