### PR TITLE
Add extensions support to GraphQLRequest

### DIFF
--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -12,7 +12,7 @@ top-level key in the request payload alongside :code:`query`, :code:`variables`,
 and :code:`operationName`.
 
 You can use this to pass protocol extensions such as
-`persisted queries <https://www.apollographql.com/docs/apollo-server/performance/apq/>`_:
+`trusted documents <https://graphql.org/learn/security/#trusted-documents>`_:
 
 .. code-block:: python
 
@@ -26,10 +26,7 @@ You can use this to pass protocol extensions such as
         request = GraphQLRequest(
             "query { viewer { name } }",
             extensions={
-                "persistedQuery": {
-                    "version": 1,
-                    "sha256Hash": "abc123...",
-                }
+                "x-trusted-document-id": "foo",
             },
         )
 

--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -26,7 +26,7 @@ You can use this to pass protocol extensions such as
         request = GraphQLRequest(
             "query { viewer { name } }",
             extensions={
-                "x-trusted-document-id": "foo",
+                "document-id": "foo",
             },
         )
 

--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -26,7 +26,7 @@ You can use this to pass protocol extensions such as
         request = GraphQLRequest(
             "query { viewer { name } }",
             extensions={
-                "document-id": "foo",
+                "document-id": "155d6e8f5545...",
             },
         )
 

--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -3,6 +3,41 @@
 Extensions
 ----------
 
+Request extensions
+^^^^^^^^^^^^^^^^^^
+
+The `GraphQL over HTTP spec <https://github.com/graphql/graphql-over-http>`_
+defines an optional :code:`extensions` field on requests. This is sent as a
+top-level key in the request payload alongside :code:`query`, :code:`variables`,
+and :code:`operationName`.
+
+You can use this to pass protocol extensions such as
+`persisted queries <https://www.apollographql.com/docs/apollo-server/performance/apq/>`_:
+
+.. code-block:: python
+
+    from gql import Client, GraphQLRequest
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    transport = AIOHTTPTransport(url="https://example.com/graphql")
+
+    async with Client(transport=transport) as session:
+
+        request = GraphQLRequest(
+            "query { viewer { name } }",
+            extensions={
+                "persistedQuery": {
+                    "version": 1,
+                    "sha256Hash": "abc123...",
+                }
+            },
+        )
+
+        result = await session.execute(request)
+
+Response extensions
+^^^^^^^^^^^^^^^^^^^
+
 When you execute (or subscribe) GraphQL requests, the server will send
 responses which may have 3 fields:
 

--- a/gql/graphql_request.py
+++ b/gql/graphql_request.py
@@ -13,6 +13,7 @@ class GraphQLRequest:
         *,
         variable_values: Optional[Dict[str, Any]] = None,
         operation_name: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
     ):
         """Initialize a GraphQL request.
 
@@ -21,6 +22,10 @@ class GraphQLRequest:
         :param variable_values: Dictionary of input parameters (Default: None).
         :param operation_name: Name of the operation that shall be executed.
             Only required in multi-operation documents (Default: None).
+        :param extensions: Dictionary of protocol extensions (Default: None).
+            This is passed as the top-level ``extensions`` key in the request
+            payload, as defined in the `GraphQL over HTTP spec
+            <https://github.com/graphql/graphql-over-http>`_.
         :return: a :class:`GraphQLRequest <gql.GraphQLRequest>`
                  which can be later executed or subscribed by a
                  :class:`Client <gql.client.Client>`, by an
@@ -42,9 +47,12 @@ class GraphQLRequest:
                 variable_values = request.variable_values
             if operation_name is None:
                 operation_name = request.operation_name
+            if extensions is None:
+                extensions = request.extensions
 
         self.variable_values: Optional[Dict[str, Any]] = variable_values
         self.operation_name: Optional[str] = operation_name
+        self.extensions: Optional[Dict[str, Any]] = extensions
 
     def serialize_variable_values(self, schema: GraphQLSchema) -> "GraphQLRequest":
 
@@ -61,6 +69,7 @@ class GraphQLRequest:
                 operation_name=self.operation_name,
             ),
             operation_name=self.operation_name,
+            extensions=self.extensions,
         )
 
     @property
@@ -73,6 +82,9 @@ class GraphQLRequest:
 
         if self.variable_values:
             payload["variables"] = self.variable_values
+
+        if self.extensions:
+            payload["extensions"] = self.extensions
 
         return payload
 

--- a/gql/graphql_request.py
+++ b/gql/graphql_request.py
@@ -23,9 +23,8 @@ class GraphQLRequest:
         :param operation_name: Name of the operation that shall be executed.
             Only required in multi-operation documents (Default: None).
         :param extensions: Dictionary of protocol extensions (Default: None).
-            This is passed as the top-level ``extensions`` key in the request
-            payload, as defined in the `GraphQL over HTTP spec
-            <https://github.com/graphql/graphql-over-http>`_.
+            This is passed as the top-level "extensions" key in the request
+            payload, as defined in the GraphQL over HTTP spec.
         :return: a :class:`GraphQLRequest <gql.GraphQLRequest>`
                  which can be later executed or subscribed by a
                  :class:`Client <gql.client.Client>`, by an

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -619,6 +619,46 @@ async def test_aiohttp_subscribe_running_in_thread(aiohttp_server, run_sync_test
     await run_sync_test(server, test_code)
 
 
+@pytest.mark.asyncio
+async def test_aiohttp_subscribe_with_extensions(aiohttp_server):
+    from aiohttp import web
+
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert "extensions" in body
+        assert body["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    transport = AIOHTTPTransport(url=url, timeout=10)
+
+    request = GraphQLRequest(
+        query1_str,
+        extensions={"persistedQuery": {"version": 1, "sha256Hash": "abc123"}},
+    )
+
+    async with Client(transport=transport) as session:
+
+        results = []
+        async for result in session.subscribe(request):
+            results.append(result)
+
+        assert len(results) == 1
+        assert results[0]["continents"][0]["code"] == "AF"
+
+
 file_upload_mutation_1 = """
     mutation($file: Upload!) {
       uploadFile(input:{other_var:$other_var, file:$file}) {

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -6,7 +6,7 @@ from typing import Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.cli import get_parser, main
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
@@ -85,6 +85,46 @@ async def test_aiohttp_query(aiohttp_server):
         assert hasattr(transport, "response_headers")
         assert isinstance(transport.response_headers, Mapping)
         assert transport.response_headers["dummy"] == "test1234"
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_query_with_extensions(aiohttp_server):
+    from aiohttp import web
+
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert "extensions" in body
+        assert body["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    transport = AIOHTTPTransport(url=url, timeout=10)
+
+    async with Client(transport=transport) as session:
+
+        request = GraphQLRequest(
+            query1_str,
+            extensions={
+                "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+            },
+        )
+
+        result = await session.execute(request)
+
+        continents = result["continents"]
+        assert continents[0]["code"] == "AF"
 
 
 @pytest.mark.asyncio

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -88,17 +88,16 @@ async def test_aiohttp_query(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_query_with_extensions(aiohttp_server):
+async def test_aiohttp_request_extensions(aiohttp_server):
     from aiohttp import web
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
-        assert "extensions" in body
-        assert body["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body["extensions"] == extensions
         return web.Response(
             text=query1_server_answer,
             content_type="application/json",
@@ -112,19 +111,17 @@ async def test_aiohttp_query_with_extensions(aiohttp_server):
 
     transport = AIOHTTPTransport(url=url, timeout=10)
 
+    request = GraphQLRequest(query1_str, extensions=extensions)
+
     async with Client(transport=transport) as session:
 
-        request = GraphQLRequest(
-            query1_str,
-            extensions={
-                "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-            },
-        )
-
+        # execute
         result = await session.execute(request)
+        assert result["continents"][0]["code"] == "AF"
 
-        continents = result["continents"]
-        assert continents[0]["code"] == "AF"
+        # subscribe
+        async for result in session.subscribe(request):
+            assert result["continents"][0]["code"] == "AF"
 
 
 @pytest.mark.asyncio
@@ -617,46 +614,6 @@ async def test_aiohttp_subscribe_running_in_thread(aiohttp_server, run_sync_test
         assert results[0]["continents"][0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
-
-
-@pytest.mark.asyncio
-async def test_aiohttp_subscribe_with_extensions(aiohttp_server):
-    from aiohttp import web
-
-    from gql.transport.aiohttp import AIOHTTPTransport
-
-    async def handler(request):
-        body = await request.json()
-        assert "extensions" in body
-        assert body["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
-        return web.Response(
-            text=query1_server_answer,
-            content_type="application/json",
-        )
-
-    app = web.Application()
-    app.router.add_route("POST", "/", handler)
-    server = await aiohttp_server(app)
-
-    url = server.make_url("/")
-
-    transport = AIOHTTPTransport(url=url, timeout=10)
-
-    request = GraphQLRequest(
-        query1_str,
-        extensions={"persistedQuery": {"version": 1, "sha256Hash": "abc123"}},
-    )
-
-    async with Client(transport=transport) as session:
-
-        results = []
-        async for result in session.subscribe(request):
-            results.append(result)
-
-        assert len(results) == 1
-        assert results[0]["continents"][0]["code"] == "AF"
 
 
 file_upload_mutation_1 = """

--- a/tests/test_aiohttp_batch.py
+++ b/tests/test_aiohttp_batch.py
@@ -90,6 +90,49 @@ async def test_aiohttp_batch_query(aiohttp_server):
 
 
 @pytest.mark.asyncio
+async def test_aiohttp_batch_query_with_extensions(aiohttp_server):
+    from aiohttp import web
+
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert isinstance(body, list)
+        assert "extensions" in body[0]
+        assert body[0]["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer_list,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    transport = AIOHTTPTransport(url=url, timeout=10)
+
+    async with Client(transport=transport) as session:
+
+        query = [
+            GraphQLRequest(
+                query1_str,
+                extensions={
+                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                },
+            )
+        ]
+
+        results = await session.execute_batch(query)
+
+        continents = results[0]["continents"]
+        assert continents[0]["code"] == "AF"
+
+
+@pytest.mark.asyncio
 async def test_aiohttp_batch_query_auto_batch_enabled(aiohttp_server, run_sync_test):
     from aiohttp import web
 

--- a/tests/test_aiohttp_batch.py
+++ b/tests/test_aiohttp_batch.py
@@ -90,18 +90,17 @@ async def test_aiohttp_batch_query(aiohttp_server):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_batch_query_with_extensions(aiohttp_server):
+async def test_aiohttp_batch_request_extensions(aiohttp_server):
     from aiohttp import web
 
     from gql.transport.aiohttp import AIOHTTPTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
         assert isinstance(body, list)
-        assert "extensions" in body[0]
-        assert body[0]["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body[0]["extensions"] == extensions
         return web.Response(
             text=query1_server_answer_list,
             content_type="application/json",
@@ -117,19 +116,9 @@ async def test_aiohttp_batch_query_with_extensions(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [
-            GraphQLRequest(
-                query1_str,
-                extensions={
-                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                },
-            )
-        ]
-
+        query = [GraphQLRequest(query1_str, extensions=extensions)]
         results = await session.execute_batch(query)
-
-        continents = results[0]["continents"]
-        assert continents[0]["code"] == "AF"
+        assert results[0]["continents"][0]["code"] == "AF"
 
 
 @pytest.mark.asyncio

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -485,9 +485,10 @@ async def test_aiohttp_websocket_subscription_with_extensions(
 
     assert count == -1
 
-    # Check that the query contains the extensions
-    assert '"persistedQuery"' in logged_messages[0]
-    assert '"sha256Hash": "abc123"' in logged_messages[0]
+    message = json.loads(logged_messages[0])
+    assert message["payload"]["extensions"] == {
+        "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+    }
 
 
 WITH_KEEPALIVE = True

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -478,8 +478,6 @@ async def test_aiohttp_websocket_subscription_with_extensions(
     async for result in session.subscribe(request):
 
         number = result["number"]
-        print(f"Number received: {number}")
-
         assert number == count
         count -= 1
 

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -8,7 +8,7 @@ import pytest
 from graphql import ExecutionResult
 from parse import search
 
-from gql import Client, gql
+from gql import Client, GraphQLRequest, gql
 from gql.client import AsyncClientSession
 from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
 
@@ -458,6 +458,36 @@ async def test_aiohttp_websocket_subscription_with_operation_name(
 
     # Check that the query contains the operationName
     assert '"operationName": "CountdownSubscription"' in logged_messages[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server", [server_countdown], indirect=True)
+@pytest.mark.parametrize("subscription_str", [countdown_subscription_str])
+async def test_aiohttp_websocket_subscription_with_extensions(
+    aiohttp_client_and_server, subscription_str
+):
+
+    session, server = aiohttp_client_and_server
+
+    count = 10
+    request = GraphQLRequest(
+        subscription_str.format(count=count),
+        extensions={"persistedQuery": {"version": 1, "sha256Hash": "abc123"}},
+    )
+
+    async for result in session.subscribe(request):
+
+        number = result["number"]
+        print(f"Number received: {number}")
+
+        assert number == count
+        count -= 1
+
+    assert count == -1
+
+    # Check that the query contains the extensions
+    assert '"persistedQuery"' in logged_messages[0]
+    assert '"sha256Hash": "abc123"' in logged_messages[0]
 
 
 WITH_KEEPALIVE = True

--- a/tests/test_aiohttp_websocket_subscription.py
+++ b/tests/test_aiohttp_websocket_subscription.py
@@ -478,6 +478,8 @@ async def test_aiohttp_websocket_subscription_with_extensions(
     async for result in session.subscribe(request):
 
         number = result["number"]
+        print(f"Number received: {number}")
+
         assert number == count
         count -= 1
 

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -238,55 +238,26 @@ def test_graphql_request_init_with_graphql_request():
     assert request_3.variable_values["money"] == money_value_2
 
 
-def test_graphql_request_extensions_in_payload():
-    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
-    request = GraphQLRequest("{balance}", extensions=extensions)
-
-    payload = request.payload
-    assert payload["extensions"] == extensions
-
-
-def test_graphql_request_extensions_not_in_payload_when_none():
-    request = GraphQLRequest("{balance}")
-    assert "extensions" not in request.payload
-
-
-def test_graphql_request_extensions_copied_from_graphql_request():
-    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
-    request_1 = GraphQLRequest("{balance}", extensions=extensions)
-    request_2 = GraphQLRequest(request_1)
-
-    assert request_2.extensions == extensions
-    assert request_2.payload["extensions"] == extensions
-
-
-def test_graphql_request_extensions_override_from_graphql_request():
+def test_graphql_request_extensions():
     extensions_1 = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
     extensions_2 = {"custom": "value"}
-    request_1 = GraphQLRequest("{balance}", extensions=extensions_1)
-    request_2 = GraphQLRequest(request_1, extensions=extensions_2)
-
-    assert request_2.extensions == extensions_2
-
-
-def test_graphql_request_extensions_preserved_by_serialize_variable_values():
-    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
     money_value = Money(10, "DM")
 
-    request = GraphQLRequest(
+    assert "extensions" not in GraphQLRequest("{balance}").payload
+
+    request_1 = GraphQLRequest("{balance}", extensions=extensions_1)
+    assert request_1.payload["extensions"] == extensions_1
+
+    request_2 = GraphQLRequest(request_1)
+    assert request_2.extensions == extensions_1
+
+    request_3 = GraphQLRequest(request_1, extensions=extensions_2)
+    assert request_3.extensions == extensions_2
+
+    request_4 = GraphQLRequest(
         "query myquery($money: Money) {toEuros(money: $money)}",
         variable_values={"money": money_value},
-        extensions=extensions,
+        extensions=extensions_1,
     )
-
-    serialized = request.serialize_variable_values(schema)
-    assert serialized.extensions == extensions
-    assert serialized.payload["extensions"] == extensions
-
-
-def test_graphql_request_str_includes_extensions():
-    extensions = {"key": "value"}
-    request = GraphQLRequest("{balance}", extensions=extensions)
-    result = str(request)
-    assert "extensions" in result
-    assert "'key': 'value'" in result
+    serialized = request_4.serialize_variable_values(schema)
+    assert serialized.extensions == extensions_1

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -236,3 +236,57 @@ def test_graphql_request_init_with_graphql_request():
     assert request_1.variable_values["money"] == money_value_1
     assert request_2.variable_values["money"] == money_value_1
     assert request_3.variable_values["money"] == money_value_2
+
+
+def test_graphql_request_extensions_in_payload():
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+    request = GraphQLRequest("{balance}", extensions=extensions)
+
+    payload = request.payload
+    assert payload["extensions"] == extensions
+
+
+def test_graphql_request_extensions_not_in_payload_when_none():
+    request = GraphQLRequest("{balance}")
+    assert "extensions" not in request.payload
+
+
+def test_graphql_request_extensions_copied_from_graphql_request():
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+    request_1 = GraphQLRequest("{balance}", extensions=extensions)
+    request_2 = GraphQLRequest(request_1)
+
+    assert request_2.extensions == extensions
+    assert request_2.payload["extensions"] == extensions
+
+
+def test_graphql_request_extensions_override_from_graphql_request():
+    extensions_1 = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+    extensions_2 = {"custom": "value"}
+    request_1 = GraphQLRequest("{balance}", extensions=extensions_1)
+    request_2 = GraphQLRequest(request_1, extensions=extensions_2)
+
+    assert request_2.extensions == extensions_2
+
+
+def test_graphql_request_extensions_preserved_by_serialize_variable_values():
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+    money_value = Money(10, "DM")
+
+    request = GraphQLRequest(
+        "query myquery($money: Money) {toEuros(money: $money)}",
+        variable_values={"money": money_value},
+        extensions=extensions,
+    )
+
+    serialized = request.serialize_variable_values(schema)
+    assert serialized.extensions == extensions
+    assert serialized.payload["extensions"] == extensions
+
+
+def test_graphql_request_str_includes_extensions():
+    extensions = {"key": "value"}
+    request = GraphQLRequest("{balance}", extensions=extensions)
+    result = str(request)
+    assert "extensions" in result
+    assert "'key': 'value'" in result

--- a/tests/test_graphql_request.py
+++ b/tests/test_graphql_request.py
@@ -248,12 +248,15 @@ def test_graphql_request_extensions():
     request_1 = GraphQLRequest("{balance}", extensions=extensions_1)
     assert request_1.payload["extensions"] == extensions_1
 
+    # Copied from another GraphQLRequest
     request_2 = GraphQLRequest(request_1)
     assert request_2.extensions == extensions_1
 
+    # Explicit extensions override the copied value
     request_3 = GraphQLRequest(request_1, extensions=extensions_2)
     assert request_3.extensions == extensions_2
 
+    # Preserved through serialize_variable_values
     request_4 = GraphQLRequest(
         "query myquery($money: Money) {toEuros(money: $money)}",
         variable_values={"money": money_value},

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -80,6 +80,50 @@ async def test_httpx_query(aiohttp_server, run_sync_test):
             assert hasattr(transport, "response_headers")
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
+
+    await run_sync_test(server, test_code)
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_httpx_query_with_extensions(aiohttp_server, run_sync_test):
+    from aiohttp import web
+
+    from gql.transport.httpx import HTTPXTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert "extensions" in body
+        assert body["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    def test_code():
+        transport = HTTPXTransport(url=url)
+
+        with Client(transport=transport) as session:
+
+            request = GraphQLRequest(
+                query1_str,
+                extensions={
+                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                },
+            )
+
+            result = session.execute(request)
+
+            continents = result["continents"]
+            assert continents[0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -86,17 +86,16 @@ async def test_httpx_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_query_with_extensions(aiohttp_server, run_sync_test):
+async def test_httpx_request_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
 
     from gql.transport.httpx import HTTPXTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
-        assert "extensions" in body
-        assert body["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body["extensions"] == extensions
         return web.Response(
             text=query1_server_answer,
             content_type="application/json",
@@ -112,18 +111,9 @@ async def test_httpx_query_with_extensions(aiohttp_server, run_sync_test):
         transport = HTTPXTransport(url=url)
 
         with Client(transport=transport) as session:
-
-            request = GraphQLRequest(
-                query1_str,
-                extensions={
-                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                },
-            )
-
+            request = GraphQLRequest(query1_str, extensions=extensions)
             result = session.execute(request)
-
-            continents = result["continents"]
-            assert continents[0]["code"] == "AF"
+            assert result["continents"][0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_httpx_batch.py
+++ b/tests/test_httpx_batch.py
@@ -120,6 +120,97 @@ async def test_httpx_sync_batch_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
+async def test_httpx_async_batch_query_with_extensions(aiohttp_server):
+    from aiohttp import web
+
+    from gql.transport.httpx import HTTPXAsyncTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert isinstance(body, list)
+        assert "extensions" in body[0]
+        assert body[0]["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer_list,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    transport = HTTPXAsyncTransport(url=url, timeout=10)
+
+    async with Client(transport=transport) as session:
+
+        query = [
+            GraphQLRequest(
+                query1_str,
+                extensions={
+                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                },
+            )
+        ]
+
+        results = await session.execute_batch(query)
+
+        continents = results[0]["continents"]
+        assert continents[0]["code"] == "AF"
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_httpx_sync_batch_query_with_extensions(aiohttp_server, run_sync_test):
+    from aiohttp import web
+
+    from gql.transport.httpx import HTTPXTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert isinstance(body, list)
+        assert "extensions" in body[0]
+        assert body[0]["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer_list,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = str(server.make_url("/"))
+
+    transport = HTTPXTransport(url=url, timeout=10)
+
+    def test_code():
+        with Client(transport=transport) as session:
+
+            query = [
+                GraphQLRequest(
+                    query1_str,
+                    extensions={
+                        "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                    },
+                )
+            ]
+
+            results = session.execute_batch(query)
+
+            continents = results[0]["continents"]
+            assert continents[0]["code"] == "AF"
+
+    await run_sync_test(server, test_code)
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
 async def test_httpx_async_batch_query_without_session(aiohttp_server, run_sync_test):
     from aiohttp import web
 

--- a/tests/test_httpx_batch.py
+++ b/tests/test_httpx_batch.py
@@ -120,18 +120,17 @@ async def test_httpx_sync_batch_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_httpx_async_batch_query_with_extensions(aiohttp_server):
+async def test_httpx_batch_request_extensions(aiohttp_server):
     from aiohttp import web
 
     from gql.transport.httpx import HTTPXAsyncTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
         assert isinstance(body, list)
-        assert "extensions" in body[0]
-        assert body[0]["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body[0]["extensions"] == extensions
         return web.Response(
             text=query1_server_answer_list,
             content_type="application/json",
@@ -147,66 +146,9 @@ async def test_httpx_async_batch_query_with_extensions(aiohttp_server):
 
     async with Client(transport=transport) as session:
 
-        query = [
-            GraphQLRequest(
-                query1_str,
-                extensions={
-                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                },
-            )
-        ]
-
+        query = [GraphQLRequest(query1_str, extensions=extensions)]
         results = await session.execute_batch(query)
-
-        continents = results[0]["continents"]
-        assert continents[0]["code"] == "AF"
-
-
-@pytest.mark.aiohttp
-@pytest.mark.asyncio
-async def test_httpx_sync_batch_query_with_extensions(aiohttp_server, run_sync_test):
-    from aiohttp import web
-
-    from gql.transport.httpx import HTTPXTransport
-
-    async def handler(request):
-        body = await request.json()
-        assert isinstance(body, list)
-        assert "extensions" in body[0]
-        assert body[0]["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
-        return web.Response(
-            text=query1_server_answer_list,
-            content_type="application/json",
-        )
-
-    app = web.Application()
-    app.router.add_route("POST", "/", handler)
-    server = await aiohttp_server(app)
-
-    url = str(server.make_url("/"))
-
-    transport = HTTPXTransport(url=url, timeout=10)
-
-    def test_code():
-        with Client(transport=transport) as session:
-
-            query = [
-                GraphQLRequest(
-                    query1_str,
-                    extensions={
-                        "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                    },
-                )
-            ]
-
-            results = session.execute_batch(query)
-
-            continents = results[0]["continents"]
-            assert continents[0]["code"] == "AF"
-
-    await run_sync_test(server, test_code)
+        assert results[0]["continents"][0]["code"] == "AF"
 
 
 @pytest.mark.aiohttp

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 
 import pytest
 
-from gql import Client, FileVar, gql
+from gql import Client, FileVar, GraphQLRequest, gql
 from gql.transport.exceptions import (
     TransportAlreadyConnected,
     TransportClosed,
@@ -81,6 +81,50 @@ async def test_requests_query(aiohttp_server, run_sync_test):
             assert hasattr(transport, "response_headers")
             assert isinstance(transport.response_headers, Mapping)
             assert transport.response_headers["dummy"] == "test1234"
+
+    await run_sync_test(server, test_code)
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
+    from aiohttp import web
+
+    from gql.transport.requests import RequestsHTTPTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert "extensions" in body
+        assert body["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        transport = RequestsHTTPTransport(url=url)
+
+        with Client(transport=transport) as session:
+
+            request = GraphQLRequest(
+                query1_str,
+                extensions={
+                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                },
+            )
+
+            result = session.execute(request)
+
+            continents = result["continents"]
+            assert continents[0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -87,17 +87,16 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
+async def test_requests_request_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
 
     from gql.transport.requests import RequestsHTTPTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
-        assert "extensions" in body
-        assert body["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body["extensions"] == extensions
         return web.Response(
             text=query1_server_answer,
             content_type="application/json",
@@ -113,18 +112,9 @@ async def test_requests_query_with_extensions(aiohttp_server, run_sync_test):
         transport = RequestsHTTPTransport(url=url)
 
         with Client(transport=transport) as session:
-
-            request = GraphQLRequest(
-                query1_str,
-                extensions={
-                    "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                },
-            )
-
+            request = GraphQLRequest(query1_str, extensions=extensions)
             result = session.execute(request)
-
-            continents = result["continents"]
-            assert continents[0]["code"] == "AF"
+            assert result["continents"][0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
 

--- a/tests/test_requests_batch.py
+++ b/tests/test_requests_batch.py
@@ -92,6 +92,53 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
+async def test_requests_batch_query_with_extensions(aiohttp_server, run_sync_test):
+    from aiohttp import web
+
+    from gql.transport.requests import RequestsHTTPTransport
+
+    async def handler(request):
+        body = await request.json()
+        assert isinstance(body, list)
+        assert "extensions" in body[0]
+        assert body[0]["extensions"] == {
+            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+        }
+        return web.Response(
+            text=query1_server_answer_list,
+            content_type="application/json",
+        )
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    def test_code():
+        transport = RequestsHTTPTransport(url=url)
+
+        with Client(transport=transport) as session:
+
+            query = [
+                GraphQLRequest(
+                    query1_str,
+                    extensions={
+                        "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
+                    },
+                )
+            ]
+
+            results = session.execute_batch(query)
+
+            continents = results[0]["continents"]
+            assert continents[0]["code"] == "AF"
+
+    await run_sync_test(server, test_code)
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
 async def test_requests_query_auto_batch_enabled(aiohttp_server, run_sync_test):
     from aiohttp import web
 

--- a/tests/test_requests_batch.py
+++ b/tests/test_requests_batch.py
@@ -92,18 +92,17 @@ async def test_requests_query(aiohttp_server, run_sync_test):
 
 @pytest.mark.aiohttp
 @pytest.mark.asyncio
-async def test_requests_batch_query_with_extensions(aiohttp_server, run_sync_test):
+async def test_requests_batch_request_extensions(aiohttp_server, run_sync_test):
     from aiohttp import web
 
     from gql.transport.requests import RequestsHTTPTransport
 
+    extensions = {"persistedQuery": {"version": 1, "sha256Hash": "abc123"}}
+
     async def handler(request):
         body = await request.json()
         assert isinstance(body, list)
-        assert "extensions" in body[0]
-        assert body[0]["extensions"] == {
-            "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-        }
+        assert body[0]["extensions"] == extensions
         return web.Response(
             text=query1_server_answer_list,
             content_type="application/json",
@@ -119,20 +118,9 @@ async def test_requests_batch_query_with_extensions(aiohttp_server, run_sync_tes
         transport = RequestsHTTPTransport(url=url)
 
         with Client(transport=transport) as session:
-
-            query = [
-                GraphQLRequest(
-                    query1_str,
-                    extensions={
-                        "persistedQuery": {"version": 1, "sha256Hash": "abc123"}
-                    },
-                )
-            ]
-
+            query = [GraphQLRequest(query1_str, extensions=extensions)]
             results = session.execute_batch(query)
-
-            continents = results[0]["continents"]
-            assert continents[0]["code"] == "AF"
+            assert results[0]["continents"][0]["code"] == "AF"
 
     await run_sync_test(server, test_code)
 


### PR DESCRIPTION
## Summary

Adds an optional `extensions` parameter to `GraphQLRequest`, as defined in the [GraphQL over HTTP spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md). When set, it is included as a top-level key in the request payload alongside `query`, `variables`, and `operationName`.

No transport changes needed — all transports already serialize `request.payload`.

```python
request = GraphQLRequest(
    "query { viewer { name } }",
    extensions={"persistedQuery": {"version": 1, "sha256Hash": "abc123"}},
)
result = await session.execute(request)
```

Closes #590

## Test plan

- Unit tests for extensions in payload, copy, override, and serialize_variable_values
- Integration tests for execute, subscribe, and batch across aiohttp, httpx, requests, and websockets