### PR TITLE
Fix gql to work with graphql-core 3.3.0rc0

### DIFF
--- a/gql/dsl.py
+++ b/gql/dsl.py
@@ -416,7 +416,7 @@ class DSLDirective:
         :raises graphql.error.GraphQLError:
                 if argument doesn't exist in directive definition
         """
-        if len(self.ast_directive.arguments) > 0:
+        if self.ast_directive.arguments and len(self.ast_directive.arguments) > 0:
             raise AttributeError(f"Arguments for directive @{self.name} already set.")
 
         errs = []
@@ -448,7 +448,7 @@ class DSLDirective:
     def __repr__(self) -> str:
         args_str = ", ".join(
             f"{arg.name.value}={getattr(arg.value, 'value')}"
-            for arg in self.ast_directive.arguments
+            for arg in (self.ast_directive.arguments or ())
         )
         return f"<DSLDirective @{self.name}({args_str})>"
 
@@ -893,7 +893,7 @@ class DSLVariable(DSLDirectable):
 
     def is_valid_directive(self, directive: DSLDirective) -> bool:
         """Check if directive is valid for Variable definitions."""
-        for arg in directive.ast_directive.arguments:
+        for arg in directive.ast_directive.arguments or ():
             if isinstance(arg.value, VariableNode):
                 raise GraphQLError(
                     f"Directive @{directive.name} argument value has "

--- a/gql/utilities/build_client_schema.py
+++ b/gql/utilities/build_client_schema.py
@@ -23,10 +23,10 @@ INCLUDE_DIRECTIVE_JSON: IntrospectionDirective = {
             "description": "Included when true.",
             "type": {
                 "kind": "NON_NULL",
-                "name": "None",
-                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": "None"},
+                "name": None,
+                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": None},
             },
-            "defaultValue": "None",
+            "defaultValue": None,
         }
     ],
 }
@@ -48,10 +48,10 @@ SKIP_DIRECTIVE_JSON: IntrospectionDirective = {
             "description": "Skipped when true.",
             "type": {
                 "kind": "NON_NULL",
-                "name": "None",
-                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": "None"},
+                "name": None,
+                "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": None},
             },
-            "defaultValue": "None",
+            "defaultValue": None,
         }
     ],
 }

--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -37,9 +37,9 @@ def get_introspection_query_ast(
         schema.select(ds.__Schema.description)
 
     schema.select(
-        ds.__Schema.queryType.select(ds.__Type.name),
-        ds.__Schema.mutationType.select(ds.__Type.name),
-        ds.__Schema.subscriptionType.select(ds.__Type.name),
+        ds.__Schema.queryType.select(ds.__Type.name, ds.__Type.kind),
+        ds.__Schema.mutationType.select(ds.__Type.name, ds.__Type.kind),
+        ds.__Schema.subscriptionType.select(ds.__Type.name, ds.__Type.kind),
     )
 
     schema.select(ds.__Schema.types.select(fragment_FullType))

--- a/gql/utilities/get_introspection_query_ast.py
+++ b/gql/utilities/get_introspection_query_ast.py
@@ -134,10 +134,10 @@ def get_introspection_query_ast(
     )
 
     if type_recursion_level >= 1:
-        current_field = ds.__Type.ofType.select(ds.__Type.kind, ds.__Type.name)
+        current_field = ds.__Type.ofType.select(ds.__Type.name, ds.__Type.kind)
 
         for _ in repeat(None, type_recursion_level - 1):
-            parent_field = ds.__Type.ofType.select(ds.__Type.kind, ds.__Type.name)
+            parent_field = ds.__Type.ofType.select(ds.__Type.name, ds.__Type.kind)
             parent_field.select(current_field)
             current_field = parent_field
 

--- a/gql/utilities/node_tree.py
+++ b/gql/utilities/node_tree.py
@@ -29,22 +29,21 @@ def _node_tree_recursive(
                     continue
                 attr_value = getattr(obj, key, None)
                 results.append("  " * (indent + 1) + f"{key}:")
-                if isinstance(attr_value, Iterable) and not isinstance(
+                if attr_value is None or (
+                    isinstance(attr_value, Sized) and len(attr_value) == 0
+                ):
+                    results.append("  " * (indent + 2) + "None")
+                elif isinstance(attr_value, Iterable) and not isinstance(
                     attr_value, (str, bytes)
                 ):
-                    if isinstance(attr_value, Sized) and len(attr_value) == 0:
+                    for item in attr_value:
                         results.append(
-                            "  " * (indent + 2) + f"empty {type(attr_value).__name__}"
-                        )
-                    else:
-                        for item in attr_value:
-                            results.append(
-                                _node_tree_recursive(
-                                    item,
-                                    indent=indent + 2,
-                                    ignored_keys=ignored_keys,
-                                )
+                            _node_tree_recursive(
+                                item,
+                                indent=indent + 2,
+                                ignored_keys=ignored_keys,
                             )
+                        )
                 else:
                     results.append(
                         _node_tree_recursive(
@@ -91,5 +90,8 @@ def node_tree(
 
     # Ignore new field added in graphql-core 3.3.0a12 to keep output compatible
     ignored_keys.append("nullability_assertion")
+
+    # Ignore description field which was added to OperationDefinitionNode in graphql-core 3.3.0b0
+    ignored_keys.append("description")
 
     return _node_tree_recursive(obj, ignored_keys=ignored_keys)

--- a/gql/utilities/node_tree.py
+++ b/gql/utilities/node_tree.py
@@ -91,7 +91,8 @@ def node_tree(
     # Ignore new field added in graphql-core 3.3.0a12 to keep output compatible
     ignored_keys.append("nullability_assertion")
 
-    # Ignore description field which was added to OperationDefinitionNode in graphql-core 3.3.0b0
+    # Ignore description field which was added to OperationDefinitionNode
+    # in graphql-core 3.3.0b0
     ignored_keys.append("description")
 
     return _node_tree_recursive(obj, ignored_keys=ignored_keys)

--- a/gql/utilities/serialize_variable_values.py
+++ b/gql/utilities/serialize_variable_values.py
@@ -115,7 +115,7 @@ def serialize_variable_values(
     operation = _get_document_operation(document, operation_name=operation_name)
 
     # Serialize every variable value defined for the operation
-    for var_def_node in operation.variable_definitions:
+    for var_def_node in operation.variable_definitions or ():
         var_name = var_def_node.variable.name.value
         var_type = type_from_ast(schema, var_def_node.type)
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.11.2,<4",
+    "aiohttp>=3.11.2,<=3.13.2",
 ]
 
 install_requests_requires = [

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -1045,8 +1045,8 @@ def test_invalid_meta_field_selection(ds):
 
 
 @pytest.mark.skipif(
-    version.parse(graphql_version) < version.parse("3.3.0b0"),
-    reason="Requires graphql-core >= 3.3.0b0",
+    version.parse(graphql_version) < version.parse("3.3.0rc0"),
+    reason="Requires graphql-core >= 3.3.0rc0",
 )
 @pytest.mark.parametrize("option", [True, False])
 def test_get_introspection_query_ast(option):
@@ -1093,8 +1093,8 @@ def test_get_introspection_query_ast(option):
 
 
 @pytest.mark.skipif(
-    version.parse(graphql_version) < version.parse("3.3.0b0"),
-    reason="Requires graphql-core >= 3.3.0b0",
+    version.parse(graphql_version) < version.parse("3.3.0rc0"),
+    reason="Requires graphql-core >= 3.3.0rc0",
 )
 @pytest.mark.parametrize("option", [True, False])
 def test_get_introspection_query_ast_is_one_of(option):

--- a/tests/starwars/test_dsl.py
+++ b/tests/starwars/test_dsl.py
@@ -1044,6 +1044,10 @@ def test_invalid_meta_field_selection(ds):
         ds.Query.hero.select(DSLMetaField("__type"))
 
 
+@pytest.mark.skipif(
+    version.parse(graphql_version) < version.parse("3.3.0b0"),
+    reason="Requires graphql-core >= 3.3.0b0",
+)
 @pytest.mark.parametrize("option", [True, False])
 def test_get_introspection_query_ast(option):
 
@@ -1089,8 +1093,8 @@ def test_get_introspection_query_ast(option):
 
 
 @pytest.mark.skipif(
-    version.parse(graphql_version) < version.parse("3.3.0a7"),
-    reason="Requires graphql-core >= 3.3.0a7",
+    version.parse(graphql_version) < version.parse("3.3.0b0"),
+    reason="Requires graphql-core >= 3.3.0b0",
 )
 @pytest.mark.parametrize("option", [True, False])
 def test_get_introspection_query_ast_is_one_of(option):
@@ -1165,7 +1169,7 @@ DocumentNode
   definitions:
     OperationDefinitionNode
       directives:
-        empty tuple
+        None
       loc:
         Location
           <Location 0:43>
@@ -1188,9 +1192,9 @@ DocumentNode
               alias:
                 None
               arguments:
-                empty tuple
+                None
               directives:
-                empty tuple
+                None
               loc:
                 Location
                   <Location 22:41>
@@ -1213,9 +1217,9 @@ DocumentNode
                       alias:
                         None
                       arguments:
-                        empty tuple
+                        None
                       directives:
-                        empty tuple
+                        None
                       loc:
                         Location
                           <Location 33:37>
@@ -1231,7 +1235,7 @@ DocumentNode
                       selection_set:
                         None
       variable_definitions:
-        empty tuple
+        None
   loc:
     Location
       <Location 0:43>
@@ -1242,7 +1246,7 @@ DocumentNode
   definitions:
     OperationDefinitionNode
       directives:
-        empty tuple
+        None
       loc:
         Location
           <Location 0:43>
@@ -1265,9 +1269,9 @@ DocumentNode
               alias:
                 None
               arguments:
-                empty tuple
+                None
               directives:
-                empty tuple
+                None
               loc:
                 Location
                   <Location 22:41>
@@ -1288,9 +1292,9 @@ DocumentNode
                       alias:
                         None
                       arguments:
-                        empty tuple
+                        None
                       directives:
-                        empty tuple
+                        None
                       loc:
                         Location
                           <Location 33:37>
@@ -1304,7 +1308,7 @@ DocumentNode
                       selection_set:
                         None
       variable_definitions:
-        empty tuple
+        None
   loc:
     Location
       <Location 0:43>

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -13,14 +13,40 @@ pytestmark = pytest.mark.requests
 
 def use_cassette(name):
     import vcr
+    import json
+
+    # method to ignore introspection changes in graphql-core 3.3.0b0
+    def graphql_body_matcher(r1, r2):
+        try:
+            b1 = json.loads(r1.body)
+            b2 = json.loads(r2.body)
+            if isinstance(b1, dict) and isinstance(b2, dict):
+                q1 = b1.get("query", "")
+                q2 = b2.get("query", "")
+                if "IntrospectionQuery" in q1 and "IntrospectionQuery" in q2:
+                    return True
+                return b1 == b2
+            elif isinstance(b1, list) and isinstance(b2, list) and len(b1) == len(b2):
+                for item1, item2 in zip(b1, b2):
+                    q1 = item1.get("query", "")
+                    q2 = item2.get("query", "")
+                    if "IntrospectionQuery" in q1 and "IntrospectionQuery" in q2:
+                        continue
+                    if item1 != item2:
+                        return False
+                return True
+        except Exception:
+            pass
+        return r1.body == r2.body
 
     query_vcr = vcr.VCR(
         cassette_library_dir=os.path.join(
             os.path.dirname(__file__), "fixtures", "vcr_cassettes"
         ),
         record_mode="new_episodes",
-        match_on=["uri", "method", "body"],
     )
+    query_vcr.register_matcher("graphql_body", graphql_body_matcher)
+    query_vcr.match_on = ["uri", "method", "graphql_body"]
 
     return query_vcr.use_cassette(name + ".yaml")
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -12,8 +12,9 @@ pytestmark = pytest.mark.requests
 
 
 def use_cassette(name):
-    import vcr
     import json
+
+    import vcr
 
     # method to ignore introspection changes in graphql-core 3.3.0b0
     def graphql_body_matcher(r1, r2):

--- a/tests/test_transport_batch.py
+++ b/tests/test_transport_batch.py
@@ -13,14 +13,40 @@ pytestmark = pytest.mark.requests
 
 def use_cassette(name):
     import vcr
+    import json
+
+    # method to ignore introspection changes in graphql-core 3.3.0b0
+    def graphql_body_matcher(r1, r2):
+        try:
+            b1 = json.loads(r1.body)
+            b2 = json.loads(r2.body)
+            if isinstance(b1, dict) and isinstance(b2, dict):
+                q1 = b1.get("query", "")
+                q2 = b2.get("query", "")
+                if "IntrospectionQuery" in q1 and "IntrospectionQuery" in q2:
+                    return True
+                return b1 == b2
+            elif isinstance(b1, list) and isinstance(b2, list) and len(b1) == len(b2):
+                for item1, item2 in zip(b1, b2):
+                    q1 = item1.get("query", "")
+                    q2 = item2.get("query", "")
+                    if "IntrospectionQuery" in q1 and "IntrospectionQuery" in q2:
+                        continue
+                    if item1 != item2:
+                        return False
+                return True
+        except Exception:
+            pass
+        return r1.body == r2.body
 
     query_vcr = vcr.VCR(
         cassette_library_dir=os.path.join(
             os.path.dirname(__file__), "fixtures", "vcr_cassettes"
         ),
         record_mode="new_episodes",
-        match_on=["uri", "method", "body"],
     )
+    query_vcr.register_matcher("graphql_body", graphql_body_matcher)
+    query_vcr.match_on = ["uri", "method", "graphql_body"]
 
     return query_vcr.use_cassette(name + ".yaml")
 

--- a/tests/test_transport_batch.py
+++ b/tests/test_transport_batch.py
@@ -12,8 +12,9 @@ pytestmark = pytest.mark.requests
 
 
 def use_cassette(name):
-    import vcr
     import json
+
+    import vcr
 
     # method to ignore introspection changes in graphql-core 3.3.0b0
     def graphql_body_matcher(r1, r2):


### PR DESCRIPTION
* Allow None values instead of empty tuples in graphql-core types
* add `kind` to the root types in the introspection query
* switch the order of `kind` and `name` in the introspection query types

Note: aiohttp dependency is temporarily restricted to <3.13.2 to avoid an unrelated error in the tests