### PR TITLE
Make AIOHTTPTransport.connect() reentrant for shared client instances

### DIFF
--- a/gql/transport/aiohttp.py
+++ b/gql/transport/aiohttp.py
@@ -98,6 +98,7 @@ class AIOHTTPTransport(AsyncTransport):
         self.ssl_close_timeout: Optional[Union[int, float]] = ssl_close_timeout
         self.client_session_args = client_session_args
         self.session: Optional[aiohttp.ClientSession] = None
+        self._connect_count: int = 0
         self.response_headers: Optional[CIMultiDictProxy[str]]
         self.json_serialize: Callable = json_serialize
         self.json_deserialize: Callable = json_deserialize
@@ -110,6 +111,10 @@ class AIOHTTPTransport(AsyncTransport):
         to create the session.
 
         Should be cleaned with a call to the close coroutine.
+
+        This method is reentrant: if the session already exists, the existing
+        session is reused and a reference count is incremented. Each connect()
+        call must be paired with a close() call.
         """
 
         if self.session is None:
@@ -136,8 +141,7 @@ class AIOHTTPTransport(AsyncTransport):
 
             self.session = aiohttp.ClientSession(**client_session_args)
 
-        else:
-            raise TransportAlreadyConnected("Transport is already connected")
+        self._connect_count += 1
 
     async def close(self) -> None:
         """Coroutine which will close the aiohttp session.
@@ -145,7 +149,15 @@ class AIOHTTPTransport(AsyncTransport):
         Don't call this coroutine directly on the transport, instead use
         :code:`async with` on the client and this coroutine will be executed
         when you exit the async context manager.
+
+        The session is only actually closed when every connect() call has been
+        balanced by a close() call.
         """
+        self._connect_count = max(0, self._connect_count - 1)
+
+        if self._connect_count > 0:
+            return
+
         if self.session is not None:
 
             log.debug("Closing transport")

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import os
@@ -1918,3 +1919,41 @@ async def test_aiohttp_type_error_execute(aiohttp_server):
             await session.execute("qmlsdkfj")
 
         assert "request should be a GraphQLRequest object" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="transport.connect() is not reentrant — shared client fails on concurrent use"
+)
+async def test_aiohttp_reentrant_connect(aiohttp_server):
+    """A single Client/transport instance should support concurrent sessions.
+
+    When a Client is cached (e.g. via lru_cache) and used from multiple
+    concurrent async-with blocks, the second caller should not get
+    TransportAlreadyConnected.
+    """
+    from aiohttp import web
+
+    from gql.transport.aiohttp import AIOHTTPTransport
+
+    async def handler(request):
+        return web.Response(text=query1_server_answer, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+    server = await aiohttp_server(app)
+
+    url = server.make_url("/")
+
+    transport = AIOHTTPTransport(url=url, timeout=10)
+    client = Client(transport=transport)
+
+    results = []
+
+    async def use_client():
+        async with client as session:
+            query = gql(query1_str)
+            result = await session.execute(query)
+            results.append(result)
+
+    await asyncio.gather(use_client(), use_client())

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -392,7 +392,7 @@ async def test_aiohttp_invalid_protocol(aiohttp_server, param):
 
 
 @pytest.mark.asyncio
-async def test_aiohttp_cannot_connect_twice(aiohttp_server):
+async def test_aiohttp_connect_twice_is_reentrant(aiohttp_server):
     from aiohttp import web
 
     from gql.transport.aiohttp import AIOHTTPTransport
@@ -409,9 +409,12 @@ async def test_aiohttp_cannot_connect_twice(aiohttp_server):
     transport = AIOHTTPTransport(url=url, timeout=10)
 
     async with Client(transport=transport) as session:
-
-        with pytest.raises(TransportAlreadyConnected):
-            await session.transport.connect()
+        # Second connect should succeed (reentrant) and reuse the session
+        original_session = session.transport.session
+        await session.transport.connect()
+        assert session.transport.session is original_session
+        # Balance the extra connect with a close
+        await session.transport.close()
 
 
 @pytest.mark.asyncio
@@ -1922,9 +1925,6 @@ async def test_aiohttp_type_error_execute(aiohttp_server):
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="transport.connect() is not reentrant — shared client fails on concurrent use"
-)
 async def test_aiohttp_reentrant_connect(aiohttp_server):
     """A single Client/transport instance should support concurrent sessions.
 


### PR DESCRIPTION
When a `Client` is cached and reused across requests (e.g. wrapped in `lru_cache` for connection pooling, as aiohttp recommends), concurrent `async with client` blocks race on `transport.connect()` — the second caller hits `TransportAlreadyConnected` because the session from the first caller is still active.

This also bites when a downstream consumer disconnects abruptly (e.g. a mobile client crashes mid-stream): `__aexit__` may never fire, the session leaks, and the next request on the same transport fails permanently.

The fix adds a reference count to `connect()`/`close()`. If the session already exists, `connect()` reuses it instead of raising. `close()` only tears it down when the last caller exits. This matches aiohttp's own guidance that a single `ClientSession` should be long-lived and shared.

The first commit adds an xfail'd minimal repro (two concurrent `asyncio.gather` callers on the same Client). The second commit fixes the behavior and un-xfails it.

_**Draft PR**: This PR was sent by Claude and may not have yet been reviewed by mark._