### PR TITLE
Upgrade vcrpy to 8.2.1 to fix aiohttp 3.14 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_requires = [
     "pytest-asyncio==1.2.0",
     "pytest-console-scripts==1.4.1",
     "pytest-cov==6.0.0",
-    "vcrpy==7.0.0",
+    "vcrpy==8.2.1",
     "aiofiles",
 ]
 
@@ -41,7 +41,7 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.11.2,<=3.13.2",
+    "aiohttp>=3.11.2,<=4",
 ]
 
 install_requests_requires = [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ tests_requires = [
     "pytest-asyncio==1.2.0",
     "pytest-console-scripts==1.4.1",
     "pytest-cov==6.0.0",
-    "vcrpy==8.2.1",
+    "vcrpy==7.0.0;python_version<='3.9'",
+    "vcrpy==8.2.1;python_version>'3.9'",
     "aiofiles",
 ]
 
@@ -41,7 +42,8 @@ dev_requires = [
 ] + tests_requires
 
 install_aiohttp_requires = [
-    "aiohttp>=3.11.2,<=4",
+    "aiohttp>=3.11.2,<=3.13.2;python_version<='3.9'",
+    "aiohttp>=3.11.2,<4;python_version>'3.9'",
 ]
 
 install_requests_requires = [


### PR DESCRIPTION
Fixing the following errors in the tests:

```
ERROR tests/test_transport.py::test_hero_name_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport.py::test_query_with_variable - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport.py::test_named_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport.py::test_header_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport_batch.py::test_hero_name_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport_batch.py::test_query_with_variable - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport_batch.py::test_named_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
ERROR tests/test_transport_batch.py::test_header_query - AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
```

Related vcrpy issue: https://github.com/kevin1024/vcrpy/issues/995