### PR TITLE
Using Python 3.14 instead of 3.9 to build read the docs documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.14"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,10 +115,13 @@ nitpick_ignore = [
     ('py:class', 'websockets.datastructures.SupportsKeysAndGetItem'),
     ('py:class', 'websockets.typing.Subprotocol'),
 
-    # httpx: no sphinx docs yet https://github.com/encode/httpx/discussions/3091
+    # httpx/httpx2: no sphinx docs yet https://github.com/encode/httpx/discussions/3091
     ('py:class', 'httpx.AsyncClient'),
     ('py:class', 'httpx.Client'),
     ('py:class', 'httpx.Headers'),
+    ('py:class', 'httpx2.AsyncClient'),
+    ('py:class', 'httpx2.Client'),
+    ('py:class', 'httpx2.Headers'),
 
     # botocore: no sphinx docs
     ('py:class', 'botocore.auth.BaseSigner'),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-sphinx>=5.3.0,<6
-sphinx_rtd_theme>=0.4,<1
-sphinx-argparse==0.2.5
-multidict<5.0,>=4.5
+sphinx>=8.1.0,<9
+sphinx_rtd_theme>=3.0.2,<4
+sphinx-argparse==0.5.2


### PR DESCRIPTION
- Fix the correct requirements in `docs/requirements.txt`
- Add the `httpx2.*` classes to the ignore list for docs